### PR TITLE
Backend support for mobile app: auth refresh + execution filters

### DIFF
--- a/backend/app/dto/workflow_execution.py
+++ b/backend/app/dto/workflow_execution.py
@@ -70,6 +70,8 @@ class WorkflowExecutionListParams(BaseModel):
     name: Optional[str] = None  # Filter by workflow execution name
     status: Optional[WorkflowStatus] = None  # Filter by execution status (e.g., in_progress, completed)
     created_by_uuid: Optional[str] = None
+    # restrict to executions the caller created or is assigned to (start_trip assigned user)
+    mine: Optional[bool] = None
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None
     tags : Optional[List[WorkflowTags]] = None  # Filter by tags associated with the workflow execution

--- a/backend/app/entrypoint/routes/auth/routes.py
+++ b/backend/app/entrypoint/routes/auth/routes.py
@@ -77,6 +77,26 @@ def login():
         set_refresh_cookies(resp, refresh_token)
         return resp, 200
 
+@auth_blueprint.route("/refresh", methods=["POST"])
+@jwt_required(refresh=True)
+def refresh():
+    """Exchange a valid refresh token (header or cookie) for a new access
+    token, re-reading the user's scopes so permission changes take effect."""
+    current_uuid = get_jwt_identity()
+    with SqlAlchemyUnitOfWork() as uow:
+        user = uow.user_repository.find_one(uuid=current_uuid, is_deleted=False)
+        if not user:
+            raise Unauthorized("User not found")
+        scopes = user.permission_scope.split(",")
+        access_token = create_access_token(
+            identity=user.uuid,
+            additional_claims={"scopes": scopes},
+            expires_delta=timedelta(days=1)
+        )
+    resp = jsonify({"access_token": access_token})
+    set_access_cookies(resp, access_token)
+    return resp, 200
+
 @auth_blueprint.route("/logout", methods=["POST"])
 def logout():
     resp = jsonify({"msg": "Logged out"})

--- a/backend/app/entrypoint/routes/workflow_execution/routes.py
+++ b/backend/app/entrypoint/routes/workflow_execution/routes.py
@@ -240,6 +240,8 @@ def list_workflow_executions():
         filters.append(WorkflowExecutionModel.uuid == params.uuid)
     if params.workflow_uuid:
         filters.append(WorkflowExecutionModel.workflow_uuid == params.workflow_uuid)
+    if params.status:
+        filters.append(WorkflowExecutionModel.status == params.status.value)
     if params.name:
         filters.append(WorkflowExecutionModel.name.ilike(f"%{params.name}%"))
     if params.tags:
@@ -252,6 +254,33 @@ def list_workflow_executions():
     if params.end_time:
         filters.append(WorkflowExecutionModel.start_time <= params.end_time)
     with SqlAlchemyUnitOfWork() as uow:
+        if params.mine:
+            # executions the caller created, or trips assigned to them via the
+            # start_trip setup (result.assigned_user_uuid holds a username)
+            from sqlalchemy import or_, select
+            from models.common import TaskExecution as TaskExecutionModel
+            from models.common import Task as TaskModel
+
+            current_uuid = get_jwt_identity()
+            current_user = uow.user_repository.find_one(uuid=current_uuid, is_deleted=False)
+            assigned_values = [current_uuid]
+            if current_user:
+                assigned_values.append(current_user.username)
+            assigned_exists = (
+                select(TaskExecutionModel.uuid)
+                .join(TaskModel, TaskModel.uuid == TaskExecutionModel.task_uuid)
+                .where(
+                    TaskExecutionModel.workflow_execution_uuid == WorkflowExecutionModel.uuid,
+                    TaskModel.operator == "start_trip_operator",
+                    TaskExecutionModel.result["assigned_user_uuid"].astext.in_(assigned_values),
+                )
+                .exists()
+            )
+            filters.append(or_(
+                WorkflowExecutionModel.created_by_uuid == current_uuid,
+                assigned_exists,
+            ))
+
         page = uow.workflow_execution_repository.find_all_by_filters_paginated(
             filters=filters,
             page=params.page,


### PR DESCRIPTION
Backend-only changes needed by the mobile app (split out of the `mobile_app` branch so dev/prod get them now):

- **POST /auth/refresh** — exchange a valid refresh token for a new 1-day access token (re-reads scopes). Powers the mobile app's silent session renewal.
- **Workflow-execution list fixes** — the `status` param was accepted but never applied; now filters server-side. New `mine=true` param restricts results to executions the caller created or trips assigned to them (start_trip `assigned_user_uuid`, matched by username or uuid).

Verified locally: refresh round-trip (+ access-token rejected for refresh), status filter (completed→4/in_progress→28 vs 48 total), mine filter (created + assigned-only branches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)