### PR TITLE
Harden dev/prod deploys: GHCR login + prune before pull

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -53,6 +53,17 @@ jobs:
             EMAIL=zaid.bardan@gmail.com
             JWT_SECRET_KEY=${{ secrets.DEV_JWT_SECRET_KEY }}
             EOF
+            # Authenticate to GHCR so the private :latest-dev image can be pulled.
+            # Without this, the droplet's cached credentials expire and
+            # `compose pull` silently no-ops, leaving stale code running.
+            echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u albardn2 --password-stdin
+            # Reclaim disk before pulling. Old image layers + build cache pile up
+            # across deploys and fill the droplet, so `pull` fails with "no space
+            # left on device" and `up` silently re-runs the stale cached image.
+            # Prune while the current containers are still up so their in-use
+            # images are protected; named volumes (the DB) are never touched.
+            docker image prune -af
+            docker builder prune -af
             docker compose -f docker-compose.dev.yaml down
             docker compose -f docker-compose.dev.yaml pull
             docker compose -f docker-compose.dev.yaml up -d --scale migrate=0 --remove-orphans

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -84,6 +84,12 @@ jobs:
             EMAIL=${EMAIL}
             JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}
             EOF
+            # Auth to GHCR + reclaim disk before pulling the private image.
+            # Without this, expired creds or a full disk make `pull` silently
+            # no-op and stale code keeps running despite a "successful" deploy.
+            echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u albardn2 --password-stdin
+            docker image prune -af
+            docker builder prune -af
             docker compose -f docker-compose.prod.yaml down
             docker compose -f docker-compose.prod.yaml pull
             docker compose -f docker-compose.prod.yaml run --rm migrate
@@ -108,6 +114,12 @@ jobs:
             EMAIL=zaid.bardan@gmail.com
             JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}
             EOF
+            # Auth to GHCR + reclaim disk before pulling the private image.
+            # Without this, expired creds or a full disk make `pull` silently
+            # no-op and stale code keeps running despite a "successful" deploy.
+            echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u albardn2 --password-stdin
+            docker image prune -af
+            docker builder prune -af
             docker compose -f docker-compose.prod.yaml down
             docker compose -f docker-compose.prod.yaml pull
             docker compose -f docker-compose.prod.yaml up -d --scale migrate=0 --remove-orphans


### PR DESCRIPTION
## Problem
Deploys report success but can silently run **stale code**. Root cause found while debugging why dev kept rejecting the new `assigned_user_uuid` trip filter after PR #20 merged:

- The dev droplet's cached GHCR credentials expire → `docker compose pull` can't fetch the **private** image.
- The droplet disk fills with old image layers → `pull` fails with `no space left on device` (dev had **14.87 GB** of reclaimable layers).
- In both cases `up` falls back to the locally-cached image, and the SSH step still exits 0 → the GitHub deploy shows ✅.

Net effect: dev ran the PR #19 image for a day after PR #20 deployed. Prod uses the same deploy pattern and is likely affected too.

## Fix
Before every `docker compose pull` (dev deploy + prod migrate & deploy scripts):
- `docker login ghcr.io -u albardn2` using `CR_PAT`
- `docker image prune -af` + `docker builder prune -af`

Pruning runs while the current containers are up (their in-use images are protected) and never touches named volumes, so the Postgres data is safe.

## Verification (dev)
After applying to dev and redeploying: prune reclaimed 14.87 GB, layers pulled clean, and `GET /workflow-execution/?assigned_user_uuid=…` now returns **200** and correctly narrows results (admin-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)