### PR TITLE
Align financial accounts UI

### DIFF
--- a/frontend/app/financial-accounts.tsx
+++ b/frontend/app/financial-accounts.tsx
@@ -388,6 +388,9 @@ export default function FinancialAccountsScreen() {
                       {formatCurrency(account.balance, account.currency)}
                     </ThemedText>
                   </View>
+                  <View style={styles.arrowColumn}>
+                    <ThemedText style={styles.arrow}>›</ThemedText>
+                  </View>
                 </View>
                 {account.notes && (
                   <ThemedText style={styles.accountNotes} numberOfLines={2}>
@@ -447,7 +450,10 @@ export default function FinancialAccountsScreen() {
         >
           <View style={styles.modalContainer}>
             <View style={styles.modalBackdrop} />
-            <View style={styles.filterModal}>
+            <View style={[
+              styles.filterModal,
+              (isMobileWeb || isNative) && styles.mobileFilterModal
+            ]}>
               <View style={styles.filterHeader}>
                 <ThemedText style={styles.filterTitle}>Filter Financial Accounts</ThemedText>
                 <TouchableOpacity 
@@ -831,6 +837,16 @@ const styles = StyleSheet.create({
     fontSize: 18,
     fontWeight: '700',
   },
+  arrowColumn: {
+    width: 16,
+    alignItems: 'center',
+    marginLeft: 8,
+  },
+  arrow: {
+    fontSize: 20,
+    color: '#9ca3af',
+    fontWeight: '300',
+  },
   accountNotes: {
     fontSize: 14,
     color: '#6b7280',
@@ -879,7 +895,7 @@ const styles = StyleSheet.create({
   // Filter Modal Styles
   modalContainer: {
     flex: 1,
-    justifyContent: 'center',
+    justifyContent: 'flex-end',
     alignItems: 'center',
   },
   modalBackdrop: {
@@ -892,12 +908,18 @@ const styles = StyleSheet.create({
   },
   filterModal: {
     backgroundColor: '#fff',
-    borderRadius: 16,
-    width: '90%',
-    maxWidth: 600,
-    maxHeight: '80%',
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    height: '90%',
+    minHeight: '90%',
+    width: '100%',
     overflow: 'hidden',
     zIndex: 1,
+  },
+  mobileFilterModal: {
+    borderRadius: 0,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
   },
   closeButtonContainer: {
     padding: 4,

--- a/frontend/components/layouts/DesktopFinancialAccountsLayout.tsx
+++ b/frontend/components/layouts/DesktopFinancialAccountsLayout.tsx
@@ -166,9 +166,14 @@ export const DesktopFinancialAccountsLayout: React.FC<DesktopFinancialAccountsLa
       activeOpacity={0.7}
     >
       <View style={styles.accountHeader}>
-        <ThemedText style={styles.accountName}>{account.account_name}</ThemedText>
-        <View style={styles.currencyBadge}>
-          <ThemedText style={styles.currencyText}>{account.currency.toUpperCase()}</ThemedText>
+        <View style={styles.accountInfo}>
+          <ThemedText style={styles.accountName}>{account.account_name}</ThemedText>
+          <View style={styles.currencyBadge}>
+            <ThemedText style={styles.currencyText}>{account.currency.toUpperCase()}</ThemedText>
+          </View>
+        </View>
+        <View style={styles.arrowColumn}>
+          <ThemedText style={styles.arrow}>›</ThemedText>
         </View>
       </View>
       <ThemedText style={styles.accountDetail}>
@@ -518,11 +523,17 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginBottom: 12,
   },
+  accountInfo: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
   accountName: {
     fontSize: 18,
     fontWeight: '600',
     color: '#1f2937',
-    flex: 1,
+    flexShrink: 1,
   },
   currencyBadge: {
     paddingVertical: 4,
@@ -542,6 +553,16 @@ const styles = StyleSheet.create({
   },
   balanceAmount: {
     fontWeight: '700',
+  },
+  arrowColumn: {
+    width: 16,
+    alignItems: 'center',
+    marginLeft: 8,
+  },
+  arrow: {
+    fontSize: 20,
+    color: '#9ca3af',
+    fontWeight: '300',
   },
   createdContainer: {
     marginTop: 8,


### PR DESCRIPTION
## Summary
- bring financial accounts list to feature the same arrow indicator as other pages
- adjust filter modal for mobile to slide up like customers/users
- add matching arrow styles in desktop layout

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9873d8248321a77514ee6b1183d9