### PR TITLE
Add vehicle inventory (independent of warehouse inventory)

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -40,6 +40,8 @@ from app.entrypoint.routes.vehicle import vehicle_blueprint
 from app.entrypoint.routes.service_area import service_area_blueprint
 from app.entrypoint.routes.trip import trip_blueprint
 from app.entrypoint.routes.trip_stop import trip_stop_blueprint
+from app.entrypoint.routes.vehicle_inventory import vehicle_inventory_blueprint
+from app.entrypoint.routes.vehicle_inventory_event import vehicle_inventory_event_blueprint
 
 
 jwt = JWTManager()
@@ -100,6 +102,8 @@ def create_app(config_object=Config):
     app.register_blueprint(service_area_blueprint, url_prefix='/service-area')
     app.register_blueprint(trip_blueprint, url_prefix='/trip')
     app.register_blueprint(trip_stop_blueprint, url_prefix='/trip-stop')
+    app.register_blueprint(vehicle_inventory_blueprint, url_prefix='/vehicle-inventory')
+    app.register_blueprint(vehicle_inventory_event_blueprint, url_prefix='/vehicle-inventory-event')
 
     register_error_handlers(app)
     return app

--- a/backend/app/adapters/repositories/vehicle_inventory_event_repository.py
+++ b/backend/app/adapters/repositories/vehicle_inventory_event_repository.py
@@ -1,0 +1,8 @@
+from app.adapters.repositories._abstract_repo import AbstractRepository
+from models.common import VehicleInventoryEvent
+
+
+class VehicleInventoryEventRepository(AbstractRepository[VehicleInventoryEvent]):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._type = VehicleInventoryEvent

--- a/backend/app/adapters/repositories/vehicle_inventory_repository.py
+++ b/backend/app/adapters/repositories/vehicle_inventory_repository.py
@@ -1,0 +1,8 @@
+from app.adapters.repositories._abstract_repo import AbstractRepository
+from models.common import VehicleInventory
+
+
+class VehicleInventoryRepository(AbstractRepository[VehicleInventory]):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._type = VehicleInventory

--- a/backend/app/adapters/unit_of_work/sqlalchemy_unit_of_work.py
+++ b/backend/app/adapters/unit_of_work/sqlalchemy_unit_of_work.py
@@ -36,6 +36,8 @@ from app.adapters.repositories.vehicle_repository import VehicleRepository
 from app.adapters.repositories.service_area_repository import ServiceAreaRepository
 from app.adapters.repositories.trip_repository import TripRepository
 from app.adapters.repositories.trip_stop_repository import TripStopRepository
+from app.adapters.repositories.vehicle_inventory_repository import VehicleInventoryRepository
+from app.adapters.repositories.vehicle_inventory_event_repository import VehicleInventoryEventRepository
 
 SQLALCHEMY_DATABASE_URI = os.getenv("SQLALCHEMY_DATABASE_URI")  # type: ignore
 DEFAULT_SESSION_FACTORY = sessionmaker(autocommit=False, autoflush=True, bind=create_engine(SQLALCHEMY_DATABASE_URI))
@@ -80,6 +82,8 @@ class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
         self.service_area_repository = ServiceAreaRepository(session=self.session)
         self.trip_repository = TripRepository(session=self.session)
         self.trip_stop_repository = TripStopRepository(session=self.session)
+        self.vehicle_inventory_repository = VehicleInventoryRepository(session=self.session)
+        self.vehicle_inventory_event_repository = VehicleInventoryEventRepository(session=self.session)
 
         return self
 

--- a/backend/app/domains/vehicle_inventory/domain.py
+++ b/backend/app/domains/vehicle_inventory/domain.py
@@ -1,0 +1,50 @@
+from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+from app.dto.vehicle_inventory import VehicleInventoryCreate, VehicleInventoryRead
+from app.entrypoint.routes.common.errors import NotFoundError, BadRequestError
+from models.common import VehicleInventory as VehicleInventoryModel
+
+
+class VehicleInventoryDomain:
+
+    @staticmethod
+    def create_vehicle_inventory(uow: SqlAlchemyUnitOfWork, payload: VehicleInventoryCreate) -> VehicleInventoryRead:
+        vehicle = uow.vehicle_repository.find_one(uuid=payload.vehicle_uuid, is_deleted=False)
+        if not vehicle:
+            raise NotFoundError("Vehicle not found")
+
+        material = uow.material_repository.find_one(uuid=payload.material_uuid, is_deleted=False)
+        if not material:
+            raise NotFoundError("Material not found")
+
+        # one active stock row per (vehicle, material)
+        existing = uow.vehicle_inventory_repository.find_first(
+            vehicle_uuid=payload.vehicle_uuid,
+            material_uuid=payload.material_uuid,
+            is_deleted=False,
+        )
+        if existing:
+            raise BadRequestError(
+                "Vehicle inventory already exists for this vehicle and material"
+            )
+
+        inventory = VehicleInventoryModel(**payload.model_dump(mode="json"))
+        inventory.unit = material.measure_unit
+        uow.vehicle_inventory_repository.save(model=inventory, commit=False)
+        return VehicleInventoryRead.from_orm(inventory)
+
+    @staticmethod
+    def delete_vehicle_inventory(uow: SqlAlchemyUnitOfWork, uuid: str) -> VehicleInventoryRead:
+        inventory = uow.vehicle_inventory_repository.find_one(uuid=uuid, is_deleted=False)
+        if not inventory:
+            raise NotFoundError("Vehicle inventory not found")
+
+        events = uow.vehicle_inventory_event_repository.find_all(
+            vehicle_inventory_uuid=inventory.uuid,
+            is_deleted=False,
+        )
+        if events:
+            raise BadRequestError("Vehicle inventory has events, cannot be deleted")
+
+        inventory.is_deleted = True
+        uow.vehicle_inventory_repository.save(model=inventory, commit=False)
+        return VehicleInventoryRead.from_orm(inventory)

--- a/backend/app/domains/vehicle_inventory_event/domain.py
+++ b/backend/app/domains/vehicle_inventory_event/domain.py
@@ -1,0 +1,64 @@
+from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+from app.dto.vehicle_inventory_event import (
+    VehicleInventoryEventCreate,
+    VehicleInventoryEventRead,
+    VehicleInventoryEventType,
+)
+from app.entrypoint.routes.common.errors import NotFoundError, BadRequestError
+from models.common import VehicleInventoryEvent as VehicleInventoryEventModel
+
+
+class VehicleInventoryEventDomain:
+
+    @staticmethod
+    def _signed_delta(event_type: VehicleInventoryEventType, quantity: float) -> float:
+        """Convert the user-entered magnitude into the signed delta to store."""
+        if event_type == VehicleInventoryEventType.MANUAL:
+            return abs(quantity)
+        if event_type == VehicleInventoryEventType.UNLOAD:
+            return -abs(quantity)
+        # adjustment: signed as given
+        return quantity
+
+    @staticmethod
+    def create_event(uow: SqlAlchemyUnitOfWork, payload: VehicleInventoryEventCreate) -> VehicleInventoryEventRead:
+        inventory = uow.vehicle_inventory_repository.find_one(
+            uuid=payload.vehicle_inventory_uuid, is_deleted=False
+        )
+        if not inventory:
+            raise NotFoundError("Vehicle inventory not found")
+
+        delta = VehicleInventoryEventDomain._signed_delta(payload.event_type, payload.quantity)
+
+        # never allow a vehicle's stock to go negative
+        if inventory.current_quantity + delta < 0:
+            raise BadRequestError(
+                f"Insufficient vehicle stock: balance {inventory.current_quantity}, "
+                f"requested change {delta}"
+            )
+
+        data = payload.model_dump(mode="json")
+        data["quantity"] = delta  # store the signed delta
+        event_model = VehicleInventoryEventModel(**data)
+        event_model.material_uuid = inventory.material_uuid
+        uow.vehicle_inventory_event_repository.save(model=event_model, commit=False)
+        return VehicleInventoryEventRead.from_orm(event_model)
+
+    @staticmethod
+    def delete_event(uow: SqlAlchemyUnitOfWork, uuid: str) -> VehicleInventoryEventRead:
+        event_model = uow.vehicle_inventory_event_repository.find_one(uuid=uuid, is_deleted=False)
+        if not event_model:
+            raise NotFoundError("Vehicle inventory event not found")
+
+        inventory = uow.vehicle_inventory_repository.find_one(
+            uuid=event_model.vehicle_inventory_uuid, is_deleted=False
+        )
+        # deleting an event removes its delta from the balance; guard against negative
+        if inventory and (inventory.current_quantity - event_model.quantity) < 0:
+            raise BadRequestError(
+                "Deleting this event would make the vehicle stock negative"
+            )
+
+        event_model.is_deleted = True
+        uow.vehicle_inventory_event_repository.save(model=event_model, commit=False)
+        return VehicleInventoryEventRead.from_orm(event_model)

--- a/backend/app/dto/vehicle_inventory.py
+++ b/backend/app/dto/vehicle_inventory.py
@@ -1,0 +1,58 @@
+from pydantic import BaseModel, ConfigDict, Field
+from typing import Optional, List
+from datetime import datetime
+
+from app.dto.common_enums import Currency
+
+
+class VehicleInventoryCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    vehicle_uuid: str
+    material_uuid: str
+    created_by_uuid: Optional[str] = None
+    notes: Optional[str] = None
+    currency: Optional[Currency] = None
+    is_active: bool = True
+
+
+class VehicleInventoryUpdate(BaseModel):
+    """Fields optional for partial updates."""
+    model_config = ConfigDict(extra="forbid")
+    notes: Optional[str] = None
+    currency: Optional[Currency] = None
+    is_active: Optional[bool] = None
+
+
+class VehicleInventoryRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+    uuid: str
+    created_by_uuid: Optional[str] = None
+    vehicle_uuid: str
+    material_uuid: str
+    material_name: Optional[str] = None
+    unit: Optional[str] = None
+    notes: Optional[str] = None
+    currency: Optional[str] = None
+    is_active: Optional[bool] = None
+    is_deleted: bool
+    created_at: datetime
+    current_quantity: Optional[float] = None
+
+
+class VehicleInventoryListParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    uuid: Optional[str] = None
+    vehicle_uuid: Optional[str] = None
+    material_uuid: Optional[str] = None
+    is_active: Optional[bool] = None
+    page: int = Field(1, gt=0)
+    per_page: int = Field(20, gt=0, le=100)
+
+
+class VehicleInventoryPage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    vehicle_inventories: List[VehicleInventoryRead]
+    total_count: int
+    page: int
+    per_page: int
+    pages: int

--- a/backend/app/dto/vehicle_inventory_event.py
+++ b/backend/app/dto/vehicle_inventory_event.py
@@ -1,0 +1,75 @@
+from enum import Enum
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing import Optional, List
+from datetime import datetime
+
+from app.dto.common_enums import Currency
+from app.entrypoint.routes.common.errors import BadRequestError
+
+
+class VehicleInventoryEventType(str, Enum):
+    MANUAL = "manual"          # add stock to the vehicle (+)
+    ADJUSTMENT = "adjustment"  # correct stock up or down (+/-)
+    UNLOAD = "unload"          # remove stock from the vehicle (-)
+
+
+class VehicleInventoryEventCreate(BaseModel):
+    """Create a vehicle inventory event.
+
+    `quantity` is the magnitude entered by the user:
+      - manual:     must be > 0  (added to the balance)
+      - unload:     must be > 0  (removed from the balance)
+      - adjustment: signed (+/-) delta applied to the balance, must be != 0
+    The domain converts this into the signed delta actually stored.
+    """
+    model_config = ConfigDict(extra="forbid")
+    created_by_uuid: Optional[str] = None
+    vehicle_inventory_uuid: str
+    event_type: VehicleInventoryEventType
+    quantity: float
+    cost_per_unit: Optional[float] = None
+    currency: Optional[Currency] = None
+    notes: Optional[str] = None
+
+    @model_validator(mode="after")
+    def check_quantity(self):
+        if self.quantity == 0:
+            raise BadRequestError("quantity must be non-zero")
+        if self.event_type in (VehicleInventoryEventType.MANUAL, VehicleInventoryEventType.UNLOAD) and self.quantity <= 0:
+            raise BadRequestError(f"quantity must be positive for event_type '{self.event_type.value}'")
+        return self
+
+
+class VehicleInventoryEventRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+    uuid: str
+    created_by_uuid: Optional[str] = None
+    vehicle_inventory_uuid: str
+    material_uuid: str
+    event_type: VehicleInventoryEventType
+    quantity: float
+    cost_per_unit: Optional[float] = None
+    currency: Optional[str] = None
+    notes: Optional[str] = None
+    is_deleted: bool
+    created_at: datetime
+
+
+class VehicleInventoryEventListParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    uuid: Optional[str] = None
+    vehicle_inventory_uuid: Optional[str] = None
+    event_type: Optional[VehicleInventoryEventType] = None
+    start_date: Optional[datetime] = Field(None, description="On or after this datetime")
+    end_date: Optional[datetime] = Field(None, description="On or before this datetime")
+    page: int = Field(1, gt=0)
+    per_page: int = Field(20, gt=0, le=100)
+
+
+class VehicleInventoryEventPage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    events: List[VehicleInventoryEventRead]
+    total_count: int
+    page: int
+    per_page: int
+    pages: int

--- a/backend/app/entrypoint/routes/vehicle_inventory/__init__.py
+++ b/backend/app/entrypoint/routes/vehicle_inventory/__init__.py
@@ -1,0 +1,6 @@
+from flask import Blueprint
+
+vehicle_inventory_blueprint = Blueprint('vehicle_inventory', __name__)
+
+# Import routes so they are registered with the blueprint
+from . import routes

--- a/backend/app/entrypoint/routes/vehicle_inventory/routes.py
+++ b/backend/app/entrypoint/routes/vehicle_inventory/routes.py
@@ -1,0 +1,112 @@
+from flask import request, jsonify
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+from app.entrypoint.routes.common.errors import NotFoundError
+from app.entrypoint.routes.common.auth import scopes_required, add_logged_user_to_payload
+from app.dto.auth import PermissionScope
+from app.dto.vehicle_inventory import (
+    VehicleInventoryCreate,
+    VehicleInventoryUpdate,
+    VehicleInventoryRead,
+    VehicleInventoryListParams,
+    VehicleInventoryPage,
+)
+from models.common import VehicleInventory as VehicleInventoryModel
+from app.domains.vehicle_inventory.domain import VehicleInventoryDomain
+from app.entrypoint.routes.vehicle_inventory import vehicle_inventory_blueprint
+
+_ALL_SCOPES = (
+    PermissionScope.ADMIN.value,
+    PermissionScope.SUPER_ADMIN.value,
+    PermissionScope.ACCOUNTANT.value,
+    PermissionScope.OPERATION_MANAGER.value,
+    PermissionScope.OPERATOR.value,
+    PermissionScope.SALES.value,
+    PermissionScope.DRIVER.value,
+)
+
+
+@vehicle_inventory_blueprint.route('/', methods=['POST'])
+@jwt_required()
+@scopes_required(*_ALL_SCOPES)
+def create_vehicle_inventory():
+    current_user_uuid = get_jwt_identity()
+    payload = VehicleInventoryCreate(**request.json)
+    with SqlAlchemyUnitOfWork() as uow:
+        add_logged_user_to_payload(uow=uow, user_uuid=current_user_uuid, payload=payload)
+        read = VehicleInventoryDomain.create_vehicle_inventory(uow=uow, payload=payload)
+        result = read.model_dump(mode='json')
+        uow.commit()
+    return jsonify(result), 201
+
+
+@vehicle_inventory_blueprint.route('/<string:uuid>', methods=['GET'])
+@jwt_required()
+@scopes_required(*_ALL_SCOPES)
+def get_vehicle_inventory(uuid: str):
+    with SqlAlchemyUnitOfWork() as uow:
+        inv = uow.vehicle_inventory_repository.find_one(uuid=uuid, is_deleted=False)
+        if not inv:
+            raise NotFoundError('Vehicle inventory not found')
+        result = VehicleInventoryRead.from_orm(inv).model_dump(mode='json')
+    return jsonify(result), 200
+
+
+@vehicle_inventory_blueprint.route('/<string:uuid>', methods=['PUT'])
+@jwt_required()
+@scopes_required(*_ALL_SCOPES)
+def update_vehicle_inventory(uuid: str):
+    payload = VehicleInventoryUpdate(**request.json)
+    updates = payload.model_dump(exclude_unset=True, mode='json')
+    with SqlAlchemyUnitOfWork() as uow:
+        inv = uow.vehicle_inventory_repository.find_one(uuid=uuid, is_deleted=False)
+        if not inv:
+            raise NotFoundError('Vehicle inventory not found')
+        for field, val in updates.items():
+            setattr(inv, field, val)
+        uow.vehicle_inventory_repository.save(model=inv, commit=True)
+        result = VehicleInventoryRead.from_orm(inv).model_dump(mode='json')
+    return jsonify(result), 200
+
+
+@vehicle_inventory_blueprint.route('/<string:uuid>', methods=['DELETE'])
+@jwt_required()
+@scopes_required(PermissionScope.ADMIN.value, PermissionScope.SUPER_ADMIN.value)
+def delete_vehicle_inventory(uuid: str):
+    with SqlAlchemyUnitOfWork() as uow:
+        read = VehicleInventoryDomain.delete_vehicle_inventory(uow=uow, uuid=uuid)
+        result = read.model_dump(mode='json')
+        uow.commit()
+    return jsonify(result), 200
+
+
+@vehicle_inventory_blueprint.route('/', methods=['GET'])
+@jwt_required()
+@scopes_required(*_ALL_SCOPES)
+def list_vehicle_inventories():
+    params = VehicleInventoryListParams(**request.args)
+    filters = [VehicleInventoryModel.is_deleted == False]
+    if params.uuid:
+        filters.append(VehicleInventoryModel.uuid == params.uuid)
+    if params.vehicle_uuid:
+        filters.append(VehicleInventoryModel.vehicle_uuid == params.vehicle_uuid)
+    if params.material_uuid:
+        filters.append(VehicleInventoryModel.material_uuid == params.material_uuid)
+    if params.is_active is not None:
+        filters.append(VehicleInventoryModel.is_active == params.is_active)
+    with SqlAlchemyUnitOfWork() as uow:
+        page_obj = uow.vehicle_inventory_repository.find_all_by_filters_paginated(
+            filters=filters,
+            page=params.page,
+            per_page=params.per_page,
+        )
+        items = [VehicleInventoryRead.from_orm(i).model_dump(mode='json') for i in page_obj.items]
+        result = VehicleInventoryPage(
+            vehicle_inventories=items,
+            total_count=page_obj.total,
+            page=page_obj.page,
+            per_page=page_obj.per_page,
+            pages=page_obj.pages,
+        ).model_dump(mode='json')
+    return jsonify(result), 200

--- a/backend/app/entrypoint/routes/vehicle_inventory_event/__init__.py
+++ b/backend/app/entrypoint/routes/vehicle_inventory_event/__init__.py
@@ -1,0 +1,6 @@
+from flask import Blueprint
+
+vehicle_inventory_event_blueprint = Blueprint('vehicle_inventory_event', __name__)
+
+# Import routes so they are registered with the blueprint
+from . import routes

--- a/backend/app/entrypoint/routes/vehicle_inventory_event/routes.py
+++ b/backend/app/entrypoint/routes/vehicle_inventory_event/routes.py
@@ -1,0 +1,96 @@
+from flask import request, jsonify
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+from app.entrypoint.routes.common.errors import NotFoundError
+from app.entrypoint.routes.common.auth import scopes_required, add_logged_user_to_payload
+from app.dto.auth import PermissionScope
+from app.dto.vehicle_inventory_event import (
+    VehicleInventoryEventCreate,
+    VehicleInventoryEventRead,
+    VehicleInventoryEventListParams,
+    VehicleInventoryEventPage,
+)
+from models.common import VehicleInventoryEvent as VehicleInventoryEventModel
+from app.domains.vehicle_inventory_event.domain import VehicleInventoryEventDomain
+from app.entrypoint.routes.vehicle_inventory_event import vehicle_inventory_event_blueprint
+
+_ALL_SCOPES = (
+    PermissionScope.ADMIN.value,
+    PermissionScope.SUPER_ADMIN.value,
+    PermissionScope.ACCOUNTANT.value,
+    PermissionScope.OPERATION_MANAGER.value,
+    PermissionScope.OPERATOR.value,
+    PermissionScope.SALES.value,
+    PermissionScope.DRIVER.value,
+)
+
+
+@vehicle_inventory_event_blueprint.route('/', methods=['POST'])
+@jwt_required()
+@scopes_required(*_ALL_SCOPES)
+def create_vehicle_inventory_event():
+    current_user_uuid = get_jwt_identity()
+    payload = VehicleInventoryEventCreate(**request.json)
+    with SqlAlchemyUnitOfWork() as uow:
+        add_logged_user_to_payload(uow=uow, user_uuid=current_user_uuid, payload=payload)
+        read = VehicleInventoryEventDomain.create_event(uow=uow, payload=payload)
+        result = read.model_dump(mode='json')
+        uow.commit()
+    return jsonify(result), 201
+
+
+@vehicle_inventory_event_blueprint.route('/<string:uuid>', methods=['GET'])
+@jwt_required()
+@scopes_required(*_ALL_SCOPES)
+def get_vehicle_inventory_event(uuid: str):
+    with SqlAlchemyUnitOfWork() as uow:
+        event = uow.vehicle_inventory_event_repository.find_one(uuid=uuid, is_deleted=False)
+        if not event:
+            raise NotFoundError('Vehicle inventory event not found')
+        result = VehicleInventoryEventRead.from_orm(event).model_dump(mode='json')
+    return jsonify(result), 200
+
+
+@vehicle_inventory_event_blueprint.route('/<string:uuid>', methods=['DELETE'])
+@jwt_required()
+@scopes_required(PermissionScope.ADMIN.value, PermissionScope.SUPER_ADMIN.value)
+def delete_vehicle_inventory_event(uuid: str):
+    with SqlAlchemyUnitOfWork() as uow:
+        read = VehicleInventoryEventDomain.delete_event(uow=uow, uuid=uuid)
+        result = read.model_dump(mode='json')
+        uow.commit()
+    return jsonify(result), 200
+
+
+@vehicle_inventory_event_blueprint.route('/', methods=['GET'])
+@jwt_required()
+@scopes_required(*_ALL_SCOPES)
+def list_vehicle_inventory_events():
+    params = VehicleInventoryEventListParams(**request.args)
+    filters = [VehicleInventoryEventModel.is_deleted == False]
+    if params.uuid:
+        filters.append(VehicleInventoryEventModel.uuid == params.uuid)
+    if params.vehicle_inventory_uuid:
+        filters.append(VehicleInventoryEventModel.vehicle_inventory_uuid == params.vehicle_inventory_uuid)
+    if params.event_type:
+        filters.append(VehicleInventoryEventModel.event_type == params.event_type.value)
+    if params.start_date:
+        filters.append(VehicleInventoryEventModel.created_at >= params.start_date)
+    if params.end_date:
+        filters.append(VehicleInventoryEventModel.created_at <= params.end_date)
+    with SqlAlchemyUnitOfWork() as uow:
+        page_obj = uow.vehicle_inventory_event_repository.find_all_by_filters_paginated(
+            filters=filters,
+            page=params.page,
+            per_page=params.per_page,
+        )
+        items = [VehicleInventoryEventRead.from_orm(e).model_dump(mode='json') for e in page_obj.items]
+        result = VehicleInventoryEventPage(
+            events=items,
+            total_count=page_obj.total,
+            page=page_obj.page,
+            per_page=page_obj.per_page,
+            pages=page_obj.pages,
+        ).model_dump(mode='json')
+    return jsonify(result), 200

--- a/backend/migrations/versions/b1f3a7c9d2e4_add_vehicle_inventory.py
+++ b/backend/migrations/versions/b1f3a7c9d2e4_add_vehicle_inventory.py
@@ -1,0 +1,78 @@
+"""add vehicle inventory (independent of warehouse inventory)
+
+Revision ID: b1f3a7c9d2e4
+Revises: fc6fa8ebb3e3
+Create Date: 2026-06-30 11:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1f3a7c9d2e4'
+down_revision: Union[str, None] = 'fc6fa8ebb3e3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'vehicle_inventory',
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('created_by_uuid', sa.String(length=36), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('vehicle_uuid', sa.String(length=36), nullable=False),
+        sa.Column('material_uuid', sa.String(length=36), nullable=False),
+        sa.Column('unit', sa.String(length=120), nullable=True),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('currency', sa.String(length=120), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=True),
+        sa.Column('is_deleted', sa.Boolean(), nullable=True),
+        sa.ForeignKeyConstraint(['created_by_uuid'], ['user.uuid']),
+        sa.ForeignKeyConstraint(['vehicle_uuid'], ['vehicle.uuid']),
+        sa.ForeignKeyConstraint(['material_uuid'], ['material.uuid']),
+        sa.PrimaryKeyConstraint('uuid'),
+    )
+    # one active stock row per (vehicle, material)
+    op.create_index(
+        'uq_vehicle_inventory_vehicle_material_active',
+        'vehicle_inventory',
+        ['vehicle_uuid', 'material_uuid'],
+        unique=True,
+        postgresql_where=sa.text('is_deleted = false'),
+    )
+
+    op.create_table(
+        'vehicle_inventory_event',
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('created_by_uuid', sa.String(length=36), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('vehicle_inventory_uuid', sa.String(length=36), nullable=False),
+        sa.Column('material_uuid', sa.String(length=36), nullable=False),
+        sa.Column('event_type', sa.String(length=120), nullable=False),
+        sa.Column('quantity', sa.Float(), nullable=False),
+        sa.Column('cost_per_unit', sa.Float(), nullable=True),
+        sa.Column('currency', sa.String(length=120), nullable=True),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('is_deleted', sa.Boolean(), nullable=True),
+        sa.ForeignKeyConstraint(['created_by_uuid'], ['user.uuid']),
+        sa.ForeignKeyConstraint(['vehicle_inventory_uuid'], ['vehicle_inventory.uuid']),
+        sa.ForeignKeyConstraint(['material_uuid'], ['material.uuid']),
+        sa.PrimaryKeyConstraint('uuid'),
+    )
+    op.create_index(
+        'ix_vehicle_inventory_event_inventory_uuid',
+        'vehicle_inventory_event',
+        ['vehicle_inventory_uuid'],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_vehicle_inventory_event_inventory_uuid', table_name='vehicle_inventory_event')
+    op.drop_table('vehicle_inventory_event')
+    op.drop_index('uq_vehicle_inventory_vehicle_material_active', table_name='vehicle_inventory')
+    op.drop_table('vehicle_inventory')

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -25,6 +25,7 @@ from sqlalchemy import (
     Integer,
 )
 from sqlalchemy.orm import relationship
+from sqlalchemy import UniqueConstraint, Index, text
 from models.base import Base
 
 class User(Base):
@@ -1969,3 +1970,91 @@ class TripStop(Base):
 
 
 
+
+
+# ------------------------------
+# Vehicle Inventory (independent of warehouse inventory)
+# ------------------------------
+# These two tables track materials carried on a vehicle. They intentionally have
+# NO foreign keys to / from the warehouse Inventory or InventoryEvent tables and
+# are not referenced by any warehouse inventory logic, so vehicle stock is fully
+# isolated from warehouse stock.
+
+class VehicleInventory(Base):
+    __tablename__ = "vehicle_inventory"
+
+    uuid = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    created_by_uuid = Column(String(36), ForeignKey('user.uuid'), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    vehicle_uuid = Column(String(36), ForeignKey("vehicle.uuid"), nullable=False)
+    material_uuid = Column(String(36), ForeignKey("material.uuid"), nullable=False)
+    unit = Column(String(120), nullable=True)  # mirrors material.measure_unit
+    notes = Column(Text, nullable=True)
+    currency = Column(String(120), nullable=True)
+    is_active = Column(Boolean, default=True)
+    is_deleted = Column(Boolean, default=False)
+
+    # one active stock row per (vehicle, material)
+    __table_args__ = (
+        Index(
+            "uq_vehicle_inventory_vehicle_material_active",
+            "vehicle_uuid", "material_uuid",
+            unique=True,
+            postgresql_where=text("is_deleted = false"),
+        ),
+    )
+
+    # relations (backref avoids editing Vehicle/Material)
+    vehicle = relationship("Vehicle", backref="vehicle_inventories")
+    material = relationship("Material", backref="vehicle_inventories")
+    events = relationship("VehicleInventoryEvent", back_populates="vehicle_inventory")
+
+    @hybrid_property
+    def current_quantity(self):
+        return sum(e.quantity for e in self.events if not e.is_deleted)
+
+    @current_quantity.expression
+    def current_quantity(cls):
+        return (
+            select(func.coalesce(func.sum(VehicleInventoryEvent.quantity), 0))
+            .where(
+                VehicleInventoryEvent.vehicle_inventory_uuid == cls.uuid,
+                VehicleInventoryEvent.is_deleted.is_(False),
+            )
+            .scalar_subquery()
+        )
+
+    @hybrid_property
+    def material_name(self):
+        return self.material.name if self.material else None
+
+    def __repr__(self):
+        return (
+            f"<VehicleInventory(uuid={self.uuid}, vehicle_uuid={self.vehicle_uuid}, "
+            f"material_uuid={self.material_uuid}, current_quantity={self.current_quantity})>"
+        )
+
+
+class VehicleInventoryEvent(Base):
+    __tablename__ = "vehicle_inventory_event"
+
+    uuid = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    created_by_uuid = Column(String(36), ForeignKey('user.uuid'), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    vehicle_inventory_uuid = Column(String(36), ForeignKey("vehicle_inventory.uuid"), nullable=False)
+    material_uuid = Column(String(36), ForeignKey("material.uuid"), nullable=False)
+    event_type = Column(String(120), nullable=False)  # manual, adjustment, unload
+    quantity = Column(Float, nullable=False)  # signed delta applied to the balance
+    cost_per_unit = Column(Float, nullable=True)
+    currency = Column(String(120), nullable=True)
+    notes = Column(Text, nullable=True)
+    is_deleted = Column(Boolean, default=False)
+
+    # relations
+    vehicle_inventory = relationship("VehicleInventory", back_populates="events")
+
+    def __repr__(self):
+        return (
+            f"<VehicleInventoryEvent(uuid={self.uuid}, type={self.event_type}, "
+            f"quantity={self.quantity})>"
+        )

--- a/frontend/client/src/components/vehicles/VehicleInventoryChart.tsx
+++ b/frontend/client/src/components/vehicles/VehicleInventoryChart.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { apiRequest } from "@/lib/queryClient";
+
+const MIN = 60 * 1000;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+
+const PRESETS: { value: string; label: string; ms?: number }[] = [
+  { value: "all", label: "All time" },
+  { value: "15m", label: "Last 15 minutes", ms: 15 * MIN },
+  { value: "30m", label: "Last 30 minutes", ms: 30 * MIN },
+  { value: "1h", label: "Last 1 hour", ms: HOUR },
+  { value: "6h", label: "Last 6 hours", ms: 6 * HOUR },
+  { value: "12h", label: "Last 12 hours", ms: 12 * HOUR },
+  { value: "24h", label: "Last 24 hours", ms: DAY },
+  { value: "7d", label: "Last 7 days", ms: 7 * DAY },
+  { value: "30d", label: "Last 30 days", ms: 30 * DAY },
+  { value: "90d", label: "Last 90 days", ms: 90 * DAY },
+  { value: "custom", label: "Custom range" },
+];
+const PRESET_MS: Record<string, number> = Object.fromEntries(
+  PRESETS.filter((p) => p.ms).map((p) => [p.value, p.ms as number])
+);
+
+interface VehicleInventory {
+  uuid: string;
+  material_uuid: string;
+  material_name?: string | null;
+  unit?: string | null;
+}
+
+interface VInvEvent {
+  created_at: string;
+  quantity: number;
+}
+
+const PALETTE = [
+  "#5469D4", "#16a34a", "#dc2626", "#d97706", "#7c3aed",
+  "#0891b2", "#db2777", "#65a30d", "#0ea5e9", "#9333ea",
+];
+
+// Backend timestamps are naive UTC ("2026-06-30T11:01:10.9"); parse them as UTC,
+// not local time, so they don't drift relative to Date.now().
+const toMs = (s: string) => {
+  const hasTz = /[zZ]|[+-]\d{2}:?\d{2}$/.test(s);
+  return new Date(hasTz ? s : s + "Z").getTime();
+};
+
+export function VehicleInventoryChart({ vehicleUuid }: { vehicleUuid: string }) {
+  const [preset, setPreset] = useState("all");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const { data: invData } = useQuery({
+    queryKey: ["/vehicle-inventory/", vehicleUuid, "chart"],
+    queryFn: async () => apiRequest(`/vehicle-inventory/?vehicle_uuid=${vehicleUuid}&per_page=100`),
+  });
+  const inventories: VehicleInventory[] = invData?.vehicle_inventories || [];
+
+  // default: all materials selected (once they load)
+  useEffect(() => {
+    if (inventories.length && selected.size === 0) {
+      setSelected(new Set(inventories.map((i) => i.uuid)));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [invData]);
+
+  const invUuids = inventories.map((i) => i.uuid).sort().join(",");
+  const { data: eventsByInv } = useQuery<Record<string, VInvEvent[]>>({
+    queryKey: ["/vehicle-inventory-event/series", vehicleUuid, invUuids],
+    queryFn: async () => {
+      const entries = await Promise.all(
+        inventories.map(async (inv) => {
+          const res = await apiRequest(
+            `/vehicle-inventory-event/?vehicle_inventory_uuid=${inv.uuid}&per_page=100`
+          );
+          const events: VInvEvent[] = (res?.events || [])
+            .slice()
+            .sort((a: VInvEvent, b: VInvEvent) => toMs(a.created_at) - toMs(b.created_at));
+          return [inv.uuid, events] as const;
+        })
+      );
+      return Object.fromEntries(entries);
+    },
+    enabled: inventories.length > 0,
+  });
+
+  const { rows, lines } = useMemo(() => {
+    if (!inventories.length || !eventsByInv) return { rows: [] as any[], lines: [] as any[] };
+
+    const now = Date.now();
+    let startMs: number;
+    let endMs: number;
+    if (preset === "custom") {
+      startMs = startDate ? new Date(startDate + "T00:00:00Z").getTime() : -Infinity;
+      endMs = endDate ? new Date(endDate + "T23:59:59Z").getTime() : now;
+    } else if (preset === "all") {
+      startMs = -Infinity;
+      endMs = now;
+    } else {
+      startMs = now - (PRESET_MS[preset] || 0);
+      endMs = now;
+    }
+
+    const shown = inventories.filter((i) => selected.has(i.uuid));
+
+    // running balance points per material
+    const cum: Record<string, { t: number; bal: number }[]> = {};
+    const times = new Set<number>();
+    for (const inv of shown) {
+      const evs = eventsByInv[inv.uuid] || [];
+      let bal = 0;
+      const pts: { t: number; bal: number }[] = [];
+      for (const e of evs) {
+        bal += e.quantity;
+        const t = toMs(e.created_at);
+        pts.push({ t, bal });
+        if (t >= startMs && t <= endMs) times.add(t);
+      }
+      cum[inv.uuid] = pts;
+    }
+
+    const sortedTimes = Array.from(times).sort((a, b) => a - b);
+    const lo = isFinite(startMs) ? startMs : sortedTimes[0];
+    const axis =
+      lo === undefined
+        ? []
+        : Array.from(new Set([lo, ...sortedTimes.filter((t) => t >= lo && t <= endMs), endMs])).sort(
+            (a, b) => a - b
+          );
+
+    const balAt = (pts: { t: number; bal: number }[], t: number) => {
+      let b = 0;
+      for (const p of pts) {
+        if (p.t <= t) b = p.bal;
+        else break;
+      }
+      return b;
+    };
+
+    const rows = axis.map((t) => {
+      const row: Record<string, number> = { t };
+      for (const inv of shown) row[inv.uuid] = balAt(cum[inv.uuid] || [], t);
+      return row;
+    });
+
+    const lines = shown.map((inv, i) => ({
+      key: inv.uuid,
+      name: inv.material_name || inv.material_uuid,
+      color: PALETTE[i % PALETTE.length],
+    }));
+
+    return { rows, lines };
+  }, [inventories, eventsByInv, selected, preset, startDate, endDate]);
+
+  const toggle = (uuid: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.has(uuid) ? next.delete(uuid) : next.add(uuid);
+      return next;
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Inventory Over Time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {/* Filters */}
+        <div className="flex flex-wrap items-end gap-4 mb-4">
+          <div>
+            <label className="text-sm font-medium text-gray-500 mb-1 block">Range</label>
+            <Select value={preset} onValueChange={setPreset}>
+              <SelectTrigger className="w-48" data-testid="select-vinv-chart-range">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PRESETS.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {preset === "custom" && (
+            <>
+              <div>
+                <label className="text-sm font-medium text-gray-500 mb-1 block">From</label>
+                <Input
+                  type="date"
+                  className="w-44"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  data-testid="input-vinv-chart-start"
+                />
+              </div>
+              <div>
+                <label className="text-sm font-medium text-gray-500 mb-1 block">To</label>
+                <Input
+                  type="date"
+                  className="w-44"
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  data-testid="input-vinv-chart-end"
+                />
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Material toggles */}
+        {inventories.length > 0 && (
+          <div className="flex flex-wrap gap-3 mb-4">
+            {inventories.map((inv, i) => (
+              <label key={inv.uuid} className="flex items-center gap-2 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selected.has(inv.uuid)}
+                  onChange={() => toggle(inv.uuid)}
+                />
+                <span
+                  className="inline-block w-3 h-3 rounded-sm"
+                  style={{ backgroundColor: PALETTE[i % PALETTE.length] }}
+                />
+                {inv.material_name || inv.material_uuid}
+              </label>
+            ))}
+          </div>
+        )}
+
+        {/* Chart */}
+        {inventories.length === 0 ? (
+          <div className="text-sm text-gray-500 py-12 text-center">
+            No inventory on this vehicle yet.
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="text-sm text-gray-500 py-12 text-center">
+            No inventory events in this range.
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={340}>
+            <LineChart data={rows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="t"
+                type="number"
+                scale="time"
+                domain={["dataMin", "dataMax"]}
+                tickFormatter={(t) => new Date(t).toLocaleDateString()}
+                fontSize={12}
+              />
+              <YAxis allowDecimals fontSize={12} />
+              <Tooltip
+                labelFormatter={(t) => new Date(t as number).toLocaleString()}
+                formatter={(value: any, name: any) => [value, name]}
+              />
+              <Legend />
+              {lines.map((l) => (
+                <Line
+                  key={l.key}
+                  type="stepAfter"
+                  dataKey={l.key}
+                  name={l.name}
+                  stroke={l.color}
+                  dot={false}
+                  strokeWidth={2}
+                  connectNulls
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/client/src/components/vehicles/VehicleInventoryDialog.tsx
+++ b/frontend/client/src/components/vehicles/VehicleInventoryDialog.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { Boxes, Plus } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+
+interface VehicleInventory {
+  uuid: string;
+  material_uuid: string;
+  material_name?: string | null;
+  unit?: string | null;
+  current_quantity?: number | null;
+}
+
+const EVENT_TYPES = [
+  { value: "manual", label: "Add (manual)" },
+  { value: "adjustment", label: "Adjust (+/-)" },
+  { value: "unload", label: "Unload" },
+];
+
+function InventoryRow({
+  inv,
+  onApply,
+  isPending,
+}: {
+  inv: VehicleInventory;
+  onApply: (eventType: string, quantity: number) => void;
+  isPending: boolean;
+}) {
+  const [eventType, setEventType] = useState("manual");
+  const [qty, setQty] = useState("");
+
+  const apply = () => {
+    const n = parseFloat(qty);
+    if (!isNaN(n) && n !== 0) {
+      onApply(eventType, n);
+      setQty("");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-3 border rounded-md p-3">
+      <div className="min-w-0">
+        <div className="font-medium truncate" data-testid={`text-vinv-material-${inv.uuid}`}>
+          {inv.material_name || inv.material_uuid}
+        </div>
+        <div className="text-sm text-gray-500">
+          On hand: <span className="font-semibold">{inv.current_quantity ?? 0}</span> {inv.unit || ""}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Select value={eventType} onValueChange={setEventType}>
+          <SelectTrigger className="w-[150px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {EVENT_TYPES.map((t) => (
+              <SelectItem key={t.value} value={t.value}>
+                {t.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Input
+          type="number"
+          step="any"
+          placeholder="Qty"
+          className="w-24"
+          value={qty}
+          onChange={(e) => setQty(e.target.value)}
+        />
+        <Button size="sm" disabled={isPending || !qty} onClick={apply}>
+          Apply
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function VehicleInventoryDialog({ vehicleUuid }: { vehicleUuid: string }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [materialUuid, setMaterialUuid] = useState("");
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const invKey = ["/vehicle-inventory/", vehicleUuid];
+
+  const { data: invData, isLoading } = useQuery({
+    queryKey: invKey,
+    queryFn: async () =>
+      apiRequest(`/vehicle-inventory/?vehicle_uuid=${vehicleUuid}&per_page=100`),
+    enabled: isOpen,
+  });
+  const inventories: VehicleInventory[] = invData?.vehicle_inventories || [];
+
+  const { data: materialsData } = useQuery({
+    queryKey: ["/material/", "vehicle-inventory"],
+    queryFn: async () => apiRequest(`/material/?page=1&per_page=100`),
+    enabled: isOpen,
+  });
+  const materials = materialsData?.materials || [];
+
+  const refresh = () => {
+    queryClient.invalidateQueries({ queryKey: invKey });
+    queryClient.refetchQueries({ queryKey: invKey });
+  };
+
+  const createInventory = useMutation({
+    mutationFn: async () =>
+      apiRequest("/vehicle-inventory/", {
+        method: "POST",
+        body: { vehicle_uuid: vehicleUuid, material_uuid: materialUuid },
+      }),
+    onSuccess: () => {
+      toast({ title: "Added", description: "Material added to vehicle." });
+      setMaterialUuid("");
+      refresh();
+    },
+    onError: (e: Error) => toast({ title: "Error", description: e.message, variant: "destructive" }),
+  });
+
+  const createEvent = useMutation({
+    mutationFn: async (vars: { vehicle_inventory_uuid: string; event_type: string; quantity: number }) =>
+      apiRequest("/vehicle-inventory-event/", { method: "POST", body: vars }),
+    onSuccess: () => {
+      toast({ title: "Updated", description: "Vehicle stock updated." });
+      refresh();
+    },
+    onError: (e: Error) => toast({ title: "Error", description: e.message, variant: "destructive" }),
+  });
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" data-testid="button-vehicle-inventory">
+          <Boxes className="h-4 w-4 mr-2" />
+          Inventory
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Vehicle Inventory</DialogTitle>
+        </DialogHeader>
+
+        {/* Add a material to this vehicle */}
+        <div className="flex items-end gap-2 border-b pb-4">
+          <div className="flex-1">
+            <label className="text-sm font-medium mb-1 block">Add material</label>
+            <Select value={materialUuid} onValueChange={setMaterialUuid}>
+              <SelectTrigger data-testid="select-vinv-material">
+                <SelectValue placeholder="Select material..." />
+              </SelectTrigger>
+              <SelectContent>
+                {materials.map((m: any) => (
+                  <SelectItem key={m.uuid} value={m.uuid}>
+                    {m.name}
+                    {m.sku ? ` (${m.sku})` : ""}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <Button
+            onClick={() => createInventory.mutate()}
+            disabled={!materialUuid || createInventory.isPending}
+            data-testid="button-add-vinv"
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            Add
+          </Button>
+        </div>
+
+        {/* Current stock + add/adjust/unload */}
+        <div className="space-y-2 max-h-[50vh] overflow-y-auto">
+          {isLoading ? (
+            <div className="text-sm text-gray-500 py-6 text-center">Loading...</div>
+          ) : inventories.length === 0 ? (
+            <div className="text-sm text-gray-500 py-6 text-center">
+              No inventory on this vehicle yet. Add a material above to get started.
+            </div>
+          ) : (
+            inventories.map((inv) => (
+              <InventoryRow
+                key={inv.uuid}
+                inv={inv}
+                isPending={createEvent.isPending}
+                onApply={(event_type, quantity) =>
+                  createEvent.mutate({ vehicle_inventory_uuid: inv.uuid, event_type, quantity })
+                }
+              />
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/client/src/pages/VehicleDetail.tsx
+++ b/frontend/client/src/pages/VehicleDetail.tsx
@@ -36,6 +36,7 @@ import { useToast } from "@/hooks/use-toast";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { VehicleStatus, type Vehicle, type VehicleUpdateData } from "@/lib/types";
 import { VehicleInventoryDialog } from "@/components/vehicles/VehicleInventoryDialog";
+import { VehicleInventoryChart } from "@/components/vehicles/VehicleInventoryChart";
 
 const vehicleUpdateSchema = z.object({
   plate_number: z.string().min(1, "Plate number is required").optional(),
@@ -599,6 +600,11 @@ export default function VehicleDetail() {
               </CardContent>
             </Card>
           </div>
+        </div>
+
+        {/* Inventory time series chart */}
+        <div className="mt-6">
+          <VehicleInventoryChart vehicleUuid={uuid as string} />
         </div>
       </div>
     </AppLayout>

--- a/frontend/client/src/pages/VehicleDetail.tsx
+++ b/frontend/client/src/pages/VehicleDetail.tsx
@@ -35,6 +35,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { VehicleStatus, type Vehicle, type VehicleUpdateData } from "@/lib/types";
+import { VehicleInventoryDialog } from "@/components/vehicles/VehicleInventoryDialog";
 
 const vehicleUpdateSchema = z.object({
   plate_number: z.string().min(1, "Plate number is required").optional(),
@@ -273,6 +274,7 @@ export default function VehicleDetail() {
           <div className="flex items-center gap-2">
             {!isEditing && (
               <>
+                <VehicleInventoryDialog vehicleUuid={uuid as string} />
                 <Button
                   variant="outline"
                   onClick={() => setIsEditing(true)}


### PR DESCRIPTION
Adds isolated vehicle inventory tracking — materials carried on a vehicle, with **no** coupling to warehouse inventory.

- **Models:** `VehicleInventory` (unique active row per vehicle+material; `current_quantity` summed from events) + `VehicleInventoryEvent` (`manual`/`adjustment`/`unload`, stored as signed delta).
- **Migration** `b1f3a7c9d2e4` (down_revision `fc6fa8ebb3e3`) — two new tables + partial unique index.
- DTOs, repositories (+UoW), domains (sign-by-type, non-negative balance guard), routes `/vehicle-inventory` and `/vehicle-inventory-event`.

Independence: the new tables have no FK to/from `inventory`/`inventory_event` and no existing warehouse logic touches them.

Verified end-to-end on the local stack: create → manual/adjustment/unload events → balance correct, over-unload + duplicate rejected, warehouse inventory unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)