### PR TITLE
Fix cancel_trip 500 (TripModel.CANCELLED → TripStatus.CANCELLED)

### DIFF
--- a/backend/app/domains/trip/domain.py
+++ b/backend/app/domains/trip/domain.py
@@ -41,12 +41,12 @@ class TripDomain:
         if trip.status in [TripStatus.COMPLETED.value, TripStatus.CANCELLED.value]:
             raise BadRequestError("Cannot cancel a completed or already cancelled trip")
 
-        trip.status = TripModel.CANCELLED.value
+        trip.status = TripStatus.CANCELLED.value
         trip.end_time = datetime.now()
 
         trip_stops = trip.stops
         for stop in trip_stops:
-            if stop.status not in [TripStopStatus.COMPLETED, TripStopStatus.CANCELLED]:
+            if stop.status not in [TripStopStatus.COMPLETED.value, TripStopStatus.CANCELLED.value]:
                 stop.status = TripStopStatus.CANCELLED.value
         uow.trip_repository.save(model=trip, commit=False)
         return TripRead.from_orm(trip)


### PR DESCRIPTION
`WorkflowExecutionDomain.cancel_workflow_execution` → `TripDomain.cancel_trip` set `trip.status = TripModel.CANCELLED.value`, but the SQLAlchemy `Trip` model has no `CANCELLED` attribute → `AttributeError` → **HTTP 500** whenever a workflow execution that has a trip is cancelled. Only pre-trip executions could be cancelled.

Fixes:
- `TripModel.CANCELLED.value` → `TripStatus.CANCELLED.value`.
- Stop-status guard compared a string column to enum *members* (`TripStopStatus.COMPLETED`) so it never matched — every stop, including completed ones, was set to cancelled. Compare against `.value`.

Found while bulk-cancelling in-progress trips on dev (5/17 succeeded, 12 500'd; the failures rolled back cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)