### PR TITLE
Trip workflow improvements: attribution, trip insights, manual stops

### DIFF
--- a/backend/app/domains/customer_order/domain.py
+++ b/backend/app/domains/customer_order/domain.py
@@ -39,7 +39,8 @@ class CustomerOrderDomain:
                 uow=uow,
                 payload=CustomerOrderItemBulkFulfill(
                     items=[FulfillItem(customer_order_item_uuid=item.uuid)
-                           for item in full.customer_order.customer_order_items]
+                           for item in full.customer_order.customer_order_items],
+                    trip_stop_uuid=payload.trip_stop_uuid,
                 ),
             )
 
@@ -56,6 +57,7 @@ class CustomerOrderDomain:
                         amount=amount,
                         currency=payload.currency,
                         payment_method=payload.payment_method,
+                        trip_stop_uuid=payload.trip_stop_uuid,
                     ),
                 )
 

--- a/backend/app/domains/customer_order/domain.py
+++ b/backend/app/domains/customer_order/domain.py
@@ -16,9 +16,51 @@ from app.dto.invoice_item import InvoiceItemRead
 from app.dto.customer_order_item import CustomerOrderItemBulkDelete
 from app.dto.invoice_item import InvoiceItemBulkDelete
 from app.entrypoint.routes.common.errors import BadRequestError
+from app.dto.customer_order import CustomerOrderCheckoutCreate
 
 
 class CustomerOrderDomain:
+
+    @staticmethod
+    def create_order_checkout(uow: SqlAlchemyUnitOfWork, payload: CustomerOrderCheckoutCreate) -> CustomerOrderWithItemsAndInvoiceRead:
+        """Create order + items + invoice, then optionally fulfill all items and
+        record a full payment against the invoice — all in one transaction."""
+        from app.dto.customer_order_item import CustomerOrderItemBulkFulfill, FulfillItem
+        from app.domains.payment.domain import PaymentDomain
+        from app.dto.payment import PaymentCreate
+
+        full = CustomerOrderDomain.create_customer_order_with_items_and_invoice(
+            uow=uow, payload=payload.to_base_create()
+        )
+        invoice = full.invoices[0]
+
+        if payload.fulfill:
+            CustomerOrderItemDomain.fulfill_items(
+                uow=uow,
+                payload=CustomerOrderItemBulkFulfill(
+                    items=[FulfillItem(customer_order_item_uuid=item.uuid)
+                           for item in full.customer_order.customer_order_items]
+                ),
+            )
+
+        if payload.pay:
+            inv = uow.invoice_repository.find_one(uuid=invoice.uuid, is_deleted=False)
+            amount = inv.net_amount_due if inv else 0
+            if amount and amount > 0:
+                PaymentDomain.create_payment(
+                    uow=uow,
+                    payload=PaymentCreate(
+                        created_by_uuid=payload.created_by_uuid,
+                        invoice_uuid=invoice.uuid,
+                        financial_account_uuid=payload.financial_account_uuid,
+                        amount=amount,
+                        currency=payload.currency,
+                        payment_method=payload.payment_method,
+                    ),
+                )
+
+        order = uow.customer_order_repository.find_one(uuid=full.customer_order.uuid, is_deleted=False)
+        return CustomerOrderWithItemsAndInvoiceRead.from_customer_order_model(order)
 
     @staticmethod
     def create_customer_order_with_items_and_invoice(uow: SqlAlchemyUnitOfWork,payload:CustomerOrderWithItemsAndInvoiceCreate) -> CustomerOrderRead:

--- a/backend/app/domains/customer_order_item/domain.py
+++ b/backend/app/domains/customer_order_item/domain.py
@@ -19,6 +19,8 @@ from app.dto.customer_order_item import CustomerOrderItemBulkUnFulfill
 
 from app.domains.inventory.domain import InventoryDomain
 from app.dto.inventory import InventoryRead, InventoryFIFOOutput
+from app.domains.vehicle_inventory.domain import VehicleInventoryDomain
+from app.domains.vehicle_inventory_event.domain import VehicleInventoryEventDomain
 
 
 class CustomerOrderItemDomain:
@@ -81,6 +83,20 @@ class CustomerOrderItemDomain:
                         affect_original=False
                     )
                 )
+
+            # If this order is being delivered on a trip, also decrement the
+            # vehicle's inventory (independent ledger; may go negative).
+            order = customer_order_item.customer_order
+            trip_stop = order.trip_stop if order else None
+            if trip_stop is not None and trip_stop.trip is not None:
+                VehicleInventoryDomain.record_trip_sale(
+                    uow=uow,
+                    vehicle_uuid=trip_stop.trip.vehicle_uuid,
+                    material_uuid=customer_order_item.material_uuid,
+                    quantity=abs(customer_order_item.quantity),
+                    customer_order_item_uuid=customer_order_item.uuid,
+                    created_by_uuid=customer_order_item.created_by_uuid,
+                )
             items.append(customer_order_item)
         uow.customer_order_item_repository.batch_save(models=items, commit=False)
         bulk_read = CustomerOrderItemBulkRead(items=[CustomerOrderItemRead.from_orm(m) for m in items])
@@ -107,6 +123,15 @@ class CustomerOrderItemDomain:
                 uuid=inventory_events[0].uuid
 
             )
+
+            # reverse any vehicle 'sale' events created when this item was fulfilled on a trip
+            vehicle_sale_events = [
+                e for e in customer_order_item.vehicle_inventory_events
+                if not e.is_deleted and e.event_type == "sale"
+            ]
+            for e in vehicle_sale_events:
+                VehicleInventoryEventDomain.delete_event(uow=uow, uuid=e.uuid)
+
             items.append(customer_order_item)
         uow.customer_order_item_repository.batch_save(models=items, commit=False)
         bulk_read = CustomerOrderItemBulkRead(items=[CustomerOrderItemRead.from_orm(m) for m in items])

--- a/backend/app/domains/customer_order_item/domain.py
+++ b/backend/app/domains/customer_order_item/domain.py
@@ -49,6 +49,14 @@ class CustomerOrderItemDomain:
         payload: CustomerOrderItemBulkFulfill
     ) -> CustomerOrderItemBulkRead:
         items = []
+        # current stop where fulfillment happens (e.g. a previously-created order
+        # handed off during this trip); overrides the order's own stop for vehicle
+        # attribution so the sale lands on the trip actually delivering it.
+        override_stop = None
+        if payload.trip_stop_uuid:
+            override_stop = uow.trip_stop_repository.find_one(uuid=payload.trip_stop_uuid)
+            if not override_stop:
+                raise NotFoundError("TripStop not found")
         for item in payload.items:
             customer_order_item = uow.customer_order_item_repository.find_one(uuid=item.customer_order_item_uuid, is_deleted=False)
             if not customer_order_item:
@@ -87,7 +95,7 @@ class CustomerOrderItemDomain:
             # If this order is being delivered on a trip, also decrement the
             # vehicle's inventory (independent ledger; may go negative).
             order = customer_order_item.customer_order
-            trip_stop = order.trip_stop if order else None
+            trip_stop = override_stop or (order.trip_stop if order else None)
             if trip_stop is not None and trip_stop.trip is not None:
                 VehicleInventoryDomain.record_trip_sale(
                     uow=uow,
@@ -96,6 +104,7 @@ class CustomerOrderItemDomain:
                     quantity=abs(customer_order_item.quantity),
                     customer_order_item_uuid=customer_order_item.uuid,
                     created_by_uuid=customer_order_item.created_by_uuid,
+                    trip_stop_uuid=trip_stop.uuid,
                 )
             items.append(customer_order_item)
         uow.customer_order_item_repository.batch_save(models=items, commit=False)

--- a/backend/app/domains/task_execution/workflow_operators/create_trip_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/create_trip_operator.py
@@ -52,6 +52,138 @@ class CreateTripOperatorSchema(BaseModel):
 
     pass
 
+
+def create_trip_stop_with_task(
+    uow: SqlAlchemyUnitOfWork,
+    workflow_execution,
+    customer,
+    created_by_uuid: Optional[str],
+    index: int,
+    depends_on: list,
+    parent_task_execution_uuid: Optional[str],
+):
+    """Create a trip stop for a customer plus its trip_stop_operator task and
+    task execution, and link them together. Used both for routed stops
+    (pre-created by CreateTripOperator) and ad-hoc manual stops added mid-trip."""
+    from app.domains.task_execution.domain import TaskExecutionDomain
+
+    trip = workflow_execution.trips[0]
+    trip_stop = TripStopDomain.create_trip_stop(
+        uow=uow,
+        payload=TripStopCreate(
+            created_by_uuid=created_by_uuid,
+            trip_uuid=trip.uuid,
+            coordinates=wkt_or_wkb_to_lat_lon(customer.coordinates),
+            customer_uuid=customer.uuid,
+            status=TripStopStatus.IN_PROGRESS.value,
+            index=index,
+        )
+    )
+
+    task_input = TaskInput(
+        data={"trip_stop_uuid": trip_stop.uuid,
+              "customer": CustomerRead.from_orm(customer).model_dump(mode='json')
+              },
+        fields=[
+            TaskInputField(
+                name="outcome -  النتيجة",
+                label="outcome",
+                type=FieldType.SELECT,
+                required=True,
+                options=[outcome.value for outcome in TripStopOutcome]
+            ),
+            TaskInputField(
+                name="notes - ملاحظات",
+                label="notes",
+                type=FieldType.TEXT,
+                required=False,
+            ),
+        ]
+    )
+
+    task_create = TaskDomain.create_task(
+        uow=uow,
+        payload=TaskCreate(
+            # index suffix keeps names unique even when the same customer is
+            # visited twice in one trip (dependency chains reference names)
+            name=f"trip_stop_{customer.company_name}:{customer.uuid}:{index}",
+            created_by_uuid=created_by_uuid,
+            workflow_uuid=None,
+            parent_task_uuid=None,
+            operator=OperatorType.TRIP_STOP_OPERATOR.value,
+            task_inputs=task_input,
+            depends_on=[],
+            callback_fns=[],
+        )
+    )
+
+    task_execution = TaskExecutionDomain.create_task_execution(
+        uow=uow,
+        payload=TaskExecutionCreate(
+            status=WorkflowStatus.NOT_STARTED.value if depends_on else WorkflowStatus.IN_PROGRESS.value,
+            depends_on=depends_on,
+            start_time=datetime.now() if not depends_on else None,
+            task_uuid=task_create.uuid,
+            workflow_execution_uuid=workflow_execution.uuid,
+            created_by_uuid=created_by_uuid,
+            parent_task_execution_uuid=parent_task_execution_uuid,
+        ))
+
+    trip_stop_model = uow.trip_stop_repository.find_one(uuid=trip_stop.uuid)
+    trip_stop_model.task_execution_uuid = task_execution.uuid
+    uow.trip_stop_repository.save(trip_stop_model, commit=False)
+    return task_create, task_execution
+
+
+def create_finish_trip_task(
+    uow: SqlAlchemyUnitOfWork,
+    workflow_execution,
+    created_by_uuid: Optional[str],
+    depends_on: list,
+    parent_task_execution_uuid: Optional[str],
+):
+    """Create the explicit finish-trip task: snapshots end inventory and marks
+    the trip completed. Keeps the workflow open while ad-hoc stops are added."""
+    from app.domains.task_execution.domain import TaskExecutionDomain
+
+    task_input = TaskInput(
+        data={},
+        fields=[
+            TaskInputField(
+                name="notes - ملاحظات",
+                label="notes",
+                type=FieldType.TEXT,
+                required=False,
+            ),
+        ]
+    )
+    task_create = TaskDomain.create_task(
+        uow=uow,
+        payload=TaskCreate(
+            name="finish_trip",
+            created_by_uuid=created_by_uuid,
+            workflow_uuid=None,
+            parent_task_uuid=None,
+            operator=OperatorType.TRIP_FINISH_OPERATOR.value,
+            task_inputs=task_input,
+            depends_on=[],
+            callback_fns=[],
+        )
+    )
+    task_execution = TaskExecutionDomain.create_task_execution(
+        uow=uow,
+        payload=TaskExecutionCreate(
+            status=WorkflowStatus.NOT_STARTED.value if depends_on else WorkflowStatus.IN_PROGRESS.value,
+            depends_on=depends_on,
+            start_time=datetime.now() if not depends_on else None,
+            task_uuid=task_create.uuid,
+            workflow_execution_uuid=workflow_execution.uuid,
+            created_by_uuid=created_by_uuid,
+            parent_task_execution_uuid=parent_task_execution_uuid,
+        ))
+    return task_create, task_execution
+
+
 class CreateTripOperator(OperatorInterface):
 
     def execute(self,uow:SqlAlchemyUnitOfWork,
@@ -74,14 +206,20 @@ class CreateTripOperator(OperatorInterface):
         if not vehicle:
             raise BadRequestError(f"Vehicle not found with plate number: {vehicle_plate}")
 
-        start_warehouse_name = self.get_start_warehouse_name()
-        start_warehouse = uow.warehouse_repository.find_one(name=start_warehouse_name)
-        if not start_warehouse:
-            raise BadRequestError(f"Start Warehouse not found with name: {start_warehouse_name}")
-        end_warehouse_name = self.get_end_warehouse_name()
-        end_warehouse = uow.warehouse_repository.find_one(name=end_warehouse_name)
-        if not end_warehouse:
-            raise BadRequestError(f"End Warehouse not found with name: {end_warehouse_name}")
+        manual_stops = self.is_manual_stops()
+
+        # warehouses are only part of the routed flow; manual trips skip them
+        start_warehouse = None
+        end_warehouse = None
+        if not manual_stops:
+            start_warehouse_name = self.get_start_warehouse_name()
+            start_warehouse = uow.warehouse_repository.find_one(name=start_warehouse_name)
+            if not start_warehouse:
+                raise BadRequestError(f"Start Warehouse not found with name: {start_warehouse_name}")
+            end_warehouse_name = self.get_end_warehouse_name()
+            end_warehouse = uow.warehouse_repository.find_one(name=end_warehouse_name)
+            if not end_warehouse:
+                raise BadRequestError(f"End Warehouse not found with name: {end_warehouse_name}")
 
         service_area_names = self.get_service_areas()
         # create trip
@@ -90,10 +228,10 @@ class CreateTripOperator(OperatorInterface):
                                    created_by_uuid=payload.completed_by_uuid,
                                    vehicle_uuid=vehicle.uuid,
                                    status=TripStatus.IN_PROGRESS.value,
-                                   start_warehouse_uuid=start_warehouse.uuid ,
-                                   end_warehouse_uuid= end_warehouse.uuid,
+                                   start_warehouse_uuid=start_warehouse.uuid if start_warehouse else None,
+                                   end_warehouse_uuid=end_warehouse.uuid if end_warehouse else None,
                                    start_time=datetime.now(),
-                                   service_area_names = service_area_names,
+                                   service_area_names = service_area_names or [],
                                    workflow_execution_uuid=task_exe.workflow_execution.uuid,
                                ))
 
@@ -103,7 +241,7 @@ class CreateTripOperator(OperatorInterface):
         trip.start_inventory = VehicleInventoryDomain.balances_for_vehicle(uow=uow, vehicle_uuid=vehicle.uuid)
         uow.trip_repository.save(model=trip, commit=False)
 
-        # create trip stops
+        # create trip stops (routed mode; manual mode has no pre-computed customers)
         created_task_names = []
         for i,customer_uuid in enumerate(self.get_customer_uuids()):
             customer = uow.customer_repository.find_one(
@@ -113,73 +251,29 @@ class CreateTripOperator(OperatorInterface):
             if not customer:
                 raise BadRequestError(f"Customer not found with uuid: {customer_uuid}")
 
-            trip_stop = TripStopDomain.create_trip_stop(
-                uow=uow,
-                payload=TripStopCreate(
-                    created_by_uuid=payload.completed_by_uuid,
-                    trip_uuid=task_exe.workflow_execution.trips[0].uuid,
-                    coordinates=wkt_or_wkb_to_lat_lon(customer.coordinates),
-                    customer_uuid=customer_uuid,
-                    status=TripStopStatus.IN_PROGRESS.value,
-                    index=i
-                )
-            )
-
-            task_input = TaskInput(
-                data = {"trip_stop_uuid":trip_stop.uuid,
-                        "customer": CustomerRead.from_orm(customer).model_dump(mode='json')
-                        },
-                fields = [
-                    TaskInputField(
-                        name = "outcome -  النتيجة",
-                        label="outcome",
-                        type=FieldType.SELECT,
-                        required=True,
-                        options=[outcome.value for outcome in TripStopOutcome]
-                    ),
-                    TaskInputField(
-                        name = "notes - ملاحظات",
-                        label="notes",
-                        type=FieldType.TEXT,
-                        required=False,
-                    ),
-
-                ]
-            )
-
-            task_create = TaskDomain.create_task(
-                uow=uow,
-                payload=TaskCreate(
-                    name=f"trip_stop_{customer.company_name}:{customer_uuid}",
-                    created_by_uuid=payload.completed_by_uuid,
-                    workflow_uuid = None, #task_exe.workflow_execution.workflow_uuid,
-                    parent_task_uuid= None, #self.get_trip_operator_task_uuid(),
-                    operator= OperatorType.TRIP_STOP_OPERATOR.value,
-                    task_inputs =task_input,
-                    depends_on = [], #if not created_task_names else [created_task_names[-1]],
-                    callback_fns = [],
-                )
-            )
-
             depends_on = [self.get_trip_operator_task_execution_name()] if not created_task_names else [created_task_names[-1]]
-            task_execution = TaskExecutionDomain.create_task_execution(
+            task_create, _ = create_trip_stop_with_task(
                 uow=uow,
-                payload=TaskExecutionCreate(
-                    status = WorkflowStatus.NOT_STARTED.value if depends_on else WorkflowStatus.IN_PROGRESS.value,
-                    depends_on=depends_on,
-                    start_time=datetime.now() if not depends_on else None,
-                    task_uuid=task_create.uuid,
-                    workflow_execution_uuid=task_exe.workflow_execution.uuid,
-                    created_by_uuid=payload.completed_by_uuid,
-                    parent_task_execution_uuid= self.get_trip_operator_task_execution_uuid()
-
-                ))
-
-            trip_stop_model  = uow.trip_stop_repository.find_one(uuid=trip_stop.uuid)
-            trip_stop_model.task_execution_uuid = task_execution.uuid
-            uow.trip_stop_repository.save(trip_stop_model, commit=False)
+                workflow_execution=task_exe.workflow_execution,
+                customer=customer,
+                created_by_uuid=payload.completed_by_uuid,
+                index=i,
+                depends_on=depends_on,
+                parent_task_execution_uuid=self.get_trip_operator_task_execution_uuid(),
+            )
             created_task_names.append(task_create.name)
 
+        # explicit finish-trip step: snapshots end inventory + completes the trip.
+        # It unblocks after the last routed stop (or right after the trip task in
+        # manual mode) and keeps the workflow open while ad-hoc stops are added.
+        finish_depends_on = [created_task_names[-1]] if created_task_names else [self.get_trip_operator_task_execution_name()]
+        create_finish_trip_task(
+            uow=uow,
+            workflow_execution=task_exe.workflow_execution,
+            created_by_uuid=payload.completed_by_uuid,
+            depends_on=finish_depends_on,
+            parent_task_execution_uuid=self.get_trip_operator_task_execution_uuid(),
+        )
 
         task_exe.result = operator_schema.model_dump(mode="json")
         task_exe.status = WorkflowStatus.COMPLETED.value
@@ -195,6 +289,12 @@ class CreateTripOperator(OperatorInterface):
         # name of class
         return self.__class__.__name__
 
+
+    def is_manual_stops(self) -> bool:
+        for task_exe in self.all_tasks_executions:
+            if task_exe.operator == OperatorType.START_TRIP_OPERATOR.value:
+                return bool(task_exe.result.get("manual_stops"))
+        return False
 
     def get_service_areas(self) -> list:
         """

--- a/backend/app/domains/task_execution/workflow_operators/create_trip_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/create_trip_operator.py
@@ -97,6 +97,12 @@ class CreateTripOperator(OperatorInterface):
                                    workflow_execution_uuid=task_exe.workflow_execution.uuid,
                                ))
 
+        # snapshot the vehicle's per-material inventory at trip start
+        from app.domains.vehicle_inventory.domain import VehicleInventoryDomain
+        trip = task_exe.workflow_execution.trips[0]
+        trip.start_inventory = VehicleInventoryDomain.balances_for_vehicle(uow=uow, vehicle_uuid=vehicle.uuid)
+        uow.trip_repository.save(model=trip, commit=False)
+
         # create trip stops
         created_task_names = []
         for i,customer_uuid in enumerate(self.get_customer_uuids()):
@@ -130,24 +136,6 @@ class CreateTripOperator(OperatorInterface):
                         type=FieldType.SELECT,
                         required=True,
                         options=[outcome.value for outcome in TripStopOutcome]
-                    ),
-                    TaskInputField(
-                        name = "kg large extra bags -   كبيرة أكسترا كيلو",
-                        label="mixed_large_extra",
-                        type=FieldType.NUMBER,
-                        required=False,
-                    ),
-                    TaskInputField(
-                        name = "kg large bags -  كبيرة كيلو",
-                        label="mixed_large",
-                        type=FieldType.NUMBER,
-                        required=False,
-                    ),
-                    TaskInputField(
-                        name = "kg small -  صغيرة كيلو",
-                        label="mixed_small",
-                        type=FieldType.NUMBER,
-                        required=False,
                     ),
                     TaskInputField(
                         name = "notes - ملاحظات",

--- a/backend/app/domains/task_execution/workflow_operators/operator_entry_point.py
+++ b/backend/app/domains/task_execution/workflow_operators/operator_entry_point.py
@@ -13,6 +13,7 @@ from app.domains.task_execution.workflow_operators.trip_route_operator import Tr
 from app.domains.task_execution.workflow_operators.create_trip_operator import CreateTripOperator
 from app.domains.task_execution.workflow_operators.trip_operator import TripOperator
 from app.domains.task_execution.workflow_operators.trip_stop_operator import TripStopOperator
+from app.domains.task_execution.workflow_operators.trip_finish_operator import TripFinishOperator
 
 
 class OperatorEntryPoint:
@@ -33,7 +34,8 @@ class OperatorEntryPoint:
                 OperatorType.TRIP_ROUTE_OPERATOR: TripRouteOperator(),
                 OperatorType.TRIP_CREATE_OPERATOR: CreateTripOperator(),
                 OperatorType.TRIP_OPERATOR: TripOperator(),  # Assuming TripOperator is similar to CreateTripOperator
-                OperatorType.TRIP_STOP_OPERATOR: TripStopOperator()
+                OperatorType.TRIP_STOP_OPERATOR: TripStopOperator(),
+                OperatorType.TRIP_FINISH_OPERATOR: TripFinishOperator()
             }
 
 

--- a/backend/app/domains/task_execution/workflow_operators/start_trip_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/start_trip_operator.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from app.domains.task_execution.workflow_operators.operator_interface import OperatorInterface
 from app.dto.task_execution import TaskExecutionComplete
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from app.entrypoint.routes.common.errors import BadRequestError
 from app.dto.workflow_execution import (
     WorkflowStatus
@@ -17,17 +17,44 @@ from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWo
 class StartTripOperatorSchema(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    service_areas: list[str]
-    start_warehouse_name: str
-    end_warehouse_name: str
+    # manual mode: the driver adds stops ad hoc during the trip; only the
+    # vehicle and assigned user are needed (routing inputs are skipped)
+    manual_stops: Optional[bool] = False
+    service_areas: Optional[list[str]] = None
+    start_warehouse_name: Optional[str] = None
+    end_warehouse_name: Optional[str] = None
     vehicle_plate: str
-    last_visit_threshold_days:int
+    last_visit_threshold_days: Optional[int] = None
     start_point: Optional[str] = None
     end_point: Optional[str] = None
     assigned_user_uuid: Optional[str] = None
     customer_categories: Optional[list[str]] = None
     max_stops: Optional[int] = None
     min_stops: Optional[int] = None
+
+    @field_validator("manual_stops", mode="before")
+    def coerce_manual_stops(cls, v):
+        # the form may send a checklist (list of picked options) or a string
+        if isinstance(v, list):
+            return len(v) > 0
+        if isinstance(v, str):
+            return v.strip().lower() in ("yes", "true", "1", "enabled")
+        return bool(v)
+
+    @model_validator(mode="after")
+    def check_required_by_mode(self):
+        if self.manual_stops:
+            if not self.assigned_user_uuid:
+                raise BadRequestError("assigned_user_uuid is required when manual_stops is enabled")
+        else:
+            missing = [
+                name for name in
+                ("service_areas", "start_warehouse_name", "end_warehouse_name", "last_visit_threshold_days")
+                if not getattr(self, name)
+            ]
+            if missing:
+                raise BadRequestError(f"Missing required fields for routed trip: {', '.join(missing)}")
+        return self
 
 
 class StartTripOperator(OperatorInterface):

--- a/backend/app/domains/task_execution/workflow_operators/trip_finish_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/trip_finish_operator.py
@@ -54,6 +54,10 @@ class TripFinishOperator(OperatorInterface):
             "inventory_left": [inv.model_dump(mode="json") for inv in operator_schema.inventory_left]
         }
 
+        # snapshot the vehicle's per-material inventory at trip end
+        from app.domains.vehicle_inventory.domain import VehicleInventoryDomain
+        trip.end_inventory = VehicleInventoryDomain.balances_for_vehicle(uow=uow, vehicle_uuid=trip.vehicle_uuid)
+
         trip.status = TripStatus.COMPLETED.value
         task_exe.result = operator_schema.model_dump(mode="json")
         task_exe.status = WorkflowStatus.COMPLETED.value

--- a/backend/app/domains/task_execution/workflow_operators/trip_finish_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/trip_finish_operator.py
@@ -4,8 +4,8 @@ from datetime import datetime
 from typing import Optional
 
 from app.domains.task_execution.workflow_operators.operator_interface import OperatorInterface
-from app.dto.task_execution import TaskExecutionComplete
-from pydantic import BaseModel, ConfigDict, model_validator
+from app.dto.task_execution import OperatorType, TaskExecutionComplete
+from pydantic import BaseModel, ConfigDict
 from app.entrypoint.routes.common.errors import BadRequestError
 from app.dto.workflow_execution import (
     WorkflowStatus
@@ -13,18 +13,14 @@ from app.dto.workflow_execution import (
 
 from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 
-from app.dto.common_enums import Currency
 from app.dto.trip import TripStatus
-
-class InventoryLeftInput(BaseModel):
-    inventory_uuid:str
-    quantity: float
 
 
 class TripFinishOperatorSchema(BaseModel):
+    """Cash and inventory are derived automatically (payments / vehicle events
+    tagged to the trip's stops), so finishing only takes optional notes."""
     model_config = ConfigDict(extra="forbid")
-    cash_collected: float
-    inventory_left: list[InventoryLeftInput]
+    notes: Optional[str] = None
 
 
 class TripFinishOperator(OperatorInterface):
@@ -35,7 +31,7 @@ class TripFinishOperator(OperatorInterface):
                 *args, **kwargs):
 
         # load the operator schema
-        operator_schema = TripFinishOperatorSchema(**payload.result)
+        operator_schema = TripFinishOperatorSchema(**(payload.result or {}))
         task_exe = uow.task_execution_repository.find_one(uuid=payload.uuid)
         if not task_exe:
             raise BadRequestError(f"TaskExecution not found with uuid: {payload.uuid}")
@@ -46,19 +42,28 @@ class TripFinishOperator(OperatorInterface):
         if not trip:
             raise BadRequestError(f"Trip not found for TaskExecution with uuid: {payload.uuid}")
 
-        # set data["output"]
+        # all stops must be resolved before the trip can be finished
+        open_stops = [
+            te for te in task_exe.workflow_execution.task_executions
+            if te.operator == OperatorType.TRIP_STOP_OPERATOR.value
+            and te.status in (WorkflowStatus.NOT_STARTED.value, WorkflowStatus.IN_PROGRESS.value)
+        ]
+        if open_stops:
+            raise BadRequestError(
+                f"Cannot finish the trip: {len(open_stops)} trip stop(s) still open"
+            )
 
-        trip.data["output"] = {
-            "cash_collected": operator_schema.cash_collected,
-            "currency": Currency.SYP.value,
-            "inventory_left": [inv.model_dump(mode="json") for inv in operator_schema.inventory_left]
-        }
+        if operator_schema.notes:
+            trip.notes = (f"{trip.notes}\n" if trip.notes else "") + operator_schema.notes
 
         # snapshot the vehicle's per-material inventory at trip end
         from app.domains.vehicle_inventory.domain import VehicleInventoryDomain
         trip.end_inventory = VehicleInventoryDomain.balances_for_vehicle(uow=uow, vehicle_uuid=trip.vehicle_uuid)
 
         trip.status = TripStatus.COMPLETED.value
+        trip.end_time = datetime.now()
+        uow.trip_repository.save(model=trip, commit=False)
+
         task_exe.result = operator_schema.model_dump(mode="json")
         task_exe.status = WorkflowStatus.COMPLETED.value
         task_exe.end_time = datetime.now()
@@ -77,9 +82,5 @@ class TripFinishOperator(OperatorInterface):
 
 
     def get_trip(self):
-       trip = self.task_exe.workflow_execution.trip
-
-       return trip
-
-
-
+        trips = self.task_exe.workflow_execution.trips
+        return trips[0] if trips else None

--- a/backend/app/domains/task_execution/workflow_operators/trip_route_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/trip_route_operator.py
@@ -44,6 +44,18 @@ class TripRouteOperator(OperatorInterface):
         self.task_exe = task_exe
         self.all_tasks_executions = task_exe.workflow_execution.task_executions
 
+        # manual-stops mode: the driver adds stops ad hoc, no routing to compute
+        if self.is_manual_stops():
+            operator_schema.customer_uuids = []
+            operator_schema.waypoints = []
+            operator_schema.route_coordinates = []
+            task_exe.result = operator_schema.model_dump(mode="json")
+            task_exe.status = WorkflowStatus.COMPLETED.value
+            task_exe.end_time = datetime.now()
+            task_exe.completed_by_uuid = payload.completed_by_uuid
+            uow.task_execution_repository.save(task_exe, commit=False)
+            return
+
         service_area_names = self.get_service_areas()
         # name is in service_area names
 
@@ -106,6 +118,12 @@ class TripRouteOperator(OperatorInterface):
         # name of class
         return self.__class__.__name__
 
+
+    def is_manual_stops(self) -> bool:
+        for task_exe in self.all_tasks_executions:
+            if task_exe.operator == OperatorType.START_TRIP_OPERATOR.value:
+                return bool(task_exe.result.get("manual_stops"))
+        return False
 
     def get_service_areas(self) -> str:
         """

--- a/backend/app/domains/vehicle_inventory/domain.py
+++ b/backend/app/domains/vehicle_inventory/domain.py
@@ -33,6 +33,65 @@ class VehicleInventoryDomain:
         return VehicleInventoryRead.from_orm(inventory)
 
     @staticmethod
+    def get_or_create_inventory(
+        uow: SqlAlchemyUnitOfWork,
+        vehicle_uuid: str,
+        material_uuid: str,
+        created_by_uuid: str = None,
+    ) -> VehicleInventoryModel:
+        """Return the active (vehicle, material) inventory row, creating it if absent."""
+        inv = uow.vehicle_inventory_repository.find_first(
+            vehicle_uuid=vehicle_uuid, material_uuid=material_uuid, is_deleted=False
+        )
+        if inv:
+            return inv
+        material = uow.material_repository.find_one(uuid=material_uuid, is_deleted=False)
+        inv = VehicleInventoryModel(
+            vehicle_uuid=vehicle_uuid,
+            material_uuid=material_uuid,
+            created_by_uuid=created_by_uuid,
+            unit=material.measure_unit if material else None,
+            is_active=True,
+        )
+        uow.vehicle_inventory_repository.save(model=inv, commit=False)
+        return inv
+
+    @staticmethod
+    def balances_for_vehicle(uow: SqlAlchemyUnitOfWork, vehicle_uuid: str) -> dict:
+        """Snapshot of the vehicle's current per-material balances ({material_uuid: qty})."""
+        rows = uow.vehicle_inventory_repository.find_all(vehicle_uuid=vehicle_uuid, is_deleted=False)
+        return {r.material_uuid: r.current_quantity for r in rows}
+
+    @staticmethod
+    def record_trip_sale(
+        uow: SqlAlchemyUnitOfWork,
+        vehicle_uuid: str,
+        material_uuid: str,
+        quantity: float,
+        customer_order_item_uuid: str,
+        created_by_uuid: str = None,
+    ):
+        """Decrement the vehicle's stock of a material for a fulfilled trip-stop order item.
+        Auto-creates the inventory row if missing and may push the balance negative."""
+        from app.domains.vehicle_inventory_event.domain import VehicleInventoryEventDomain
+        from app.dto.vehicle_inventory_event import VehicleInventoryEventCreate, VehicleInventoryEventType
+
+        inv = VehicleInventoryDomain.get_or_create_inventory(
+            uow=uow, vehicle_uuid=vehicle_uuid, material_uuid=material_uuid, created_by_uuid=created_by_uuid
+        )
+        return VehicleInventoryEventDomain.create_event(
+            uow=uow,
+            payload=VehicleInventoryEventCreate(
+                vehicle_inventory_uuid=inv.uuid,
+                event_type=VehicleInventoryEventType.SALE,
+                quantity=abs(quantity),
+                customer_order_item_uuid=customer_order_item_uuid,
+                created_by_uuid=created_by_uuid,
+            ),
+            allow_negative=True,
+        )
+
+    @staticmethod
     def delete_vehicle_inventory(uow: SqlAlchemyUnitOfWork, uuid: str) -> VehicleInventoryRead:
         inventory = uow.vehicle_inventory_repository.find_one(uuid=uuid, is_deleted=False)
         if not inventory:

--- a/backend/app/domains/vehicle_inventory/domain.py
+++ b/backend/app/domains/vehicle_inventory/domain.py
@@ -70,6 +70,7 @@ class VehicleInventoryDomain:
         quantity: float,
         customer_order_item_uuid: str,
         created_by_uuid: str = None,
+        trip_stop_uuid: str = None,
     ):
         """Decrement the vehicle's stock of a material for a fulfilled trip-stop order item.
         Auto-creates the inventory row if missing and may push the balance negative."""
@@ -87,6 +88,7 @@ class VehicleInventoryDomain:
                 quantity=abs(quantity),
                 customer_order_item_uuid=customer_order_item_uuid,
                 created_by_uuid=created_by_uuid,
+                trip_stop_uuid=trip_stop_uuid,
             ),
             allow_negative=True,
         )

--- a/backend/app/domains/vehicle_inventory_event/domain.py
+++ b/backend/app/domains/vehicle_inventory_event/domain.py
@@ -15,13 +15,17 @@ class VehicleInventoryEventDomain:
         """Convert the user-entered magnitude into the signed delta to store."""
         if event_type == VehicleInventoryEventType.MANUAL:
             return abs(quantity)
-        if event_type == VehicleInventoryEventType.UNLOAD:
+        if event_type in (VehicleInventoryEventType.UNLOAD, VehicleInventoryEventType.SALE):
             return -abs(quantity)
         # adjustment: signed as given
         return quantity
 
     @staticmethod
-    def create_event(uow: SqlAlchemyUnitOfWork, payload: VehicleInventoryEventCreate) -> VehicleInventoryEventRead:
+    def create_event(
+        uow: SqlAlchemyUnitOfWork,
+        payload: VehicleInventoryEventCreate,
+        allow_negative: bool = False,
+    ) -> VehicleInventoryEventRead:
         inventory = uow.vehicle_inventory_repository.find_one(
             uuid=payload.vehicle_inventory_uuid, is_deleted=False
         )
@@ -30,8 +34,8 @@ class VehicleInventoryEventDomain:
 
         delta = VehicleInventoryEventDomain._signed_delta(payload.event_type, payload.quantity)
 
-        # never allow a vehicle's stock to go negative
-        if inventory.current_quantity + delta < 0:
+        # by default a vehicle's stock cannot go negative; trip sales may override
+        if not allow_negative and inventory.current_quantity + delta < 0:
             raise BadRequestError(
                 f"Insufficient vehicle stock: balance {inventory.current_quantity}, "
                 f"requested change {delta}"

--- a/backend/app/dto/customer_order.py
+++ b/backend/app/dto/customer_order.py
@@ -1,7 +1,10 @@
 # app/dto/customer_order.py
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing import Optional, List
 from datetime import datetime
+
+from app.dto.payment import PaymentMethod
+from app.entrypoint.routes.common.errors import BadRequestError
 
 from app.dto.customer_order_item import CustomerOrderItemCreate
 from app.dto.invoice import InvoiceCreate
@@ -147,3 +150,39 @@ class CustomerOrderWithItemsAndInvoiceRead(BaseModel):
         )
 
 
+
+
+class CustomerOrderCheckoutCreate(BaseModel):
+    """Create an order with items + invoice and, in one submit, optionally
+    fulfill all items and record a full payment against the invoice."""
+    model_config = ConfigDict(extra="forbid")
+    created_by_uuid: Optional[str] = None
+    customer_uuid: str
+    currency: Currency
+    trip_stop_uuid: Optional[str] = None
+    notes: Optional[str] = None
+    due_date: Optional[datetime] = None
+    items: List[CustomerOrderAndInvoiceItemCreate]
+    fulfill: bool = True
+    pay: bool = True
+    financial_account_uuid: Optional[str] = None
+    payment_method: Optional[PaymentMethod] = None
+
+    @model_validator(mode="after")
+    def _check_pay(self):
+        if not self.items:
+            raise BadRequestError("At least one item is required")
+        if self.pay and not self.payment_method:
+            raise BadRequestError("payment_method is required when pay=true")
+        return self
+
+    def to_base_create(self) -> "CustomerOrderWithItemsAndInvoiceCreate":
+        return CustomerOrderWithItemsAndInvoiceCreate(
+            created_by_uuid=self.created_by_uuid,
+            customer_uuid=self.customer_uuid,
+            currency=self.currency,
+            trip_stop_uuid=self.trip_stop_uuid,
+            notes=self.notes,
+            due_date=self.due_date,
+            items=self.items,
+        )

--- a/backend/app/dto/customer_order_item.py
+++ b/backend/app/dto/customer_order_item.py
@@ -50,6 +50,10 @@ class CustomerOrderItemBulkFulfill(BaseModel):
     """Schema for bulk fulfilling customer order items by UUID."""
     model_config = ConfigDict(extra="forbid")
     items: List[FulfillItem]
+    # current trip stop where fulfillment happens; attributes the vehicle sale to
+    # this stop's trip (overriding the order's own stop, e.g. previously-created
+    # orders handed off during a trip). Falls back to the order's stop if unset.
+    trip_stop_uuid: Optional[str] = None
 
 class CustomerOrderItemBulkUnFulfill(BaseModel):
     """Schema for bulk unfulfilling customer order items by UUID."""

--- a/backend/app/dto/payment.py
+++ b/backend/app/dto/payment.py
@@ -22,6 +22,7 @@ class PaymentBase(BaseModel):
     payment_method: PaymentMethod
     notes: Optional[str] = None
     debit_note_item_uuid: Optional[str] = None
+    trip_stop_uuid: Optional[str] = None  # set when cash is collected during a trip
 
     # validate invoice uuid or debit note item uuid must exist but not both
     @model_validator(mode="after")

--- a/backend/app/dto/task_execution.py
+++ b/backend/app/dto/task_execution.py
@@ -17,6 +17,7 @@ class OperatorType(str, Enum):
     TRIP_ADD_INVENTORY_OPERATOR = "trip_add_inventory_operator"
     TRIP_ROUTE_OPERATOR = "trip_route_operator"
     TRIP_CREATE_OPERATOR = "trip_create_operator"
+    TRIP_FINISH_OPERATOR = "trip_finish_operator"
 
 
 # Base DTO for TaskExecution
@@ -61,6 +62,7 @@ class TaskExecutionRead(TaskExecutionBase):
     created_at: datetime  # Time when the task execution was created
     parent_task_execution_uuid: Optional[str] = None  # Parent task execution str if this is a child task
     name: Optional[str] = None  # Name of the task execution, if applicable
+    operator: Optional[str] = None  # Operator of the underlying task
     result : Optional[Dict[str, Any]] = Field(default_factory=dict)  # Ensure result is always a dict
 
 

--- a/backend/app/dto/trip.py
+++ b/backend/app/dto/trip.py
@@ -184,6 +184,7 @@ class TripRead(BaseModel):
     start_inventory: Optional[dict] = None
     end_inventory: Optional[dict] = None
     inventory_reconciliation: Optional[dict] = None
+    expected_cash: Optional[dict] = None  # {currency: amount} collected at this trip's stops
 
     @field_validator("distribution_area", "start_point", "end_point", mode="before")
     def _ensure_wkt(cls, v):

--- a/backend/app/dto/trip.py
+++ b/backend/app/dto/trip.py
@@ -181,6 +181,9 @@ class TripRead(BaseModel):
     end_point: Optional[str] = None
     data: Optional[dict] = None
     workflow_execution_uuid: Optional[str] = None
+    start_inventory: Optional[dict] = None
+    end_inventory: Optional[dict] = None
+    inventory_reconciliation: Optional[dict] = None
 
     @field_validator("distribution_area", "start_point", "end_point", mode="before")
     def _ensure_wkt(cls, v):

--- a/backend/app/dto/trip_stop.py
+++ b/backend/app/dto/trip_stop.py
@@ -61,6 +61,24 @@ class TripStopCreate(BaseModel):
         return lat_lon_to_wkt(coords=v)  # This will raise BadRequestError if invalid
 
 
+class ManualStopCreate(BaseModel):
+    """Ad-hoc stop added by the driver mid-trip: either an existing customer
+    or a brand-new one created on the spot."""
+    model_config = ConfigDict(extra="forbid")
+
+    customer_uuid: Optional[str] = None
+    customer: Optional[dict] = None  # CustomerCreate fields for a new customer
+    # "lat,lon" fallback used when the customer has no stored coordinates
+    # (e.g. device geolocation at the shop)
+    coordinates: Optional[str] = None
+
+    @model_validator(mode="after")
+    def check_exclusive(self):
+        if bool(self.customer_uuid) == bool(self.customer):
+            raise BadRequestError("Set exactly one of `customer_uuid` or `customer`.")
+        return self
+
+
 class TripStopUpdate(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/app/dto/vehicle_inventory_event.py
+++ b/backend/app/dto/vehicle_inventory_event.py
@@ -11,6 +11,7 @@ class VehicleInventoryEventType(str, Enum):
     MANUAL = "manual"          # add stock to the vehicle (+)
     ADJUSTMENT = "adjustment"  # correct stock up or down (+/-)
     UNLOAD = "unload"          # remove stock from the vehicle (-)
+    SALE = "sale"              # sold off the vehicle during a trip (-), system-generated
 
 
 class VehicleInventoryEventCreate(BaseModel):
@@ -30,12 +31,19 @@ class VehicleInventoryEventCreate(BaseModel):
     cost_per_unit: Optional[float] = None
     currency: Optional[Currency] = None
     notes: Optional[str] = None
+    # set for system-generated 'sale' events tied to a fulfilled trip-stop order item
+    customer_order_item_uuid: Optional[str] = None
 
     @model_validator(mode="after")
     def check_quantity(self):
         if self.quantity == 0:
             raise BadRequestError("quantity must be non-zero")
-        if self.event_type in (VehicleInventoryEventType.MANUAL, VehicleInventoryEventType.UNLOAD) and self.quantity <= 0:
+        positive_types = (
+            VehicleInventoryEventType.MANUAL,
+            VehicleInventoryEventType.UNLOAD,
+            VehicleInventoryEventType.SALE,
+        )
+        if self.event_type in positive_types and self.quantity <= 0:
             raise BadRequestError(f"quantity must be positive for event_type '{self.event_type.value}'")
         return self
 
@@ -51,6 +59,7 @@ class VehicleInventoryEventRead(BaseModel):
     cost_per_unit: Optional[float] = None
     currency: Optional[str] = None
     notes: Optional[str] = None
+    customer_order_item_uuid: Optional[str] = None
     is_deleted: bool
     created_at: datetime
 

--- a/backend/app/dto/vehicle_inventory_event.py
+++ b/backend/app/dto/vehicle_inventory_event.py
@@ -33,6 +33,8 @@ class VehicleInventoryEventCreate(BaseModel):
     notes: Optional[str] = None
     # set for system-generated 'sale' events tied to a fulfilled trip-stop order item
     customer_order_item_uuid: Optional[str] = None
+    # trip stop where the stock left the truck (attributes the sale to a trip)
+    trip_stop_uuid: Optional[str] = None
 
     @model_validator(mode="after")
     def check_quantity(self):
@@ -60,6 +62,7 @@ class VehicleInventoryEventRead(BaseModel):
     currency: Optional[str] = None
     notes: Optional[str] = None
     customer_order_item_uuid: Optional[str] = None
+    trip_stop_uuid: Optional[str] = None
     is_deleted: bool
     created_at: datetime
 

--- a/backend/app/entrypoint/routes/customer_order/routes.py
+++ b/backend/app/entrypoint/routes/customer_order/routes.py
@@ -13,6 +13,7 @@ from models.common import CustomerOrder as CustomerOrderModel
 from app.entrypoint.routes.customer_order import customer_order_blueprint
 from app.domains.customer_order.domain import CustomerOrderDomain
 from app.dto.customer_order import CustomerOrderWithItemsAndInvoiceCreate
+from app.dto.customer_order import CustomerOrderCheckoutCreate
 from app.dto.customer_order import CustomerOrderWithItemsAndInvoiceRead
 
 from app.dto.customer_order_item import CustomerOrderItemBulkRead, CustomerOrderItemRead
@@ -35,6 +36,23 @@ def create_customer_order_with_items_and_invoice():
     with SqlAlchemyUnitOfWork() as uow:
         add_logged_user_to_payload(uow=uow, user_uuid=current_uuid, payload=payload)
         full_read = CustomerOrderDomain.create_customer_order_with_items_and_invoice(uow=uow, payload=payload)
+        result = full_read.model_dump(mode="json")
+        uow.commit()
+    return jsonify(result), 201
+
+
+@customer_order_blueprint.route("/with-items-and-invoice/checkout", methods=["POST"])
+@jwt_required()
+@scopes_required(PermissionScope.ADMIN.value,
+                 PermissionScope.SUPER_ADMIN.value,
+                 PermissionScope.SALES.value)
+def create_customer_order_checkout():
+    """Create order + items + invoice, optionally fulfill + pay, in one submit."""
+    current_uuid = get_jwt_identity()
+    payload = CustomerOrderCheckoutCreate(**request.json)
+    with SqlAlchemyUnitOfWork() as uow:
+        add_logged_user_to_payload(uow=uow, user_uuid=current_uuid, payload=payload)
+        full_read = CustomerOrderDomain.create_order_checkout(uow=uow, payload=payload)
         result = full_read.model_dump(mode="json")
         uow.commit()
     return jsonify(result), 201

--- a/backend/app/entrypoint/routes/trip/routes.py
+++ b/backend/app/entrypoint/routes/trip/routes.py
@@ -58,6 +58,83 @@ def get_trip(uuid: str):
     return jsonify(dto), 200
 #
 #
+@trip_blueprint.route("/<string:uuid>/activity", methods=["GET"])
+@jwt_required()
+@scopes_required(
+    PermissionScope.ADMIN.value,
+    PermissionScope.SUPER_ADMIN.value,
+    PermissionScope.OPERATOR.value,
+    PermissionScope.OPERATION_MANAGER.value,
+    PermissionScope.DRIVER.value,
+    PermissionScope.SALES.value,
+)
+def get_trip_activity(uuid: str):
+    """Orders, fulfillments (vehicle sales) and payments at this trip's stops."""
+    with SqlAlchemyUnitOfWork() as uow:
+        trip = uow.trip_repository.find_one(uuid=uuid)
+        if not trip:
+            raise NotFoundError("Trip not found")
+
+        def customer_name(customer):
+            if not customer:
+                return None
+            return customer.company_name or customer.full_name
+
+        material_names: dict = {}
+        def material_name(material_uuid):
+            if material_uuid not in material_names:
+                mat = uow.material_repository.find_one(uuid=material_uuid)
+                material_names[material_uuid] = mat.name if mat else material_uuid
+            return material_names[material_uuid]
+
+        orders, fulfillments, payments = [], [], []
+        for stop in trip.stops:
+            for o in stop.customer_orders:
+                if o.is_deleted:
+                    continue
+                orders.append({
+                    "uuid": o.uuid,
+                    "created_at": o.created_at.isoformat() if o.created_at else None,
+                    "customer_name": customer_name(o.customer),
+                    "total": o.total_adjusted_amount,
+                    "currency": o.currency,
+                    "is_paid": o.is_paid,
+                    "is_fulfilled": o.is_fulfilled,
+                })
+            for ev in stop.vehicle_inventory_events:
+                if ev.is_deleted or ev.event_type != "sale":
+                    continue
+                item = ev.customer_order_item
+                order = item.customer_order if item else None
+                fulfillments.append({
+                    "created_at": ev.created_at.isoformat() if ev.created_at else None,
+                    "material_name": material_name(ev.material_uuid),
+                    "quantity": -ev.quantity,  # stored as negative delta; report as positive
+                    "customer_name": customer_name(order.customer) if order else None,
+                    "customer_order_uuid": order.uuid if order else None,
+                })
+            for p in stop.payments:
+                if p.is_deleted:
+                    continue
+                inv = p.invoice
+                order = inv.customer_order if inv else None
+                payments.append({
+                    "created_at": p.created_at.isoformat() if p.created_at else None,
+                    "amount": p.amount,
+                    "currency": p.currency,
+                    "customer_name": customer_name(order.customer) if order else None,
+                    "customer_order_uuid": order.uuid if order else None,
+                })
+
+        newest_first = lambda rows: sorted(rows, key=lambda r: r["created_at"] or "", reverse=True)
+        result = {
+            "orders": newest_first(orders),
+            "fulfillments": newest_first(fulfillments),
+            "payments": newest_first(payments),
+        }
+    return jsonify(result), 200
+#
+#
 @trip_blueprint.route("/<string:uuid>", methods=["PUT"])
 @jwt_required()
 @scopes_required(

--- a/backend/app/entrypoint/routes/trip/routes.py
+++ b/backend/app/entrypoint/routes/trip/routes.py
@@ -69,7 +69,9 @@ def get_trip(uuid: str):
     PermissionScope.SALES.value,
 )
 def get_trip_activity(uuid: str):
-    """Orders, fulfillments (vehicle sales) and payments at this trip's stops."""
+    """Stops, orders, fulfillments (vehicle sales) and payments at this trip's stops."""
+    from app.utils.geom_utils import wkt_or_wkb_to_lat_lon
+
     with SqlAlchemyUnitOfWork() as uow:
         trip = uow.trip_repository.find_one(uuid=uuid)
         if not trip:
@@ -86,6 +88,29 @@ def get_trip_activity(uuid: str):
                 mat = uow.material_repository.find_one(uuid=material_uuid)
                 material_names[material_uuid] = mat.name if mat else material_uuid
             return material_names[material_uuid]
+
+        stops = []
+        for stop in trip.stops:
+            task_exe = (
+                uow.task_execution_repository.find_one(uuid=stop.task_execution_uuid)
+                if stop.task_execution_uuid else None
+            )
+            try:
+                latlon = wkt_or_wkb_to_lat_lon(stop.coordinates)
+            except Exception:
+                latlon = None
+            stops.append({
+                "uuid": stop.uuid,
+                "index": stop.index,
+                "customer_uuid": stop.customer_uuid,
+                "customer_name": customer_name(stop.customer),
+                "status": task_exe.status if task_exe else stop.status,
+                "outcome": stop.outcome,
+                "coordinates": latlon,  # "lat,lon"
+                "created_at": stop.created_at.isoformat() if stop.created_at else None,
+                "completed_at": task_exe.end_time.isoformat() if task_exe and task_exe.end_time else None,
+            })
+        stops.sort(key=lambda s: (s["index"] is None, s["index"], s["created_at"] or ""))
 
         orders, fulfillments, payments = [], [], []
         for stop in trip.stops:
@@ -128,6 +153,7 @@ def get_trip_activity(uuid: str):
 
         newest_first = lambda rows: sorted(rows, key=lambda r: r["created_at"] or "", reverse=True)
         result = {
+            "stops": stops,
             "orders": newest_first(orders),
             "fulfillments": newest_first(fulfillments),
             "payments": newest_first(payments),

--- a/backend/app/entrypoint/routes/workflow_execution/routes.py
+++ b/backend/app/entrypoint/routes/workflow_execution/routes.py
@@ -69,6 +69,126 @@ def get_workflow_execution(uuid: str):
         dto = WorkflowExecutionRead.from_orm(workflow_exe).model_dump(mode="json")
     return jsonify(dto), 200
 
+
+@workflow_execution_blueprint.route("/<string:uuid>/manual-stop", methods=["POST"])
+@jwt_required()
+@scopes_required(
+    PermissionScope.ADMIN.value,
+    PermissionScope.SUPER_ADMIN.value,
+    PermissionScope.OPERATION_MANAGER.value,
+    PermissionScope.OPERATOR.value,
+    PermissionScope.DRIVER.value,
+    PermissionScope.SALES.value)
+def add_manual_stop(uuid: str):
+    """Add an ad-hoc trip stop mid-trip: picks an existing customer or creates
+    a new one on the spot, then creates the stop + its trip_stop task."""
+    from datetime import datetime
+    from app.dto.trip_stop import ManualStopCreate
+    from app.dto.trip import TripStatus
+    from app.dto.task_execution import OperatorType
+    from app.dto.customer import CustomerCreate, CustomerRead
+    from models.common import Customer as CustomerModel
+    from app.utils.geom_utils import lat_lon_to_wkt
+    from app.domains.task_execution.workflow_operators.create_trip_operator import create_trip_stop_with_task
+
+    current_uuid = get_jwt_identity()
+    payload = ManualStopCreate(**request.json)
+    with SqlAlchemyUnitOfWork() as uow:
+        workflow_exe = uow.workflow_execution_repository.find_one(uuid=uuid)
+        if not workflow_exe:
+            raise NotFoundError(f"workflow_exe not found with uuid: {uuid}")
+        trips = workflow_exe.trips
+        if not trips:
+            raise BadRequestError("This workflow execution has no trip yet")
+        trip = trips[0]
+        if trip.status != TripStatus.IN_PROGRESS.value:
+            raise BadRequestError(f"Trip is not in progress (status: {trip.status})")
+
+        # resolve or create the customer
+        if payload.customer_uuid:
+            customer = uow.customer_repository.find_one(uuid=payload.customer_uuid, is_deleted=False)
+            if not customer:
+                raise NotFoundError("Customer not found")
+        else:
+            customer_create = CustomerCreate(**payload.customer)
+            customer_create.created_by_uuid = current_uuid
+            if customer_create.email_address and uow.customer_repository.find_one(email_address=customer_create.email_address):
+                raise BadRequestError(f"Customer with email {customer_create.email_address} already exists")
+            customer = CustomerModel(**customer_create.model_dump())
+            uow.customer_repository.save(model=customer, commit=False)
+
+        # the stop needs coordinates; backfill from the request (device location)
+        if customer.coordinates is None:
+            if not payload.coordinates:
+                raise BadRequestError("Customer has no coordinates; provide `coordinates` (lat,lon)")
+            customer.coordinates = lat_lon_to_wkt(coords=payload.coordinates)
+            uow.customer_repository.save(model=customer, commit=False)
+
+        # flush + refresh so coordinates round-trips to a geometry element
+        # (downstream code calls to_shape() on it)
+        uow.session.flush()
+        uow.session.refresh(customer)
+
+        existing_indexes = [s.index for s in trip.stops if s.index is not None]
+        next_index = (max(existing_indexes) + 1) if existing_indexes else 0
+
+        trip_op_exe = next(
+            (te for te in workflow_exe.task_executions if te.operator == OperatorType.TRIP_OPERATOR.value),
+            None,
+        )
+
+        # splice the new stop into the execution chain: it follows the latest
+        # finished chain task, and whatever previously followed that task is
+        # rewired to depend on the new stop — so the flow continues through it.
+        chain_ops = (OperatorType.TRIP_OPERATOR.value, OperatorType.TRIP_STOP_OPERATOR.value)
+        completed_chain = [
+            te for te in workflow_exe.task_executions
+            if te.operator in chain_ops and te.status == WorkflowStatus.COMPLETED.value
+        ]
+        anchor = (
+            max(completed_chain, key=lambda te: te.end_time or te.created_at)
+            if completed_chain else trip_op_exe
+        )
+        successors = [
+            te for te in workflow_exe.task_executions
+            if anchor is not None
+            and te.uuid != anchor.uuid
+            and te.depends_on and anchor.name in te.depends_on
+            and te.status in (WorkflowStatus.NOT_STARTED.value, WorkflowStatus.IN_PROGRESS.value)
+        ]
+
+        task_create, task_execution = create_trip_stop_with_task(
+            uow=uow,
+            workflow_execution=workflow_exe,
+            customer=customer,
+            created_by_uuid=current_uuid,
+            index=next_index,
+            depends_on=[anchor.name] if anchor is not None else [],
+            parent_task_execution_uuid=trip_op_exe.uuid if trip_op_exe else None,
+        )
+
+        # the new stop is current when its anchor is already done
+        new_exe_model = uow.task_execution_repository.find_one(uuid=task_execution.uuid)
+        if anchor is not None and anchor.status == WorkflowStatus.COMPLETED.value:
+            new_exe_model.status = WorkflowStatus.IN_PROGRESS.value
+            new_exe_model.start_time = datetime.now()
+            uow.task_execution_repository.save(model=new_exe_model, commit=False)
+
+        # re-point the old successors (next stop / finish_trip) at the new stop
+        for succ in successors:
+            succ.depends_on = [task_create.name]
+            if succ.status == WorkflowStatus.IN_PROGRESS.value:
+                succ.status = WorkflowStatus.NOT_STARTED.value
+                succ.start_time = None
+            uow.task_execution_repository.save(model=succ, commit=False)
+
+        uow.commit()
+        result = {
+            "task_execution_uuid": task_execution.uuid,
+            "customer": CustomerRead.from_orm(customer).model_dump(mode="json"),
+        }
+    return jsonify(result), 201
+
 # # Route to update a Workflow
 # @workflow_execution_blueprint.route("/<string:uuid>", methods=["PUT"])
 # @jwt_required()

--- a/backend/migrations/versions/c7e1a2b9f4d3_trip_inventory_snapshots.py
+++ b/backend/migrations/versions/c7e1a2b9f4d3_trip_inventory_snapshots.py
@@ -1,0 +1,44 @@
+"""trip inventory snapshots + link vehicle events to order items
+
+Revision ID: c7e1a2b9f4d3
+Revises: b1f3a7c9d2e4
+Create Date: 2026-06-30 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'c7e1a2b9f4d3'
+down_revision: Union[str, None] = 'b1f3a7c9d2e4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('trip', sa.Column('start_inventory', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('trip', sa.Column('end_inventory', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+    op.add_column(
+        'vehicle_inventory_event',
+        sa.Column('customer_order_item_uuid', sa.String(length=36), nullable=True),
+    )
+    op.create_foreign_key(
+        'fk_vehicle_inventory_event_coi',
+        'vehicle_inventory_event',
+        'customer_order_item',
+        ['customer_order_item_uuid'],
+        ['uuid'],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint('fk_vehicle_inventory_event_coi', 'vehicle_inventory_event', type_='foreignkey')
+    op.drop_column('vehicle_inventory_event', 'customer_order_item_uuid')
+    op.drop_column('trip', 'end_inventory')
+    op.drop_column('trip', 'start_inventory')

--- a/backend/migrations/versions/d8f2c1a4b6e5_payment_trip_stop.py
+++ b/backend/migrations/versions/d8f2c1a4b6e5_payment_trip_stop.py
@@ -1,0 +1,31 @@
+"""attribute payments to a trip stop (for trip expected_cash)
+
+Revision ID: d8f2c1a4b6e5
+Revises: c7e1a2b9f4d3
+Create Date: 2026-06-30 13:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'd8f2c1a4b6e5'
+down_revision: Union[str, None] = 'c7e1a2b9f4d3'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('payment', sa.Column('trip_stop_uuid', sa.String(length=36), nullable=True))
+    op.create_foreign_key('fk_payment_trip_stop', 'payment', 'trip_stop', ['trip_stop_uuid'], ['uuid'])
+    op.create_index('ix_payment_trip_stop_uuid', 'payment', ['trip_stop_uuid'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_payment_trip_stop_uuid', table_name='payment')
+    op.drop_constraint('fk_payment_trip_stop', 'payment', type_='foreignkey')
+    op.drop_column('payment', 'trip_stop_uuid')

--- a/backend/migrations/versions/e9a3b5c7d1f6_vehicle_event_trip_stop.py
+++ b/backend/migrations/versions/e9a3b5c7d1f6_vehicle_event_trip_stop.py
@@ -1,0 +1,31 @@
+"""attribute vehicle inventory sale events to a trip stop (for trip inventory reconciliation)
+
+Revision ID: e9a3b5c7d1f6
+Revises: d8f2c1a4b6e5
+Create Date: 2026-07-04
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'e9a3b5c7d1f6'
+down_revision = 'd8f2c1a4b6e5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('vehicle_inventory_event', sa.Column('trip_stop_uuid', sa.String(length=36), nullable=True))
+    op.create_foreign_key(
+        'fk_vehicle_inventory_event_trip_stop',
+        'vehicle_inventory_event', 'trip_stop',
+        ['trip_stop_uuid'], ['uuid'],
+    )
+    op.create_index('ix_vehicle_inventory_event_trip_stop_uuid', 'vehicle_inventory_event', ['trip_stop_uuid'])
+
+
+def downgrade():
+    op.drop_index('ix_vehicle_inventory_event_trip_stop_uuid', table_name='vehicle_inventory_event')
+    op.drop_constraint('fk_vehicle_inventory_event_trip_stop', 'vehicle_inventory_event', type_='foreignkey')
+    op.drop_column('vehicle_inventory_event', 'trip_stop_uuid')

--- a/backend/migrations/versions/f4b8d2e6a1c9_manual_stops_field.py
+++ b/backend/migrations/versions/f4b8d2e6a1c9_manual_stops_field.py
@@ -1,0 +1,93 @@
+"""add the manual_stops checkbox to start_trip task definitions and relax
+routing-field required flags (per-mode validation now lives in the backend
+StartTripOperatorSchema)
+
+Revision ID: f4b8d2e6a1c9
+Revises: e9a3b5c7d1f6
+Create Date: 2026-07-04
+
+"""
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'f4b8d2e6a1c9'
+down_revision = 'e9a3b5c7d1f6'
+branch_labels = None
+depends_on = None
+
+# fields the backend now requires conditionally (routed mode only)
+ROUTING_FIELDS = {
+    "service_areas", "start_warehouse_name", "end_warehouse_name",
+    "start_point", "end_point", "customer_categories",
+    "last_visit_threshold_days", "max_stops", "min_stops",
+}
+
+MANUAL_STOPS_FIELD = {
+    "name": "manual_stops", "label": "manual_stops", "type": "checklist",
+    "options": ["yes"], "required": False, "multiple": False,
+    "max": None, "min": None, "cols": None, "rows": None, "accept": None,
+    "max_length": None, "min_length": None, "button_text": None, "placeholder": None,
+}
+
+
+def _load(task_inputs):
+    if isinstance(task_inputs, str):
+        return json.loads(task_inputs)
+    return task_inputs or {}
+
+
+def upgrade():
+    conn = op.get_bind()
+    rows = conn.execute(sa.text(
+        "SELECT uuid, task_inputs FROM task "
+        "WHERE operator = 'start_trip_operator' AND is_deleted = false"
+    )).fetchall()
+
+    for task_uuid, task_inputs in rows:
+        ti = _load(task_inputs)
+        fields = ti.get("fields") or []
+        changed = False
+
+        if not any(f.get("name") == "manual_stops" for f in fields):
+            fields.insert(0, dict(MANUAL_STOPS_FIELD))
+            changed = True
+
+        for f in fields:
+            if f.get("name") in ROUTING_FIELDS and f.get("required"):
+                f["required"] = False
+                changed = True
+
+        if changed:
+            ti["fields"] = fields
+            conn.execute(
+                sa.text("UPDATE task SET task_inputs = (:ti)::jsonb WHERE uuid = :u"),
+                {"ti": json.dumps(ti), "u": task_uuid},
+            )
+
+
+def downgrade():
+    conn = op.get_bind()
+    rows = conn.execute(sa.text(
+        "SELECT uuid, task_inputs FROM task "
+        "WHERE operator = 'start_trip_operator' AND is_deleted = false"
+    )).fetchall()
+
+    # the originally-required routing fields (pre manual-stops)
+    previously_required = {
+        "service_areas", "start_warehouse_name", "end_warehouse_name",
+        "last_visit_threshold_days",
+    }
+    for task_uuid, task_inputs in rows:
+        ti = _load(task_inputs)
+        fields = [f for f in (ti.get("fields") or []) if f.get("name") != "manual_stops"]
+        for f in fields:
+            if f.get("name") in previously_required:
+                f["required"] = True
+        ti["fields"] = fields
+        conn.execute(
+            sa.text("UPDATE task SET task_inputs = (:ti)::jsonb WHERE uuid = :u"),
+            {"ti": json.dumps(ti), "u": task_uuid},
+        )

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -1884,6 +1884,9 @@ class Trip(Base):
     data = Column(MutableDict.as_mutable(JSONB), default=dict, nullable=True)
     workflow_execution_uuid = Column(String(36), ForeignKey("workflow_execution.uuid"), nullable=True)
     service_area_names = Column(ARRAY(String), nullable=True, default=list)
+    # snapshots of the vehicle's per-material inventory at trip start / end ({material_uuid: qty})
+    start_inventory = Column(MutableDict.as_mutable(JSONB), nullable=True)
+    end_inventory = Column(MutableDict.as_mutable(JSONB), nullable=True)
 
     # relations
     vehicle = relationship("Vehicle", back_populates="trips")
@@ -1898,44 +1901,52 @@ class Trip(Base):
             all_orders.extend(orders)
 
         # get amount paid
-        return sum(order.amount_paid for order in all_orders)
+        return sum(order.net_amount_paid for order in all_orders)
 
-    @hybrid_property
-    def expected_inventory_map(self):
-        trip_input_inventory = self.data.get("input_inventory")
-        if not trip_input_inventory:
-            return {}
+    @property
+    def sold_inventory_map(self):
+        """Quantity sold off the vehicle during the trip, per material.
 
-        # get customer order item fulfilled inventory and subtract quantity
-        all_orders = []
+        Derived from the vehicle 'sale' events created when trip-stop orders are
+        fulfilled (stored as negative deltas), returned here as positive amounts.
+        """
+        sold: dict[str, float] = {}
         for stop in self.stops:
-            orders = [order for order in stop.customer_orders if not order.is_deleted]
-            all_orders.extend(orders)
+            for order in stop.customer_orders:
+                if order.is_deleted:
+                    continue
+                for item in order.customer_order_items:
+                    if item.is_deleted or not item.is_fulfilled:
+                        continue
+                    for ev in item.vehicle_inventory_events:
+                        if ev.is_deleted or ev.event_type != "sale":
+                            continue
+                        sold[ev.material_uuid] = sold.get(ev.material_uuid, 0) - ev.quantity
+        return sold
 
-        all_fulfilled_order_items = []
-        for order in all_orders:
-            fulfilled_items = [item for item in order.customer_order_items if not item.is_deleted and item.is_fulfilled]
-            all_fulfilled_order_items.extend(fulfilled_items)
-
-        inventory_sale_mapper = {}
-        for item in all_fulfilled_order_items:
-            events = [event for event in item.inventory_events if not event.is_deleted and event.event_type == "sale"]
-            for event in events:
-                if event.inventory_uuid not in inventory_sale_mapper:
-                    inventory_sale_mapper[event.inventory_uuid] = {
-                        "quantity": 0
-                    }
-                inventory_sale_mapper[event.inventory_uuid]["quantity"] += event.quantity
-
-        # now add the quantity from the inventory_map
-        for inventory_uuid, inventory_data in trip_input_inventory.items():
-            if inventory_uuid not in inventory_sale_mapper:
-                inventory_sale_mapper[inventory_uuid] = {
-                    "quantity": 0
-                }
-            inventory_sale_mapper[inventory_uuid]["quantity"] += inventory_data["quantity"]
-
-        return inventory_sale_mapper
+    @property
+    def inventory_reconciliation(self):
+        """Per-material reconciliation of vehicle stock over the trip:
+        start snapshot, amount sold, expected end (= start - sold), actual end
+        snapshot, and the variance (actual - expected)."""
+        start = self.start_inventory or {}
+        end = self.end_inventory or {}
+        sold = self.sold_inventory_map
+        materials = set(start) | set(end) | set(sold)
+        result = {}
+        for m in materials:
+            s = start.get(m, 0) or 0
+            sld = sold.get(m, 0) or 0
+            expected_end = s - sld
+            actual_end = end.get(m)
+            result[m] = {
+                "start": s,
+                "sold": sld,
+                "expected_end": expected_end,
+                "actual_end": actual_end,
+                "variance": (actual_end - expected_end) if actual_end is not None else None,
+            }
+        return result
 
 
 class TripStop(Base):
@@ -2043,15 +2054,18 @@ class VehicleInventoryEvent(Base):
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
     vehicle_inventory_uuid = Column(String(36), ForeignKey("vehicle_inventory.uuid"), nullable=False)
     material_uuid = Column(String(36), ForeignKey("material.uuid"), nullable=False)
-    event_type = Column(String(120), nullable=False)  # manual, adjustment, unload
+    event_type = Column(String(120), nullable=False)  # manual, adjustment, unload, sale
     quantity = Column(Float, nullable=False)  # signed delta applied to the balance
     cost_per_unit = Column(Float, nullable=True)
     currency = Column(String(120), nullable=True)
     notes = Column(Text, nullable=True)
     is_deleted = Column(Boolean, default=False)
+    # set for trip-driven 'sale' events, linking the decrement to the fulfilled order item
+    customer_order_item_uuid = Column(String(36), ForeignKey("customer_order_item.uuid"), nullable=True)
 
     # relations
     vehicle_inventory = relationship("VehicleInventory", back_populates="events")
+    customer_order_item = relationship("CustomerOrderItem", backref="vehicle_inventory_events")
 
     def __repr__(self):
         return (

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -1899,13 +1899,14 @@ class Trip(Base):
     @hybrid_property
     def expected_cash(self):
         # cash actually collected at this trip's stops (payments tagged to the stop),
-        # including payments taken for previously-created orders during the trip
-        total = 0
+        # including payments taken for previously-created orders during the trip.
+        # Keyed by currency, since a trip may collect in more than one (USD/SYP).
+        totals: dict[str, float] = {}
         for stop in self.stops:
             for payment in stop.payments:
                 if not payment.is_deleted:
-                    total += payment.amount
-        return total
+                    totals[payment.currency] = totals.get(payment.currency, 0) + payment.amount
+        return totals
 
     @property
     def sold_inventory_map(self):

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -645,11 +645,14 @@ class Payment(Base):
     notes = Column(Text, nullable=True)
     debit_note_item_uuid = Column(String(36), ForeignKey("debit_note_item.uuid"), nullable=True)
     is_deleted  = Column(Boolean, default=False)
+    # trip stop where this cash was collected (set for payments taken during a trip)
+    trip_stop_uuid = Column(String(36), ForeignKey("trip_stop.uuid"), nullable=True)
 
     # relations
     invoice = relationship("Invoice", back_populates="payments")
     financial_account = relationship("FinancialAccount", back_populates="payments")
     debit_note_item = relationship("DebitNoteItem", back_populates="payments")
+    trip_stop = relationship("TripStop", backref="payments")
 
     def __repr__(self):
         return (
@@ -1895,33 +1898,30 @@ class Trip(Base):
 
     @hybrid_property
     def expected_cash(self):
-        all_orders = []
+        # cash actually collected at this trip's stops (payments tagged to the stop),
+        # including payments taken for previously-created orders during the trip
+        total = 0
         for stop in self.stops:
-            orders = [order for order in stop.customer_orders if not order.is_deleted]
-            all_orders.extend(orders)
-
-        # get amount paid
-        return sum(order.net_amount_paid for order in all_orders)
+            for payment in stop.payments:
+                if not payment.is_deleted:
+                    total += payment.amount
+        return total
 
     @property
     def sold_inventory_map(self):
         """Quantity sold off the vehicle during the trip, per material.
 
-        Derived from the vehicle 'sale' events created when trip-stop orders are
-        fulfilled (stored as negative deltas), returned here as positive amounts.
+        Derived from the vehicle 'sale' events tagged to this trip's stops (stored
+        as negative deltas), returned here as positive amounts. Tagging by stop
+        (rather than walking the stops' orders) captures stock handed off for
+        previously-created orders that are fulfilled during the trip.
         """
         sold: dict[str, float] = {}
         for stop in self.stops:
-            for order in stop.customer_orders:
-                if order.is_deleted:
+            for ev in stop.vehicle_inventory_events:
+                if ev.is_deleted or ev.event_type != "sale":
                     continue
-                for item in order.customer_order_items:
-                    if item.is_deleted or not item.is_fulfilled:
-                        continue
-                    for ev in item.vehicle_inventory_events:
-                        if ev.is_deleted or ev.event_type != "sale":
-                            continue
-                        sold[ev.material_uuid] = sold.get(ev.material_uuid, 0) - ev.quantity
+                sold[ev.material_uuid] = sold.get(ev.material_uuid, 0) - ev.quantity
         return sold
 
     @property
@@ -2062,10 +2062,13 @@ class VehicleInventoryEvent(Base):
     is_deleted = Column(Boolean, default=False)
     # set for trip-driven 'sale' events, linking the decrement to the fulfilled order item
     customer_order_item_uuid = Column(String(36), ForeignKey("customer_order_item.uuid"), nullable=True)
+    # trip stop where the stock left the truck (set for sales collected during a trip)
+    trip_stop_uuid = Column(String(36), ForeignKey("trip_stop.uuid"), nullable=True)
 
     # relations
     vehicle_inventory = relationship("VehicleInventory", back_populates="events")
     customer_order_item = relationship("CustomerOrderItem", backref="vehicle_inventory_events")
+    trip_stop = relationship("TripStop", backref="vehicle_inventory_events")
 
     def __repr__(self):
         return (

--- a/frontend/client/src/components/TaskExecutionProgress.tsx
+++ b/frontend/client/src/components/TaskExecutionProgress.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { Check, X, Clock, Circle } from "lucide-react";
 import type { TaskExecution } from "@/types/taskExecution";
 
@@ -15,6 +16,16 @@ export function TaskExecutionProgress({
   // Topological sort to order tasks based on depends_on
   const orderedTasks = topologicalSort(taskExecutions);
 
+  // keep the selected circle visible (e.g. a freshly added ad-hoc stop)
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!selectedTaskExecutionUuid || !containerRef.current) return;
+    const el = containerRef.current.querySelector(
+      `[data-testid="progress-task-${selectedTaskExecutionUuid}"]`
+    );
+    el?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "center" });
+  }, [selectedTaskExecutionUuid, orderedTasks.length]);
+
   if (orderedTasks.length === 0) {
     return (
       <div className="flex items-center justify-center h-32 text-gray-500">
@@ -24,7 +35,7 @@ export function TaskExecutionProgress({
   }
 
   return (
-    <div className="w-full overflow-x-auto py-8">
+    <div className="w-full overflow-x-auto py-8" ref={containerRef}>
       <div className="flex items-center justify-center min-w-max px-8">
         {orderedTasks.map((task, index) => (
           <div key={task.uuid} className="flex items-center">
@@ -74,66 +85,42 @@ export function TaskExecutionProgress({
 function topologicalSort(tasks: TaskExecution[]): TaskExecution[] {
   if (tasks.length === 0) return [];
 
-  // Build maps: name -> task and name -> dependents
-  const taskByName = new Map<string, TaskExecution>();
-  const dependents = new Map<string, Set<string>>();
-  const inDegree = new Map<string, number>();
-
-  // Initialize maps
-  tasks.forEach((task) => {
-    const name = task.name || task.uuid;
-    taskByName.set(name, task);
-    inDegree.set(name, 0);
-    dependents.set(name, new Set());
+  // Graph keyed by uuid (names can collide, e.g. two ad-hoc stops for the
+  // same customer). depends_on refers to task NAMES, so resolve names to uuids.
+  const byUuid = new Map<string, TaskExecution>(tasks.map((t) => [t.uuid, t]));
+  const uuidsByName = new Map<string, string[]>();
+  tasks.forEach((t) => {
+    const name = t.name || t.uuid;
+    if (!uuidsByName.has(name)) uuidsByName.set(name, []);
+    uuidsByName.get(name)!.push(t.uuid);
   });
 
-  // Build dependency graph based on task names in depends_on
-  tasks.forEach((task) => {
-    const name = task.name || task.uuid;
-    const deps = task.depends_on || [];
-    
-    // Count how many valid dependencies this task has
-    let validDepsCount = 0;
-    deps.forEach((depName) => {
-      if (taskByName.has(depName)) {
-        validDepsCount++;
-        // Add this task as a dependent of the dependency
-        dependents.get(depName)!.add(name);
-      }
-    });
-    
-    inDegree.set(name, validDepsCount);
-  });
-
-  // Kahn's algorithm for topological sort
-  const queue: string[] = [];
-  const result: TaskExecution[] = [];
-
-  // Start with tasks that have no dependencies
-  inDegree.forEach((degree, name) => {
-    if (degree === 0) {
-      queue.push(name);
-    }
-  });
-
-  while (queue.length > 0) {
-    const currentName = queue.shift()!;
-    const currentTask = taskByName.get(currentName);
-    if (currentTask) {
-      result.push(currentTask);
-    }
-
-    // Reduce in-degree for dependents
-    const deps = dependents.get(currentName);
-    if (deps) {
-      deps.forEach((depName) => {
-        const newDegree = inDegree.get(depName)! - 1;
-        inDegree.set(depName, newDegree);
-        if (newDegree === 0) {
-          queue.push(depName);
-        }
+  const inDegree = new Map<string, number>(tasks.map((t) => [t.uuid, 0]));
+  const dependents = new Map<string, Set<string>>(tasks.map((t) => [t.uuid, new Set<string>()]));
+  tasks.forEach((t) => {
+    (t.depends_on || []).forEach((depName) => {
+      (uuidsByName.get(depName) || []).forEach((depUuid) => {
+        dependents.get(depUuid)!.add(t.uuid);
+        inDegree.set(t.uuid, (inDegree.get(t.uuid) || 0) + 1);
       });
-    }
+    });
+  });
+
+  // Kahn's algorithm; among available tasks always pick the earliest-created,
+  // so dynamically added tasks (ad-hoc stops) land in chronological position
+  // instead of being pushed to the front of the bar.
+  const createdAt = (u: string) => new Date((byUuid.get(u) as any)?.created_at || 0).getTime();
+  const available: string[] = tasks.filter((t) => inDegree.get(t.uuid) === 0).map((t) => t.uuid);
+  const result: TaskExecution[] = [];
+  while (available.length > 0) {
+    available.sort((a, b) => createdAt(a) - createdAt(b));
+    const current = available.shift()!;
+    result.push(byUuid.get(current)!);
+    dependents.get(current)!.forEach((next) => {
+      const degree = (inDegree.get(next) || 0) - 1;
+      inDegree.set(next, degree);
+      if (degree === 0) available.push(next);
+    });
   }
 
   // If we couldn't process all tasks, there might be a cycle or missing dependencies
@@ -145,7 +132,13 @@ function topologicalSort(tasks: TaskExecution[]): TaskExecution[] {
       }
     });
   }
-  
+
+  // keep the explicit finish step visually last
+  const finishIdx = result.findIndex((t) => t.name === "finish_trip");
+  if (finishIdx >= 0 && finishIdx !== result.length - 1) {
+    result.push(...result.splice(finishIdx, 1));
+  }
+
   return result;
 }
 

--- a/frontend/client/src/components/customer-orders/CreateOrderDialog.tsx
+++ b/frontend/client/src/components/customer-orders/CreateOrderDialog.tsx
@@ -1,0 +1,226 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { Plus, Trash2, ShoppingCart } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+
+interface LineItem {
+  material_uuid: string;
+  quantity: string;
+  price_per_unit: string;
+}
+
+const CURRENCIES = ["USD", "SYP"];
+
+export function CreateOrderDialog({
+  customerUuid,
+  customerName,
+  tripStopUuid,
+}: {
+  customerUuid: string;
+  customerName?: string;
+  tripStopUuid?: string;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [items, setItems] = useState<LineItem[]>([{ material_uuid: "", quantity: "", price_per_unit: "" }]);
+  const [currency, setCurrency] = useState("USD");
+  const [markFulfilled, setMarkFulfilled] = useState(true);
+  const [markPaid, setMarkPaid] = useState(true);
+  const [financialAccountUuid, setFinancialAccountUuid] = useState("");
+  const [paymentMethod, setPaymentMethod] = useState("cash");
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: materialsData } = useQuery({
+    queryKey: ["/material/", "create-order"],
+    queryFn: async () => apiRequest("/material/?page=1&per_page=100"),
+    enabled: isOpen,
+  });
+  const materials = materialsData?.materials || [];
+
+  const { data: accountsData } = useQuery({
+    queryKey: ["/financial-account/", "create-order"],
+    queryFn: async () => apiRequest("/financial-account/?page=1&per_page=100"),
+    enabled: isOpen && markPaid,
+  });
+  const accounts = accountsData?.accounts || [];
+
+  const { data: methodsData } = useQuery({
+    queryKey: ["/payment/payment-methods"],
+    queryFn: async () => apiRequest("/payment/payment-methods"),
+    enabled: isOpen && markPaid,
+  });
+  const methods: string[] = methodsData || ["cash"];
+
+  const total = items.reduce(
+    (sum, it) => sum + (parseFloat(it.quantity) || 0) * (parseFloat(it.price_per_unit) || 0),
+    0
+  );
+
+  const setItem = (i: number, patch: Partial<LineItem>) =>
+    setItems((prev) => prev.map((it, idx) => (idx === i ? { ...it, ...patch } : it)));
+  const addItem = () => setItems((prev) => [...prev, { material_uuid: "", quantity: "", price_per_unit: "" }]);
+  const removeItem = (i: number) => setItems((prev) => prev.filter((_, idx) => idx !== i));
+
+  const reset = () => {
+    setItems([{ material_uuid: "", quantity: "", price_per_unit: "" }]);
+    setCurrency("USD");
+    setMarkFulfilled(true);
+    setMarkPaid(true);
+    setFinancialAccountUuid("");
+    setPaymentMethod("cash");
+  };
+
+  const createOrder = useMutation({
+    mutationFn: async () => {
+      const body: any = {
+        customer_uuid: customerUuid,
+        currency,
+        trip_stop_uuid: tripStopUuid || null,
+        items: items.map((it) => ({
+          material_uuid: it.material_uuid,
+          quantity: parseInt(it.quantity, 10),
+          price_per_unit: parseFloat(it.price_per_unit),
+        })),
+        fulfill: markFulfilled,
+        pay: markPaid,
+      };
+      if (markPaid) {
+        body.financial_account_uuid = financialAccountUuid || null;
+        body.payment_method = paymentMethod;
+      }
+      return apiRequest("/customer-order/with-items-and-invoice/checkout", { method: "POST", body });
+    },
+    onSuccess: () => {
+      toast({ title: "Order created", description: "The order was created successfully." });
+      queryClient.invalidateQueries({ queryKey: ["/customer-order/"] });
+      queryClient.invalidateQueries({ queryKey: ["/trip-stop/"] });
+      reset();
+      setIsOpen(false);
+    },
+    onError: (e: Error) => toast({ title: "Error", description: e.message, variant: "destructive" }),
+  });
+
+  const validItems = items.filter((it) => it.material_uuid && parseInt(it.quantity, 10) > 0);
+  const canSubmit =
+    validItems.length > 0 &&
+    items.every((it) => !it.material_uuid || (parseInt(it.quantity, 10) > 0 && it.price_per_unit !== "")) &&
+    (!markPaid || true);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button data-testid="button-create-order" className="bg-[#5469D4] hover:bg-[#5469D4]/90">
+          <ShoppingCart className="h-4 w-4 mr-2" />
+          Create Order
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Create Order{customerName ? ` — ${customerName}` : ""}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* currency */}
+          <div className="flex items-end gap-3">
+            <div>
+              <label className="text-sm font-medium mb-1 block">Currency</label>
+              <Select value={currency} onValueChange={setCurrency}>
+                <SelectTrigger className="w-32"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {CURRENCIES.map((c) => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="ml-auto text-right">
+              <div className="text-sm text-gray-500">Total</div>
+              <div className="text-lg font-semibold">{total.toFixed(2)} {currency}</div>
+            </div>
+          </div>
+
+          {/* line items */}
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Items</label>
+            {items.map((it, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <Select value={it.material_uuid} onValueChange={(v) => setItem(i, { material_uuid: v })}>
+                  <SelectTrigger className="flex-1" data-testid={`select-material-${i}`}>
+                    <SelectValue placeholder="Select material..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {materials.map((m: any) => (
+                      <SelectItem key={m.uuid} value={m.uuid}>{m.name}{m.sku ? ` (${m.sku})` : ""}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Input type="number" min="1" step="1" placeholder="Qty" className="w-20"
+                  value={it.quantity} onChange={(e) => setItem(i, { quantity: e.target.value })} />
+                <Input type="number" min="0" step="any" placeholder="Price" className="w-24"
+                  value={it.price_per_unit} onChange={(e) => setItem(i, { price_per_unit: e.target.value })} />
+                <Button type="button" variant="ghost" size="icon" onClick={() => removeItem(i)} disabled={items.length === 1}>
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            <Button type="button" variant="outline" size="sm" onClick={addItem}>
+              <Plus className="h-4 w-4 mr-1" /> Add item
+            </Button>
+          </div>
+
+          {/* toggles */}
+          <div className="flex flex-wrap gap-6 border-t pt-4">
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={markFulfilled} onChange={(e) => setMarkFulfilled(e.target.checked)} data-testid="toggle-fulfilled" />
+              Mark fulfilled
+            </label>
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={markPaid} onChange={(e) => setMarkPaid(e.target.checked)} data-testid="toggle-paid" />
+              Mark paid
+            </label>
+          </div>
+
+          {/* payment fields */}
+          {markPaid && (
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="text-sm font-medium mb-1 block">Financial account</label>
+                <Select value={financialAccountUuid} onValueChange={setFinancialAccountUuid}>
+                  <SelectTrigger data-testid="select-account"><SelectValue placeholder="Default (by currency)" /></SelectTrigger>
+                  <SelectContent>
+                    {accounts.map((a: any) => (
+                      <SelectItem key={a.uuid} value={a.uuid}>{a.account_name} ({a.currency})</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <label className="text-sm font-medium mb-1 block">Payment method</label>
+                <Select value={paymentMethod} onValueChange={setPaymentMethod}>
+                  <SelectTrigger data-testid="select-method"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {methods.map((m) => <SelectItem key={m} value={m}>{m}</SelectItem>)}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={() => setIsOpen(false)}>Cancel</Button>
+            <Button
+              onClick={() => createOrder.mutate()}
+              disabled={!canSubmit || createOrder.isPending}
+              className="bg-[#5469D4] hover:bg-[#5469D4]/90"
+            >
+              {createOrder.isPending ? "Submitting..." : "Submit Order"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/client/src/components/customer-orders/CreateOrderDialog.tsx
+++ b/frontend/client/src/components/customer-orders/CreateOrderDialog.tsx
@@ -98,6 +98,7 @@ export function CreateOrderDialog({
     onSuccess: () => {
       toast({ title: "Order created", description: "The order was created successfully." });
       queryClient.invalidateQueries({ queryKey: ["/customer-order/"] });
+      queryClient.invalidateQueries({ queryKey: ["/customer/"] }); // refresh customer balance
       queryClient.invalidateQueries({ queryKey: ["/trip-stop/"] });
       reset();
       setIsOpen(false);

--- a/frontend/client/src/components/customer-orders/CreateOrderDialog.tsx
+++ b/frontend/client/src/components/customer-orders/CreateOrderDialog.tsx
@@ -30,8 +30,6 @@ export function CreateOrderDialog({
   const [currency, setCurrency] = useState("USD");
   const [markFulfilled, setMarkFulfilled] = useState(true);
   const [markPaid, setMarkPaid] = useState(true);
-  const [financialAccountUuid, setFinancialAccountUuid] = useState("");
-  const [paymentMethod, setPaymentMethod] = useState("cash");
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
@@ -40,21 +38,32 @@ export function CreateOrderDialog({
     queryFn: async () => apiRequest("/material/?page=1&per_page=100"),
     enabled: isOpen,
   });
-  const materials = materialsData?.materials || [];
+  const allMaterials = materialsData?.materials || [];
 
-  const { data: accountsData } = useQuery({
-    queryKey: ["/financial-account/", "create-order"],
-    queryFn: async () => apiRequest("/financial-account/?page=1&per_page=100"),
-    enabled: isOpen && markPaid,
+  // when creating an order at a trip stop, only offer materials that were on
+  // the truck at trip start (per the trip's start_inventory snapshot)
+  const { data: tripStopData } = useQuery({
+    queryKey: ["/trip-stop/", tripStopUuid],
+    queryFn: async () => apiRequest(`/trip-stop/${tripStopUuid}`),
+    enabled: isOpen && !!tripStopUuid,
   });
-  const accounts = accountsData?.accounts || [];
-
-  const { data: methodsData } = useQuery({
-    queryKey: ["/payment/payment-methods"],
-    queryFn: async () => apiRequest("/payment/payment-methods"),
-    enabled: isOpen && markPaid,
+  const tripUuid = tripStopData?.trip_uuid;
+  const { data: tripData } = useQuery({
+    queryKey: ["/trip/", tripUuid],
+    queryFn: async () => apiRequest(`/trip/${tripUuid}`),
+    enabled: isOpen && !!tripUuid,
   });
-  const methods: string[] = methodsData || ["cash"];
+  const startInventory: Record<string, number> = tripData?.start_inventory || {};
+  const loadedMaterialUuids = Object.entries(startInventory)
+    .filter(([, qty]) => Number(qty) > 0)
+    .map(([uuid]) => uuid);
+  // fall back to all materials when the trip has no snapshot (e.g. older trips)
+  const materials =
+    tripStopUuid && loadedMaterialUuids.length > 0
+      ? allMaterials.filter((m: any) => loadedMaterialUuids.includes(m.uuid))
+      : allMaterials;
+  const unitOf = (materialUuid: string) =>
+    allMaterials.find((m: any) => m.uuid === materialUuid)?.measure_unit || "";
 
   const total = items.reduce(
     (sum, it) => sum + (parseFloat(it.quantity) || 0) * (parseFloat(it.price_per_unit) || 0),
@@ -71,8 +80,6 @@ export function CreateOrderDialog({
     setCurrency("USD");
     setMarkFulfilled(true);
     setMarkPaid(true);
-    setFinancialAccountUuid("");
-    setPaymentMethod("cash");
   };
 
   const createOrder = useMutation({
@@ -90,8 +97,8 @@ export function CreateOrderDialog({
         pay: markPaid,
       };
       if (markPaid) {
-        body.financial_account_uuid = financialAccountUuid || null;
-        body.payment_method = paymentMethod;
+        body.financial_account_uuid = null; // default account (by currency) on the backend
+        body.payment_method = "cash"; // default method
       }
       return apiRequest("/customer-order/with-items-and-invoice/checkout", { method: "POST", body });
     },
@@ -158,8 +165,17 @@ export function CreateOrderDialog({
                     ))}
                   </SelectContent>
                 </Select>
-                <Input type="number" min="1" step="1" placeholder="Qty" className="w-20"
-                  value={it.quantity} onChange={(e) => setItem(i, { quantity: e.target.value })} />
+                <div className="relative w-24">
+                  <Input type="number" min="1" step="1" placeholder="Qty"
+                    className={unitOf(it.material_uuid) ? "pr-10" : ""}
+                    value={it.quantity} onChange={(e) => setItem(i, { quantity: e.target.value })} />
+                  {unitOf(it.material_uuid) && (
+                    <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-500 pointer-events-none"
+                      data-testid={`unit-${i}`}>
+                      {unitOf(it.material_uuid)}
+                    </span>
+                  )}
+                </div>
                 <Input type="number" min="0" step="any" placeholder="Price" className="w-24"
                   value={it.price_per_unit} onChange={(e) => setItem(i, { price_per_unit: e.target.value })} />
                 <Button type="button" variant="ghost" size="icon" onClick={() => removeItem(i)} disabled={items.length === 1}>
@@ -183,32 +199,6 @@ export function CreateOrderDialog({
               Mark paid
             </label>
           </div>
-
-          {/* payment fields */}
-          {markPaid && (
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="text-sm font-medium mb-1 block">Financial account</label>
-                <Select value={financialAccountUuid} onValueChange={setFinancialAccountUuid}>
-                  <SelectTrigger data-testid="select-account"><SelectValue placeholder="Default (by currency)" /></SelectTrigger>
-                  <SelectContent>
-                    {accounts.map((a: any) => (
-                      <SelectItem key={a.uuid} value={a.uuid}>{a.account_name} ({a.currency})</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <label className="text-sm font-medium mb-1 block">Payment method</label>
-                <Select value={paymentMethod} onValueChange={setPaymentMethod}>
-                  <SelectTrigger data-testid="select-method"><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    {methods.map((m) => <SelectItem key={m} value={m}>{m}</SelectItem>)}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-          )}
 
           <div className="flex justify-end gap-2 pt-2">
             <Button variant="outline" onClick={() => setIsOpen(false)}>Cancel</Button>

--- a/frontend/client/src/components/customer-orders/CustomerRecentOrders.tsx
+++ b/frontend/client/src/components/customer-orders/CustomerRecentOrders.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { apiRequest } from "@/lib/queryClient";
+import { OrderDetailDialog } from "@/components/customer-orders/OrderDetailDialog";
+
+interface OrderRow {
+  uuid: string;
+  created_at: string;
+  is_paid?: boolean;
+  is_fulfilled?: boolean;
+  net_amount_due?: number;
+  total_adjusted_amount?: number;
+  currency?: string;
+}
+
+export function CustomerRecentOrders({ customerUuid }: { customerUuid: string }) {
+  const [selectedOrderUuid, setSelectedOrderUuid] = useState<string | null>(null);
+  const { data, isLoading } = useQuery({
+    queryKey: ["/customer-order/", "recent", customerUuid],
+    queryFn: async () => apiRequest(`/customer-order/?customer_uuid=${customerUuid}&per_page=50`),
+    enabled: !!customerUuid,
+  });
+
+  const { data: customer } = useQuery({
+    queryKey: ["/customer/", customerUuid],
+    queryFn: async () => apiRequest(`/customer/${customerUuid}`),
+    enabled: !!customerUuid,
+  });
+  const balances: Record<string, number> = customer?.balance_per_currency || {};
+
+  const all: OrderRow[] = data?.orders || data?.customer_orders || [];
+  const needsAttention = (o: OrderRow) => o.is_paid === false || o.is_fulfilled === false;
+
+  // unpaid/unfulfilled first, then most recent; show the last 5
+  const orders = [...all]
+    .sort((a, b) => {
+      const ap = needsAttention(a) ? 0 : 1;
+      const bp = needsAttention(b) ? 0 : 1;
+      if (ap !== bp) return ap - bp;
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    })
+    .slice(0, 5);
+
+  const fmtDate = (s: string) => {
+    const d = new Date(s);
+    return isNaN(d.getTime()) ? s : d.toLocaleDateString();
+  };
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="text-base">Recent orders</CardTitle>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-gray-500">Balance</span>
+            {Object.keys(balances).length === 0 ? (
+              <span className="text-sm text-gray-400">—</span>
+            ) : (
+              Object.entries(balances).map(([cur, amt]) => (
+                <Badge key={cur} variant={Number(amt) > 0 ? "destructive" : "secondary"} data-testid={`balance-${cur}`}>
+                  {Number(amt).toFixed(2)} {cur}
+                </Badge>
+              ))
+            )}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="text-sm text-gray-500">Loading…</div>
+        ) : orders.length === 0 ? (
+          <div className="text-sm text-gray-500">No previous orders for this customer.</div>
+        ) : (
+          <div className="divide-y">
+            {orders.map((o) => (
+              <div
+                key={o.uuid}
+                role="button"
+                onClick={() => setSelectedOrderUuid(o.uuid)}
+                className="flex items-center justify-between py-2 px-1 rounded cursor-pointer hover:bg-gray-50"
+                data-testid={`recent-order-${o.uuid}`}
+              >
+                <div className="text-sm">
+                  <div className="font-medium text-gray-900">{fmtDate(o.created_at)}</div>
+                  <div className="text-gray-500">
+                    {(o.net_amount_due ?? o.total_adjusted_amount ?? 0)} {o.currency || ""} due
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <Badge variant={o.is_paid ? "secondary" : "destructive"}>
+                    {o.is_paid ? "Paid" : "Unpaid"}
+                  </Badge>
+                  <Badge variant={o.is_fulfilled ? "secondary" : "outline"}>
+                    {o.is_fulfilled ? "Fulfilled" : "Unfulfilled"}
+                  </Badge>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <OrderDetailDialog
+        orderUuid={selectedOrderUuid}
+        open={!!selectedOrderUuid}
+        onOpenChange={(o) => { if (!o) setSelectedOrderUuid(null); }}
+      />
+    </Card>
+  );
+}

--- a/frontend/client/src/components/customer-orders/CustomerRecentOrders.tsx
+++ b/frontend/client/src/components/customer-orders/CustomerRecentOrders.tsx
@@ -15,7 +15,7 @@ interface OrderRow {
   currency?: string;
 }
 
-export function CustomerRecentOrders({ customerUuid }: { customerUuid: string }) {
+export function CustomerRecentOrders({ customerUuid, tripStopUuid }: { customerUuid: string; tripStopUuid?: string }) {
   const [selectedOrderUuid, setSelectedOrderUuid] = useState<string | null>(null);
   const { data, isLoading } = useQuery({
     queryKey: ["/customer-order/", "recent", customerUuid],
@@ -104,6 +104,7 @@ export function CustomerRecentOrders({ customerUuid }: { customerUuid: string })
 
       <OrderDetailDialog
         orderUuid={selectedOrderUuid}
+        tripStopUuid={tripStopUuid}
         open={!!selectedOrderUuid}
         onOpenChange={(o) => { if (!o) setSelectedOrderUuid(null); }}
       />

--- a/frontend/client/src/components/customer-orders/OrderDetailDialog.tsx
+++ b/frontend/client/src/components/customer-orders/OrderDetailDialog.tsx
@@ -9,10 +9,12 @@ import { apiRequest } from "@/lib/queryClient";
 
 export function OrderDetailDialog({
   orderUuid,
+  tripStopUuid,
   open,
   onOpenChange,
 }: {
   orderUuid: string | null;
+  tripStopUuid?: string;
   open: boolean;
   onOpenChange: (o: boolean) => void;
 }) {
@@ -39,6 +41,7 @@ export function OrderDetailDialog({
     queryClient.invalidateQueries({ queryKey: detailKey });
     queryClient.refetchQueries({ queryKey: detailKey });
     queryClient.invalidateQueries({ queryKey: ["/customer-order/"] });
+    queryClient.invalidateQueries({ queryKey: ["/customer/"] }); // refresh customer balance
   };
 
   const canFulfill = unfulfilled.length > 0;
@@ -49,7 +52,10 @@ export function OrderDetailDialog({
       if (doFulfill && canFulfill) {
         await apiRequest("/customer-order-item/fulfill-items", {
           method: "POST",
-          body: { items: unfulfilled.map((i: any) => ({ customer_order_item_uuid: i.uuid })) },
+          body: {
+            items: unfulfilled.map((i: any) => ({ customer_order_item_uuid: i.uuid })),
+            trip_stop_uuid: tripStopUuid || null, // attribute the vehicle sale to the current stop
+          },
         });
       }
       if (doPay && canPay) {
@@ -61,6 +67,7 @@ export function OrderDetailDialog({
             amount: amountDue,
             currency,
             payment_method: "cash", // default method
+            trip_stop_uuid: tripStopUuid || null, // attribute cash to the current trip stop
           },
         });
       }

--- a/frontend/client/src/components/customer-orders/OrderDetailDialog.tsx
+++ b/frontend/client/src/components/customer-orders/OrderDetailDialog.tsx
@@ -1,0 +1,160 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { CheckCircle2 } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+
+export function OrderDetailDialog({
+  orderUuid,
+  open,
+  onOpenChange,
+}: {
+  orderUuid: string | null;
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+}) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [doFulfill, setDoFulfill] = useState(true);
+  const [doPay, setDoPay] = useState(true);
+
+  const detailKey = ["/customer-order/with-items-and-invoice/", orderUuid];
+  const { data, isLoading } = useQuery({
+    queryKey: detailKey,
+    queryFn: async () => apiRequest(`/customer-order/with-items-and-invoice/${orderUuid}`),
+    enabled: open && !!orderUuid,
+  });
+
+  const order = data?.customer_order;
+  const invoice = data?.invoices?.[0];
+  const items = (order?.customer_order_items || []).filter((i: any) => !i.is_deleted);
+  const unfulfilled = items.filter((i: any) => !i.is_fulfilled);
+  const amountDue = invoice?.net_amount_due ?? order?.net_amount_due ?? 0;
+  const currency = order?.currency || "";
+
+  const refresh = () => {
+    queryClient.invalidateQueries({ queryKey: detailKey });
+    queryClient.refetchQueries({ queryKey: detailKey });
+    queryClient.invalidateQueries({ queryKey: ["/customer-order/"] });
+  };
+
+  const canFulfill = unfulfilled.length > 0;
+  const canPay = amountDue > 0;
+
+  const submitMutation = useMutation({
+    mutationFn: async () => {
+      if (doFulfill && canFulfill) {
+        await apiRequest("/customer-order-item/fulfill-items", {
+          method: "POST",
+          body: { items: unfulfilled.map((i: any) => ({ customer_order_item_uuid: i.uuid })) },
+        });
+      }
+      if (doPay && canPay) {
+        await apiRequest("/payment/", {
+          method: "POST",
+          body: {
+            invoice_uuid: invoice.uuid,
+            financial_account_uuid: null, // default account (by currency) on the backend
+            amount: amountDue,
+            currency,
+            payment_method: "cash", // default method
+          },
+        });
+      }
+    },
+    onSuccess: () => {
+      toast({ title: "Order updated", description: "Selected actions were applied." });
+      refresh();
+    },
+    onError: (e: Error) => toast({ title: "Error", description: e.message, variant: "destructive" }),
+  });
+
+  const nothingSelected = !(doFulfill && canFulfill) && !(doPay && canPay);
+
+  const fmtDate = (s?: string) => {
+    if (!s) return "";
+    const d = new Date(s);
+    return isNaN(d.getTime()) ? s : d.toLocaleString();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Order details</DialogTitle>
+        </DialogHeader>
+
+        {isLoading || !order ? (
+          <div className="text-sm text-gray-500 py-6 text-center">Loading…</div>
+        ) : (
+          <div className="space-y-4">
+            {/* header */}
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-gray-500">{fmtDate(order.created_at)}</div>
+              <div className="flex gap-2">
+                <Badge variant={order.is_paid ? "secondary" : "destructive"}>
+                  {order.is_paid ? "Paid" : "Unpaid"}
+                </Badge>
+                <Badge variant={order.is_fulfilled ? "secondary" : "outline"}>
+                  {order.is_fulfilled ? "Fulfilled" : "Unfulfilled"}
+                </Badge>
+              </div>
+            </div>
+
+            {/* items */}
+            <div className="border rounded-md divide-y">
+              {items.map((i: any) => (
+                <div key={i.uuid} className="flex items-center justify-between px-3 py-2 text-sm">
+                  <span>{i.material_name} × {i.quantity} {i.unit || ""}</span>
+                  <Badge variant={i.is_fulfilled ? "secondary" : "outline"} className="text-xs">
+                    {i.is_fulfilled ? "fulfilled" : "pending"}
+                  </Badge>
+                </div>
+              ))}
+            </div>
+
+            {/* totals */}
+            <div className="text-sm space-y-1">
+              <div className="flex justify-between"><span className="text-gray-500">Total</span><span>{invoice?.total_amount ?? order.total_adjusted_amount ?? 0} {currency}</span></div>
+              <div className="flex justify-between"><span className="text-gray-500">Paid</span><span>{invoice?.net_amount_paid ?? order.net_amount_paid ?? 0} {currency}</span></div>
+              <div className="flex justify-between font-semibold"><span>Due</span><span>{amountDue} {currency}</span></div>
+            </div>
+
+            {/* actions: tick what to do, then submit */}
+            {(canFulfill || canPay) && (
+              <div className="border-t pt-4 space-y-3">
+                <div className="flex flex-wrap gap-6">
+                  {canFulfill && (
+                    <label className="flex items-center gap-2 text-sm cursor-pointer">
+                      <input type="checkbox" checked={doFulfill} onChange={(e) => setDoFulfill(e.target.checked)} data-testid="check-fulfill" />
+                      Mark fulfilled ({unfulfilled.length} item{unfulfilled.length > 1 ? "s" : ""})
+                    </label>
+                  )}
+                  {canPay && (
+                    <label className="flex items-center gap-2 text-sm cursor-pointer">
+                      <input type="checkbox" checked={doPay} onChange={(e) => setDoPay(e.target.checked)} data-testid="check-pay" />
+                      Mark paid ({amountDue} {currency})
+                    </label>
+                  )}
+                </div>
+
+                <Button
+                  onClick={() => submitMutation.mutate()}
+                  disabled={nothingSelected || submitMutation.isPending}
+                  className="w-full bg-[#5469D4] hover:bg-[#5469D4]/90"
+                  data-testid="button-submit-order-actions"
+                >
+                  <CheckCircle2 className="h-4 w-4 mr-2" />
+                  {submitMutation.isPending ? "Submitting…" : "Submit"}
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/client/src/components/map/TripStopsMap.tsx
+++ b/frontend/client/src/components/map/TripStopsMap.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useRef, useState } from "react";
+import { MapContainer, TileLayer, Marker, Popup, Polyline, useMap } from "react-leaflet";
+import "leaflet/dist/leaflet.css";
+import L from "leaflet";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { Play, Pause, RotateCcw } from "lucide-react";
+
+export interface TripStopPoint {
+  uuid: string;
+  index?: number | null;
+  customer_name?: string | null;
+  status?: string | null;
+  outcome?: string | null;
+  coordinates?: string | null; // "lat,lon"
+  completed_at?: string | null;
+}
+
+function FitBounds({ points }: { points: [number, number][] }) {
+  const map = useMap();
+  useEffect(() => {
+    if (points.length > 0) {
+      map.fitBounds(L.latLngBounds(points), { padding: [50, 50] });
+    }
+  }, [map, points.length]);
+  return null;
+}
+
+function numberedIcon(number: number, done: boolean) {
+  const color = done ? "#16a34a" : "#5469D4";
+  return L.divIcon({
+    html: `<div style="position: relative; width: 30px; height: 41px;">
+      <svg width="30" height="41" viewBox="0 0 30 41" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 0C7.268 0 1 6.268 1 14c0 14 14 26 14 26s14-12 14-26C29 6.268 22.732 0 15 0z" fill="${color}" stroke="white" stroke-width="2"/>
+      </svg>
+      <div style="position: absolute; top: 8px; left: 50%; transform: translateX(-50%); color: white; font-weight: bold; font-size: 12px; text-align: center; width: 100%;">
+        ${number}
+      </div>
+    </div>`,
+    className: "trip-stop-numbered-icon",
+    iconSize: [30, 41],
+    iconAnchor: [15, 41],
+    popupAnchor: [0, -41],
+  });
+}
+
+export function TripStopsMap({ stops }: { stops: TripStopPoint[] }) {
+  // visibleCount: how many stops are shown; drives the "progress over time" animation
+  const [visibleCount, setVisibleCount] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const points = stops
+    .map((s) => {
+      const [lat, lon] = (s.coordinates || "").split(",").map(Number);
+      return { ...s, lat, lon };
+    })
+    .filter((s) => !isNaN(s.lat) && !isNaN(s.lon));
+
+  // start fully revealed
+  useEffect(() => {
+    setVisibleCount(points.length);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [points.length]);
+
+  useEffect(() => {
+    if (playing) {
+      timerRef.current = setInterval(() => {
+        setVisibleCount((c) => {
+          if (c >= points.length) {
+            setPlaying(false);
+            return c;
+          }
+          return c + 1;
+        });
+      }, 900);
+    }
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [playing, points.length]);
+
+  if (points.length === 0) {
+    return (
+      <div className="h-96 bg-gray-100 rounded-lg flex items-center justify-center">
+        <p className="text-gray-500">No stop locations for this trip.</p>
+      </div>
+    );
+  }
+
+  const shown = points.slice(0, visibleCount);
+  const path = shown.map((p) => [p.lat, p.lon] as [number, number]);
+  const allPoints = points.map((p) => [p.lat, p.lon] as [number, number]);
+
+  const play = () => {
+    if (visibleCount >= points.length) setVisibleCount(0);
+    setPlaying(true);
+  };
+
+  const fmtTime = (s?: string | null) => {
+    if (!s) return null;
+    const d = new Date(/[zZ]|[+-]\d{2}:?\d{2}$/.test(s) ? s : s + "Z");
+    return isNaN(d.getTime()) ? s : d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* animation controls */}
+      <div className="flex items-center gap-4">
+        {playing ? (
+          <Button variant="outline" size="sm" onClick={() => setPlaying(false)} data-testid="button-stops-pause">
+            <Pause className="h-4 w-4 mr-2" /> Pause
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" onClick={play} data-testid="button-stops-play">
+            <Play className="h-4 w-4 mr-2" /> Play
+          </Button>
+        )}
+        <Button variant="ghost" size="sm" onClick={() => { setPlaying(false); setVisibleCount(points.length); }} data-testid="button-stops-reset">
+          <RotateCcw className="h-4 w-4 mr-2" /> Show all
+        </Button>
+        <span className="text-sm text-gray-500 whitespace-nowrap" data-testid="stops-map-progress">
+          {Math.min(visibleCount, points.length)} / {points.length} stops
+        </span>
+        <Slider
+          value={[visibleCount]}
+          onValueChange={(v) => { setPlaying(false); setVisibleCount(v[0]); }}
+          min={0}
+          max={points.length}
+          step={1}
+          className="flex-1"
+          data-testid="slider-stops-progress"
+        />
+      </div>
+
+      {/* map */}
+      <div className="h-96 w-full rounded-lg overflow-hidden border border-gray-200">
+        <MapContainer center={allPoints[0]} zoom={13} style={{ height: "100%", width: "100%" }}>
+          <FitBounds points={allPoints} />
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <Polyline positions={path} pathOptions={{ color: "#5469D4", weight: 3, dashArray: "6 8" }} />
+          {shown.map((p, i) => (
+            <Marker key={p.uuid} position={[p.lat, p.lon]} icon={numberedIcon(i + 1, p.status === "completed")}>
+              <Popup>
+                <div className="text-sm">
+                  <div className="font-semibold">{i + 1}. {p.customer_name || "Unknown customer"}</div>
+                  {p.outcome && <div className="text-gray-600">{p.outcome}</div>}
+                  {p.completed_at && <div className="text-gray-500">Completed {fmtTime(p.completed_at)}</div>}
+                </div>
+              </Popup>
+            </Marker>
+          ))}
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/frontend/client/src/components/trips/AddStopDialog.tsx
+++ b/frontend/client/src/components/trips/AddStopDialog.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import { MapPin, Plus, Crosshair } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+
+interface CustomerRow {
+  uuid: string;
+  company_name?: string;
+  full_name?: string;
+  phone_number?: string;
+  coordinates?: string | null;
+}
+
+export function AddStopDialog({
+  workflowExecutionUuid,
+  onCreated,
+}: {
+  workflowExecutionUuid: string;
+  onCreated?: (taskExecutionUuid: string) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [mode, setMode] = useState<"existing" | "new">("existing");
+  const [search, setSearch] = useState("");
+  const [customerUuid, setCustomerUuid] = useState("");
+  // "lat,lon" — captured from device location, used when the customer has no stored coordinates
+  const [coords, setCoords] = useState("");
+  const [newCustomer, setNewCustomer] = useState({
+    company_name: "",
+    full_name: "",
+    phone_number: "",
+    category: "",
+    full_address: "",
+  });
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  // debounce the search text, then filter server-side (company_name ilike)
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedSearch(search.trim()), 300);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const { data: customersData } = useQuery({
+    queryKey: ["/customer/", "add-stop", debouncedSearch],
+    queryFn: async () =>
+      apiRequest(
+        `/customer/?page=1&per_page=100${debouncedSearch ? `&company_name=${encodeURIComponent(debouncedSearch)}` : ""}`
+      ),
+    enabled: isOpen && mode === "existing",
+  });
+  const customers: CustomerRow[] = customersData?.customers || [];
+  const filtered = customers;
+
+  const { data: categories } = useQuery<string[]>({
+    queryKey: ["/customer/categories"],
+    queryFn: async () => apiRequest("/customer/categories"),
+    enabled: isOpen && mode === "new",
+  });
+
+  // try to capture the device location once when the dialog opens
+  useEffect(() => {
+    if (isOpen && !coords && navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => setCoords(`${pos.coords.latitude.toFixed(6)},${pos.coords.longitude.toFixed(6)}`),
+        () => {}, // ignore errors; the user can type coordinates manually
+        { enableHighAccuracy: true, timeout: 5000 }
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  const captureLocation = () => {
+    if (!navigator.geolocation) {
+      toast({ title: "Location unavailable", description: "Geolocation is not supported here.", variant: "destructive" });
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setCoords(`${pos.coords.latitude.toFixed(6)},${pos.coords.longitude.toFixed(6)}`),
+      (e) => toast({ title: "Location error", description: e.message, variant: "destructive" }),
+      { enableHighAccuracy: true, timeout: 8000 }
+    );
+  };
+
+  const reset = () => {
+    setMode("existing");
+    setSearch("");
+    setCustomerUuid("");
+    setNewCustomer({ company_name: "", full_name: "", phone_number: "", category: "", full_address: "" });
+  };
+
+  const addStop = useMutation({
+    mutationFn: async () => {
+      const body: any = { coordinates: coords || null };
+      if (mode === "existing") {
+        body.customer_uuid = customerUuid;
+      } else {
+        body.customer = {
+          company_name: newCustomer.company_name,
+          full_name: newCustomer.full_name,
+          phone_number: newCustomer.phone_number,
+          category: newCustomer.category,
+          full_address: newCustomer.full_address || newCustomer.company_name,
+          coordinates: coords || null,
+        };
+      }
+      return apiRequest(`/workflow-execution/${workflowExecutionUuid}/manual-stop`, { method: "POST", body });
+    },
+    onSuccess: (res: any) => {
+      toast({ title: "Stop added", description: "The trip stop was created." });
+      queryClient.invalidateQueries({ queryKey: ["/workflow-execution/", workflowExecutionUuid] });
+      queryClient.invalidateQueries({ queryKey: ["/customer/"] });
+      reset();
+      setIsOpen(false);
+      if (res?.task_execution_uuid && onCreated) onCreated(res.task_execution_uuid);
+    },
+    onError: (e: Error) => toast({ title: "Error", description: e.message, variant: "destructive" }),
+  });
+
+  const canSubmit =
+    mode === "existing"
+      ? !!customerUuid
+      : !!(newCustomer.company_name && newCustomer.full_name && newCustomer.phone_number && newCustomer.category);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(o) => { setIsOpen(o); if (!o) reset(); }}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" data-testid="button-add-stop">
+          <MapPin className="h-4 w-4 mr-2" />
+          Add Stop
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Add Stop</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* mode toggle */}
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant={mode === "existing" ? "default" : "outline"}
+              onClick={() => setMode("existing")}
+              data-testid="mode-existing-customer"
+            >
+              Existing customer
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant={mode === "new" ? "default" : "outline"}
+              onClick={() => setMode("new")}
+              data-testid="mode-new-customer"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              New customer
+            </Button>
+          </div>
+
+          {mode === "existing" ? (
+            <div className="space-y-2">
+              <Input
+                placeholder="Search customers..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                data-testid="input-customer-search"
+              />
+              <div className="border rounded-md divide-y max-h-56 overflow-y-auto">
+                {filtered.length === 0 ? (
+                  <div className="text-sm text-gray-500 p-3">No customers match.</div>
+                ) : (
+                  filtered.map((c) => (
+                    <div
+                      key={c.uuid}
+                      role="button"
+                      onClick={() => setCustomerUuid(c.uuid)}
+                      className={`px-3 py-2 text-sm cursor-pointer hover:bg-gray-50 ${customerUuid === c.uuid ? "bg-blue-50" : ""}`}
+                      data-testid={`customer-option-${c.uuid}`}
+                    >
+                      <div className="font-medium">{c.company_name || c.full_name}</div>
+                      <div className="text-gray-500 text-xs">{c.full_name} {c.phone_number ? `· ${c.phone_number}` : ""}</div>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              <Input placeholder="Company / shop name *" value={newCustomer.company_name}
+                onChange={(e) => setNewCustomer((p) => ({ ...p, company_name: e.target.value }))}
+                data-testid="input-new-company" />
+              <Input placeholder="Contact full name *" value={newCustomer.full_name}
+                onChange={(e) => setNewCustomer((p) => ({ ...p, full_name: e.target.value }))}
+                data-testid="input-new-fullname" />
+              <Input placeholder="Phone number *" value={newCustomer.phone_number}
+                onChange={(e) => setNewCustomer((p) => ({ ...p, phone_number: e.target.value }))}
+                data-testid="input-new-phone" />
+              <Select value={newCustomer.category} onValueChange={(v) => setNewCustomer((p) => ({ ...p, category: v }))}>
+                <SelectTrigger data-testid="select-new-category">
+                  <SelectValue placeholder="Category *" />
+                </SelectTrigger>
+                <SelectContent>
+                  {(categories || []).map((c) => <SelectItem key={c} value={c}>{c}</SelectItem>)}
+                </SelectContent>
+              </Select>
+              <Input placeholder="Address (optional)" value={newCustomer.full_address}
+                onChange={(e) => setNewCustomer((p) => ({ ...p, full_address: e.target.value }))}
+                data-testid="input-new-address" />
+            </div>
+          )}
+
+          {/* location (used when the customer has no stored coordinates) */}
+          <div>
+            <label className="text-xs text-gray-500 mb-1 block">
+              Location (lat,lon) — used if the customer has no saved location
+            </label>
+            <div className="flex gap-2">
+              <Input
+                placeholder="e.g. 33.5138,36.2765"
+                value={coords}
+                onChange={(e) => setCoords(e.target.value)}
+                data-testid="input-stop-coords"
+              />
+              <Button type="button" variant="outline" size="icon" onClick={captureLocation} title="Use my location">
+                <Crosshair className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          <Button
+            className="w-full bg-[#5469D4] hover:bg-[#5469D4]/90"
+            onClick={() => addStop.mutate()}
+            disabled={!canSubmit || addStop.isPending}
+            data-testid="button-submit-add-stop"
+          >
+            {addStop.isPending ? "Adding…" : "Add Stop"}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/client/src/components/vehicles/VehicleInventoryChart.tsx
+++ b/frontend/client/src/components/vehicles/VehicleInventoryChart.tsx
@@ -60,7 +60,19 @@ const toMs = (s: string) => {
   return new Date(hasTz ? s : s + "Z").getTime();
 };
 
-export function VehicleInventoryChart({ vehicleUuid }: { vehicleUuid: string }) {
+export function VehicleInventoryChart({
+  vehicleUuid,
+  windowStart,
+  windowEnd,
+  title = "Inventory Over Time",
+}: {
+  vehicleUuid: string;
+  // fixed time window (e.g. a trip): hides the range picker; windowEnd omitted/null
+  // means "up until now" (trip still in progress)
+  windowStart?: string | null;
+  windowEnd?: string | null;
+  title?: string;
+}) {
   const [preset, setPreset] = useState("all");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
@@ -106,7 +118,11 @@ export function VehicleInventoryChart({ vehicleUuid }: { vehicleUuid: string }) 
     const now = Date.now();
     let startMs: number;
     let endMs: number;
-    if (preset === "custom") {
+    if (windowStart) {
+      // fixed window mode (e.g. trip start → trip end / now)
+      startMs = toMs(windowStart);
+      endMs = windowEnd ? toMs(windowEnd) : now;
+    } else if (preset === "custom") {
       startMs = startDate ? new Date(startDate + "T00:00:00Z").getTime() : -Infinity;
       endMs = endDate ? new Date(endDate + "T23:59:59Z").getTime() : now;
     } else if (preset === "all") {
@@ -166,7 +182,7 @@ export function VehicleInventoryChart({ vehicleUuid }: { vehicleUuid: string }) 
     }));
 
     return { rows, lines };
-  }, [inventories, eventsByInv, selected, preset, startDate, endDate]);
+  }, [inventories, eventsByInv, selected, preset, startDate, endDate, windowStart, windowEnd]);
 
   const toggle = (uuid: string) => {
     setSelected((prev) => {
@@ -176,13 +192,19 @@ export function VehicleInventoryChart({ vehicleUuid }: { vehicleUuid: string }) 
     });
   };
 
+  // fixed windows are usually hours long — show times on the axis, not dates
+  const spanMs = rows.length ? rows[rows.length - 1].t - rows[0].t : 0;
+  const tickFmt = (t: number) =>
+    spanMs <= 2 * DAY ? new Date(t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : new Date(t).toLocaleDateString();
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Inventory Over Time</CardTitle>
+        <CardTitle>{title}</CardTitle>
       </CardHeader>
       <CardContent>
-        {/* Filters */}
+        {/* Filters (hidden in fixed-window mode) */}
+        {!windowStart && (
         <div className="flex flex-wrap items-end gap-4 mb-4">
           <div>
             <label className="text-sm font-medium text-gray-500 mb-1 block">Range</label>
@@ -224,6 +246,7 @@ export function VehicleInventoryChart({ vehicleUuid }: { vehicleUuid: string }) 
             </>
           )}
         </div>
+        )}
 
         {/* Material toggles */}
         {inventories.length > 0 && (
@@ -263,7 +286,7 @@ export function VehicleInventoryChart({ vehicleUuid }: { vehicleUuid: string }) 
                 type="number"
                 scale="time"
                 domain={["dataMin", "dataMax"]}
-                tickFormatter={(t) => new Date(t).toLocaleDateString()}
+                tickFormatter={tickFmt}
                 fontSize={12}
               />
               <YAxis allowDecimals fontSize={12} />

--- a/frontend/client/src/lib/types.ts
+++ b/frontend/client/src/lib/types.ts
@@ -504,6 +504,13 @@ export interface Trip {
   end_point?: string;
   data?: TripData;
   workflow_execution_uuid?: string;
+  start_inventory?: Record<string, number> | null;
+  end_inventory?: Record<string, number> | null;
+  inventory_reconciliation?: Record<
+    string,
+    { start: number; sold: number; expected_end: number; actual_end: number | null; variance: number | null }
+  > | null;
+  expected_cash?: Record<string, number> | null;
 }
 
 export interface TripFormData {

--- a/frontend/client/src/pages/TripDetail.tsx
+++ b/frontend/client/src/pages/TripDetail.tsx
@@ -8,11 +8,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, Edit3, Save, X, Copy, Check, Truck } from "lucide-react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ArrowLeft, Edit3, Save, X, Copy, Check, Truck, Banknote, ChevronLeft, ChevronRight } from "lucide-react";
 import { format } from "date-fns";
 import { toast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import type { Trip } from "@/lib/types";
+import { VehicleInventoryChart } from "@/components/vehicles/VehicleInventoryChart";
 
 export default function TripDetail() {
   const params = useParams();
@@ -26,6 +28,32 @@ export default function TripDetail() {
     queryFn: () => apiRequest(`/trip/${params?.uuid}`),
     enabled: !!params?.uuid,
   });
+
+  // material names for the inventory tables (keys are material uuids)
+  const { data: materialsData } = useQuery({
+    queryKey: ["/material/", "trip-detail"],
+    queryFn: () => apiRequest("/material/?page=1&per_page=100"),
+  });
+  const materialName = (uuid: string) => {
+    const m = (materialsData?.materials || []).find((m: any) => m.uuid === uuid);
+    return m ? `${m.name}${m.measure_unit ? ` (${m.measure_unit})` : ""}` : uuid;
+  };
+
+  // orders / fulfillments / payments at this trip's stops
+  const { data: activity } = useQuery({
+    queryKey: ["/trip/", params?.uuid, "activity"],
+    queryFn: () => apiRequest(`/trip/${params?.uuid}/activity`),
+    enabled: !!params?.uuid,
+  });
+  const [activityTab, setActivityTab] = useState("orders");
+  const [activityPage, setActivityPage] = useState(0);
+  const PAGE_SIZE = 5;
+  const activityRows: any[] =
+    activityTab === "orders" ? activity?.orders || []
+    : activityTab === "fulfillments" ? activity?.fulfillments || []
+    : activity?.payments || [];
+  const pageRows = activityRows.slice(activityPage * PAGE_SIZE, (activityPage + 1) * PAGE_SIZE);
+  const pageCount = Math.max(1, Math.ceil(activityRows.length / PAGE_SIZE));
 
   const updateTripMutation = useMutation({
     mutationFn: async (data: { notes?: string }) => {
@@ -278,6 +306,220 @@ export default function TripDetail() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Expected cash collected at this trip's stops */}
+        <Card className="mt-6">
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Banknote className="h-5 w-5 text-gray-600" />
+              <CardTitle>Expected Cash</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {trip.expected_cash && Object.keys(trip.expected_cash).length > 0 ? (
+              <div className="flex flex-wrap gap-3">
+                {Object.entries(trip.expected_cash).map(([cur, amt]) => (
+                  <div key={cur} className="border rounded-md px-4 py-2" data-testid={`expected-cash-${cur}`}>
+                    <div className="text-xs text-gray-500">{cur}</div>
+                    <div className="text-lg font-semibold">{Number(amt).toFixed(2)}</div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500" data-testid="expected-cash-empty">No cash collected on this trip yet.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Start/end inventory + reconciliation */}
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Trip Inventory</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {trip.inventory_reconciliation && Object.keys(trip.inventory_reconciliation).length > 0 ? (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm" data-testid="table-trip-inventory">
+                  <thead>
+                    <tr className="text-left text-gray-500 border-b">
+                      <th className="py-2 pr-4 font-medium">Material</th>
+                      <th className="py-2 pr-4 font-medium text-right">Start</th>
+                      <th className="py-2 pr-4 font-medium text-right">Sold</th>
+                      <th className="py-2 pr-4 font-medium text-right">Expected End</th>
+                      <th className="py-2 pr-4 font-medium text-right">End</th>
+                      <th className="py-2 font-medium text-right">Variance</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {Object.entries(trip.inventory_reconciliation).map(([mu, r]) => (
+                      <tr key={mu} className="border-b last:border-0">
+                        <td className="py-2 pr-4">{materialName(mu)}</td>
+                        <td className="py-2 pr-4 text-right">{r.start}</td>
+                        <td className="py-2 pr-4 text-right">{r.sold}</td>
+                        <td className="py-2 pr-4 text-right">{r.expected_end}</td>
+                        <td className="py-2 pr-4 text-right">{r.actual_end ?? "—"}</td>
+                        <td className="py-2 text-right">
+                          {r.variance === null || r.variance === undefined ? (
+                            <span className="text-gray-400">—</span>
+                          ) : (
+                            <Badge variant={r.variance === 0 ? "secondary" : "destructive"}>
+                              {r.variance > 0 ? `+${r.variance}` : r.variance}
+                            </Badge>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                {!trip.end_inventory || Object.keys(trip.end_inventory).length === 0 ? (
+                  <p className="text-xs text-gray-500 mt-2">
+                    End inventory not snapshotted yet — End and Variance fill in when the trip completes.
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <p className="text-sm text-gray-500" data-testid="trip-inventory-empty">No inventory snapshot for this trip.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Vehicle inventory over the trip window */}
+        <div className="mt-6">
+          <VehicleInventoryChart
+            vehicleUuid={trip.vehicle_uuid}
+            windowStart={trip.start_time || trip.created_at}
+            windowEnd={trip.end_time}
+            title="Vehicle Inventory During Trip"
+          />
+        </div>
+
+        {/* Orders / fulfillments / payments at this trip's stops */}
+        <Card className="mt-6">
+          <CardHeader>
+            <CardTitle>Trip Activity</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Tabs
+              value={activityTab}
+              onValueChange={(v) => { setActivityTab(v); setActivityPage(0); }}
+            >
+              <TabsList data-testid="tabs-trip-activity">
+                <TabsTrigger value="orders" data-testid="tab-orders">
+                  Orders ({activity?.orders?.length ?? 0})
+                </TabsTrigger>
+                <TabsTrigger value="fulfillments" data-testid="tab-fulfillments">
+                  Fulfilled ({activity?.fulfillments?.length ?? 0})
+                </TabsTrigger>
+                <TabsTrigger value="payments" data-testid="tab-payments">
+                  Paid ({activity?.payments?.length ?? 0})
+                </TabsTrigger>
+              </TabsList>
+
+              <div className="mt-4">
+                {pageRows.length === 0 ? (
+                  <p className="text-sm text-gray-500 py-6 text-center" data-testid="trip-activity-empty">
+                    Nothing here for this trip yet.
+                  </p>
+                ) : (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm" data-testid="table-trip-activity">
+                      <thead>
+                        <tr className="text-left text-gray-500 border-b">
+                          <th className="py-2 pr-4 font-medium">Date</th>
+                          <th className="py-2 pr-4 font-medium">Customer</th>
+                          {activityTab === "orders" && (
+                            <>
+                              <th className="py-2 pr-4 font-medium text-right">Total</th>
+                              <th className="py-2 font-medium">Status</th>
+                            </>
+                          )}
+                          {activityTab === "fulfillments" && (
+                            <>
+                              <th className="py-2 pr-4 font-medium">Material</th>
+                              <th className="py-2 font-medium text-right">Qty</th>
+                            </>
+                          )}
+                          {activityTab === "payments" && (
+                            <th className="py-2 font-medium text-right">Amount</th>
+                          )}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {pageRows.map((r: any, i: number) => (
+                          <tr
+                            key={i}
+                            className={cn(
+                              "border-b last:border-0",
+                              (r.uuid || r.customer_order_uuid) && "cursor-pointer hover:bg-gray-50"
+                            )}
+                            onClick={() => {
+                              const target = r.uuid || r.customer_order_uuid;
+                              if (target) setLocation(`/customer-orders/${target}`);
+                            }}
+                          >
+                            <td className="py-2 pr-4 whitespace-nowrap">{formatDateTime(r.created_at)}</td>
+                            <td className="py-2 pr-4">{r.customer_name || "—"}</td>
+                            {activityTab === "orders" && (
+                              <>
+                                <td className="py-2 pr-4 text-right">{r.total} {r.currency}</td>
+                                <td className="py-2">
+                                  <div className="flex gap-2">
+                                    <Badge variant={r.is_paid ? "secondary" : "destructive"}>
+                                      {r.is_paid ? "Paid" : "Unpaid"}
+                                    </Badge>
+                                    <Badge variant={r.is_fulfilled ? "secondary" : "outline"}>
+                                      {r.is_fulfilled ? "Fulfilled" : "Unfulfilled"}
+                                    </Badge>
+                                  </div>
+                                </td>
+                              </>
+                            )}
+                            {activityTab === "fulfillments" && (
+                              <>
+                                <td className="py-2 pr-4">{r.material_name}</td>
+                                <td className="py-2 text-right">{r.quantity}</td>
+                              </>
+                            )}
+                            {activityTab === "payments" && (
+                              <td className="py-2 text-right">{r.amount} {r.currency}</td>
+                            )}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+
+                {/* pagination */}
+                {activityRows.length > PAGE_SIZE && (
+                  <div className="flex items-center justify-end gap-3 mt-3">
+                    <span className="text-xs text-gray-500" data-testid="trip-activity-page-info">
+                      {activityPage * PAGE_SIZE + 1}–{Math.min((activityPage + 1) * PAGE_SIZE, activityRows.length)} of {activityRows.length}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setActivityPage((p) => Math.max(0, p - 1))}
+                      disabled={activityPage === 0}
+                      data-testid="button-activity-prev"
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setActivityPage((p) => Math.min(pageCount - 1, p + 1))}
+                      disabled={activityPage >= pageCount - 1}
+                      data-testid="button-activity-next"
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </Tabs>
+          </CardContent>
+        </Card>
 
         {/* Notes Section */}
         <Card className="mt-6">

--- a/frontend/client/src/pages/TripDetail.tsx
+++ b/frontend/client/src/pages/TripDetail.tsx
@@ -15,6 +15,8 @@ import { toast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import type { Trip } from "@/lib/types";
 import { VehicleInventoryChart } from "@/components/vehicles/VehicleInventoryChart";
+import { TripStopsMap } from "@/components/map/TripStopsMap";
+import { Table as TableIcon, Map as MapIcon } from "lucide-react";
 
 export default function TripDetail() {
   const params = useParams();
@@ -48,6 +50,13 @@ export default function TripDetail() {
   const [activityTab, setActivityTab] = useState("orders");
   const [activityPage, setActivityPage] = useState(0);
   const PAGE_SIZE = 5;
+
+  // trip stop customers: table (paginated) / animated map toggle
+  const [stopsView, setStopsView] = useState<"table" | "map">("table");
+  const [stopsPage, setStopsPage] = useState(0);
+  const stops: any[] = activity?.stops || [];
+  const stopsPageRows = stops.slice(stopsPage * PAGE_SIZE, (stopsPage + 1) * PAGE_SIZE);
+  const stopsPageCount = Math.max(1, Math.ceil(stops.length / PAGE_SIZE));
   const activityRows: any[] =
     activityTab === "orders" ? activity?.orders || []
     : activityTab === "fulfillments" ? activity?.fulfillments || []
@@ -392,6 +401,94 @@ export default function TripDetail() {
             title="Vehicle Inventory During Trip"
           />
         </div>
+
+        {/* Trip stop customers: sorted table / animated map */}
+        <Card className="mt-6">
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle>Trip Stops</CardTitle>
+              <div className="flex gap-2">
+                <Button
+                  variant={stopsView === "table" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setStopsView("table")}
+                  data-testid="button-stops-table"
+                >
+                  <TableIcon className="h-4 w-4 mr-2" /> Table
+                </Button>
+                <Button
+                  variant={stopsView === "map" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setStopsView("map")}
+                  data-testid="button-stops-map"
+                >
+                  <MapIcon className="h-4 w-4 mr-2" /> Map
+                </Button>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            {stops.length === 0 ? (
+              <p className="text-sm text-gray-500" data-testid="trip-stops-empty">No stops on this trip yet.</p>
+            ) : stopsView === "map" ? (
+              <TripStopsMap stops={stops} />
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm" data-testid="table-trip-stops">
+                  <thead>
+                    <tr className="text-left text-gray-500 border-b">
+                      <th className="py-2 pr-4 font-medium">#</th>
+                      <th className="py-2 pr-4 font-medium">Customer</th>
+                      <th className="py-2 pr-4 font-medium">Status</th>
+                      <th className="py-2 pr-4 font-medium">Outcome</th>
+                      <th className="py-2 font-medium">Completed</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {stopsPageRows.map((s: any, i: number) => (
+                      <tr key={s.uuid} className="border-b last:border-0">
+                        <td className="py-2 pr-4 text-gray-500">{stopsPage * PAGE_SIZE + i + 1}</td>
+                        <td className="py-2 pr-4">{s.customer_name || "—"}</td>
+                        <td className="py-2 pr-4">
+                          <Badge variant={s.status === "completed" ? "secondary" : "outline"}>
+                            {s.status || "—"}
+                          </Badge>
+                        </td>
+                        <td className="py-2 pr-4 max-w-[240px] truncate">{s.outcome || "—"}</td>
+                        <td className="py-2 whitespace-nowrap">{s.completed_at ? formatDateTime(s.completed_at) : "—"}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                {stops.length > PAGE_SIZE && (
+                  <div className="flex items-center justify-end gap-3 mt-3">
+                    <span className="text-xs text-gray-500" data-testid="trip-stops-page-info">
+                      {stopsPage * PAGE_SIZE + 1}–{Math.min((stopsPage + 1) * PAGE_SIZE, stops.length)} of {stops.length}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setStopsPage((p) => Math.max(0, p - 1))}
+                      disabled={stopsPage === 0}
+                      data-testid="button-stops-prev"
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setStopsPage((p) => Math.min(stopsPageCount - 1, p + 1))}
+                      disabled={stopsPage >= stopsPageCount - 1}
+                      data-testid="button-stops-next"
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
 
         {/* Orders / fulfillments / payments at this trip's stops */}
         <Card className="mt-6">

--- a/frontend/client/src/pages/WorkflowExecutionDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { useRoute, Link } from "wouter";
+import { useRoute, useLocation, Link } from "wouter";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -53,6 +53,7 @@ import { WorkflowExecutionStatusLabels } from "@/types/workflowExecution";
 export default function WorkflowExecutionDetail() {
   const [, params] = useRoute("/workflow-execution/:uuid");
   const workflowUuid = params?.uuid || "";
+  const [, setLocation] = useLocation();
   const { toast } = useToast();
 
   const [filters, setFilters] = useState({
@@ -115,13 +116,17 @@ export default function WorkflowExecutionDetail() {
         body: payload,
       });
     },
-    onSuccess: () => {
+    onSuccess: (created: any) => {
       queryClient.invalidateQueries({ queryKey: ["/workflow-execution/"] });
       setShowExecuteDialog(false);
       toast({
         title: "Execution started",
         description: "Workflow execution has been initiated successfully.",
       });
+      // route straight to the new execution's detail page
+      if (created?.uuid) {
+        setLocation(`/workflow-execution/${workflowUuid}/${created.uuid}`);
+      }
     },
     onError: (error: any) => {
       toast({

--- a/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
@@ -43,6 +43,8 @@ import { AppLayout } from "@/components/layout/AppLayout";
 import { TaskExecutionProgress } from "@/components/TaskExecutionProgress";
 import { TripOperatorMap } from "@/components/map/TripOperatorMap";
 import { CustomerLocationMap } from "@/components/map/CustomerLocationMap";
+import { CreateOrderDialog } from "@/components/customer-orders/CreateOrderDialog";
+import { CustomerRecentOrders } from "@/components/customer-orders/CustomerRecentOrders";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import type { WorkflowExecution } from "@/types/workflowExecution";
@@ -674,6 +676,28 @@ export default function WorkflowExecutionTaskDetail() {
 
   const customerLocationData = getCustomerLocationData();
 
+  // Context for creating an order at a trip stop (customer + trip_stop from the task inputs)
+  const getTripStopOrderContext = () => {
+    if (!task || (task.operator !== "trip_stop" && task.operator !== "trip_stop_operator")) {
+      return null;
+    }
+    try {
+      let ti: any = task.taskInputs;
+      if (typeof ti === "string") ti = JSON.parse(ti);
+      const data = ti?.data;
+      const customer = data?.customer;
+      if (!customer?.uuid) return null;
+      return {
+        customerUuid: customer.uuid as string,
+        customerName: (customer.company_name || customer.full_name || customer.name) as string | undefined,
+        tripStopUuid: data?.trip_stop_uuid as string | undefined,
+      };
+    } catch {
+      return null;
+    }
+  };
+  const orderContext = getTripStopOrderContext();
+
   const renderFormField = (field: TaskInputField) => {
     const key = field.name;
 
@@ -1115,6 +1139,18 @@ export default function WorkflowExecutionTaskDetail() {
                         <CustomerLocationMap
                           coordinates={customerLocationData.coordinates}
                           customerName={customerLocationData.customerName}
+                        />
+                      </div>
+                    )}
+
+                    {/* Recent order history + create an order for this trip stop's customer */}
+                    {orderContext && (
+                      <div className="mb-6">
+                        <CustomerRecentOrders customerUuid={orderContext.customerUuid} />
+                        <CreateOrderDialog
+                          customerUuid={orderContext.customerUuid}
+                          customerName={orderContext.customerName}
+                          tripStopUuid={orderContext.tripStopUuid}
                         />
                       </div>
                     )}

--- a/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
@@ -1146,7 +1146,7 @@ export default function WorkflowExecutionTaskDetail() {
                     {/* Recent order history + create an order for this trip stop's customer */}
                     {orderContext && (
                       <div className="mb-6">
-                        <CustomerRecentOrders customerUuid={orderContext.customerUuid} />
+                        <CustomerRecentOrders customerUuid={orderContext.customerUuid} tripStopUuid={orderContext.tripStopUuid} />
                         <CreateOrderDialog
                           customerUuid={orderContext.customerUuid}
                           customerName={orderContext.customerName}

--- a/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
@@ -44,6 +44,7 @@ import { TaskExecutionProgress } from "@/components/TaskExecutionProgress";
 import { TripOperatorMap } from "@/components/map/TripOperatorMap";
 import { CustomerLocationMap } from "@/components/map/CustomerLocationMap";
 import { CreateOrderDialog } from "@/components/customer-orders/CreateOrderDialog";
+import { AddStopDialog } from "@/components/trips/AddStopDialog";
 import { CustomerRecentOrders } from "@/components/customer-orders/CustomerRecentOrders";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
@@ -145,15 +146,21 @@ export default function WorkflowExecutionTaskDetail() {
       let fieldSchema: z.ZodTypeAny;
       
       switch (field.type) {
-        case 'number':
-          fieldSchema = z.coerce.number();
+        case 'number': {
+          let numberSchema: z.ZodTypeAny = z.coerce.number();
           if (field.min !== undefined && field.min !== null) {
-            fieldSchema = (fieldSchema as z.ZodNumber).min(field.min);
+            numberSchema = (numberSchema as z.ZodNumber).min(field.min);
           }
           if (field.max !== undefined && field.max !== null) {
-            fieldSchema = (fieldSchema as z.ZodNumber).max(field.max);
+            numberSchema = (numberSchema as z.ZodNumber).max(field.max);
           }
+          // treat empty inputs as "not provided" instead of coercing "" to 0
+          fieldSchema = z.preprocess(
+            (v) => (v === "" || v === null || v === undefined ? undefined : v),
+            field.required ? numberSchema : numberSchema.optional()
+          );
           break;
+        }
         case 'email':
           fieldSchema = z.string().email();
           break;
@@ -698,6 +705,28 @@ export default function WorkflowExecutionTaskDetail() {
   };
   const orderContext = getTripStopOrderContext();
 
+  // manual-stops mode: when checked on the start_trip form, hide the routing inputs
+  const ROUTING_FIELD_NAMES = new Set([
+    "service_areas", "start_warehouse_name", "end_warehouse_name", "start_point", "end_point",
+    "customer_categories", "last_visit_threshold_days", "max_stops", "min_stops",
+  ]);
+  const manualStopsValue = form.watch("manual_stops" as any);
+  const manualStopsChecked =
+    task?.operator === "start_trip_operator" &&
+    Array.isArray(manualStopsValue) && manualStopsValue.length > 0;
+  const visibleTaskInputFields = manualStopsChecked
+    ? taskInputFields.filter((f) => !ROUTING_FIELD_NAMES.has(f.name))
+    : taskInputFields;
+
+  // ad-hoc stops can be added while the trip is underway (trip created, not yet finished)
+  const tripCreated = taskExecutions.some(
+    (te: any) => (te.operator || te.task?.operator) === "trip_create_operator" && te.status === "completed"
+  );
+  const tripFinished = taskExecutions.some(
+    (te: any) => (te.operator || te.task?.operator) === "trip_finish_operator" && te.status === "completed"
+  );
+  const canAddStop = tripCreated && !tripFinished;
+
   const renderFormField = (field: TaskInputField) => {
     const key = field.name;
 
@@ -1083,9 +1112,17 @@ export default function WorkflowExecutionTaskDetail() {
                 <CardHeader>
                   <div className="flex justify-between items-center">
                     <CardTitle>Task Execution Progress</CardTitle>
-                    <span className="text-sm text-gray-500">
-                      {Math.round(calculateProgress())}% Complete
-                    </span>
+                    <div className="flex items-center gap-3">
+                      {canAddStop && (
+                        <AddStopDialog
+                          workflowExecutionUuid={executionUuid}
+                          onCreated={(teUuid) => setSelectedTaskExecutionUuid(teUuid)}
+                        />
+                      )}
+                      <span className="text-sm text-gray-500">
+                        {Math.round(calculateProgress())}% Complete
+                      </span>
+                    </div>
                   </div>
                 </CardHeader>
                 <CardContent>
@@ -1157,8 +1194,8 @@ export default function WorkflowExecutionTaskDetail() {
 
                     <Form {...form}>
                       <form onSubmit={form.handleSubmit(handleTaskComplete)} className="space-y-6">
-                        {taskInputFields.length > 0 ? (
-                          taskInputFields.map((field) => renderFormField(field))
+                        {visibleTaskInputFields.length > 0 ? (
+                          visibleTaskInputFields.map((field) => renderFormField(field))
                         ) : (
                           <div className="text-center text-gray-500 py-4">
                             No input fields defined for this task.


### PR DESCRIPTION
## Summary
- **Payment & inventory → trip attribution**: payments and vehicle sale events are tagged with the trip stop where they happened; `expected_cash` (per currency) and `sold_inventory_map` now reflect cash/stock actually collected at the trip's stops, including previously-created orders handled mid-trip.
- **Trip detail page**: Expected Cash card, start/sold/end inventory reconciliation table, vehicle-inventory chart over the trip window (per-material filter), Trip Stops section (sorted table + animated map), Trip Activity tabs (orders / fulfilled / paid).
- **Manual-stops trip mode**: `manual_stops` flag on the simple trip workflow — only vehicle + assigned user required; driver adds stops ad hoc (existing customer or created on the spot), each spliced into the execution chain; explicit `finish_trip` task (both modes) snapshots end inventory and completes the trip.
- **Trip-stop UX**: one-submit order checkout, recent orders + balance panel, pay/fulfill modal with defaults, truck-at-trip-start material filter, unit display.

## Migrations
`d8f2c1a4b6e5` (payment.trip_stop_uuid) → `e9a3b5c7d1f6` (vehicle_inventory_event.trip_stop_uuid) → `f4b8d2e6a1c9` (data migration: manual_stops field on start_trip task definitions, idempotent).

## Test plan
- [x] Backend integration tests: expected_cash per currency incl. previous-order payments; sold inventory + reconciliation variance 0; routed flow regression (10 chained stops + finish task)
- [x] Preview E2E: manual trip end-to-end (setup → add stops → orders/payments → finish); chain enforcement (cannot finish with open stops, sequential unblocking)
- [ ] Verify on dev

⚠️ **Do not merge yet** — deploying to dev first for testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)