### PR TITLE
Security: JWT secret from environment, not source

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -51,6 +51,7 @@ jobs:
             APP_HOST=api-dev.karma-grp.com
             REGISTRY_URL=ghcr.io/albardn2/karma-backend
             EMAIL=zaid.bardan@gmail.com
+            JWT_SECRET_KEY=${{ secrets.DEV_JWT_SECRET_KEY }}
             EOF
             docker compose -f docker-compose.dev.yaml down
             docker compose -f docker-compose.dev.yaml pull

--- a/.github/workflows/migrate-dev.yml
+++ b/.github/workflows/migrate-dev.yml
@@ -39,6 +39,7 @@ jobs:
             APP_HOST=api-dev.karma-grp.com
             REGISTRY_URL=ghcr.io/albardn2/karma-backend
             EMAIL=zaid.bardan@gmail.com
+            JWT_SECRET_KEY=${{ secrets.DEV_JWT_SECRET_KEY }}
             EOF
             docker compose -f docker-compose.dev.yaml down
             docker compose -f docker-compose.dev.yaml pull

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -82,6 +82,7 @@ jobs:
             APP_HOST=${APP_HOST}
             REGISTRY_URL=${REGISTRY_URL}
             EMAIL=${EMAIL}
+            JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}
             EOF
             docker compose -f docker-compose.prod.yaml down
             docker compose -f docker-compose.prod.yaml pull
@@ -105,6 +106,7 @@ jobs:
             APP_HOST=api-prod.karma-grp.com
             REGISTRY_URL=ghcr.io/albardn2/karma-backend
             EMAIL=zaid.bardan@gmail.com
+            JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}
             EOF
             docker compose -f docker-compose.prod.yaml down
             docker compose -f docker-compose.prod.yaml pull

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -59,7 +59,13 @@ def create_app(config_object=Config):
     env_config = dotenv_values(os.path.join(BASE_DIR,"..", ".env"))
     app.config.from_mapping(env_config)
 
-    app.config['JWT_SECRET_KEY'] = "super-secret-change-me"
+    # the JWT signing secret must come from the environment (or the .env file
+    # loaded above) — never from source. Refuse to boot without it so a
+    # misconfigured deploy fails loudly instead of signing forgeable tokens.
+    jwt_secret = os.environ.get("JWT_SECRET_KEY") or app.config.get("JWT_SECRET_KEY")
+    if not jwt_secret:
+        raise RuntimeError("JWT_SECRET_KEY environment variable must be set")
+    app.config['JWT_SECRET_KEY'] = jwt_secret
     # accept tokens from both headers and cookies
     app.config['JWT_TOKEN_LOCATION'] = ["headers", "cookies"]
     app.config['JWT_COOKIE_SECURE']   = False     # only over HTTPS in prod

--- a/backend/docker-compose.dev.yaml
+++ b/backend/docker-compose.dev.yaml
@@ -42,6 +42,9 @@ services:
       - "5000"
     environment:
       SQLALCHEMY_DATABASE_URI: "postgresql://local:local@db:5432/backend"
+      # JWT signing secret; comes from the droplet-side .env written by the
+      # deploy workflow (sourced from GitHub secrets)
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
     networks:
       - proxy
 

--- a/backend/docker-compose.prod.yaml
+++ b/backend/docker-compose.prod.yaml
@@ -43,6 +43,9 @@ services:
       - "5000:5000"
     environment:
       SQLALCHEMY_DATABASE_URI: "postgresql://local:local@db:5432/backend"
+      # JWT signing secret; comes from the droplet-side .env written by the
+      # deploy workflow (sourced from GitHub secrets)
+      JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       # Proxy & Let's Encrypt settings:
       VIRTUAL_HOST: ${APP_HOST}
       LETSENCRYPT_HOST: ${APP_HOST}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -55,6 +55,7 @@ services:
     command: ["gunicorn", "--bind", "0.0.0.0:5000", "--reload", "run:app"]
     environment:
       SQLALCHEMY_DATABASE_URI: "postgresql://local:local@db:5432/backend"
+      JWT_SECRET_KEY: "local-dev-only-not-a-secret"
     ports:
       - "5000:5000"
     depends_on:


### PR DESCRIPTION
The JWT signing secret was hardcoded in `app/__init__.py` in a public repo, allowing anyone to forge valid tokens for the deployed API.

- App reads `JWT_SECRET_KEY` from the environment and refuses to boot without it
- Deploy workflows inject it into the droplet `.env` from new GitHub secrets (`DEV_JWT_SECRET_KEY` / `PROD_JWT_SECRET_KEY`, already created)
- Compose files pass it to the web service; local compose uses a fixed local-only value
- Merging rotates the secret → all existing sessions are invalidated once (intended; the old value is public)

Verified locally: login works with the env secret; boot fails loudly without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)