### PR TITLE
Fix frontend deploy: scp multi-source bug

### DIFF
--- a/.github/workflows/frontend-deploy-dev.yml
+++ b/.github/workflows/frontend-deploy-dev.yml
@@ -14,16 +14,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Copy compose + Caddyfile to server
-        uses: appleboy/scp-action@v0.1.4
+      - name: Copy compose to server
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.FRONTEND_DEV_DROPLET_HOST }}
           username: root
           password: ${{ secrets.FRONTEND_DEV_DROPLET_PASSWORD }}
           port: 22
-          source: |
-            ./frontend/docker-compose.dev.yaml
-            ./frontend/Caddyfile
+          source: ./frontend/docker-compose.dev.yaml
+          target: /root/app
+
+      - name: Copy Caddyfile to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.FRONTEND_DEV_DROPLET_HOST }}
+          username: root
+          password: ${{ secrets.FRONTEND_DEV_DROPLET_PASSWORD }}
+          port: 22
+          source: ./frontend/Caddyfile
           target: /root/app
 
       - name: Deploy via SSH

--- a/.github/workflows/frontend-prod-deploy.yml
+++ b/.github/workflows/frontend-prod-deploy.yml
@@ -53,16 +53,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Copy compose + Caddyfile to prod server
-        uses: appleboy/scp-action@v0.1.4
+      - name: Copy compose to prod server
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.FRONTEND_PROD_DROPLET_HOST }}
           username: root
           password: ${{ secrets.FRONTEND_PROD_DROPLET_PASSWORD }}
           port: 22
-          source: |
-            ./frontend/docker-compose.prod.yaml
-            ./frontend/Caddyfile
+          source: ./frontend/docker-compose.prod.yaml
+          target: /root/app
+
+      - name: Copy Caddyfile to prod server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.FRONTEND_PROD_DROPLET_HOST }}
+          username: root
+          password: ${{ secrets.FRONTEND_PROD_DROPLET_PASSWORD }}
+          port: 22
+          source: ./frontend/Caddyfile
           target: /root/app
 
       - name: Deploy via SSH


### PR DESCRIPTION
The frontend prod deploy (run on the #14 merge) built and pushed the image fine but **failed at the deploy step**: `appleboy/scp-action@v0.1.4` produced `tar: empty archive` when handed a multi-line `source:` list, so the compose/Caddyfile never reached the droplet and the SSH deploy was skipped.

**Fix:** split the compose and Caddyfile copies into separate single-source scp steps (the proven pattern) and bump to `appleboy/scp-action@v0.1.7`. Applied to both `frontend-prod-deploy.yml` and `frontend-deploy-dev.yml`.

Prod was deployed manually via SSH in the meantime, so `crm-prod.karma-grp.com` is already live; this just makes the automated path work for future pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)