### PR TITLE
Trips: one in-progress trip per user + unique assignee identifier

### DIFF
--- a/backend/app/domains/task_execution/workflow_operators/start_trip_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/start_trip_operator.py
@@ -71,6 +71,46 @@ class StartTripOperator(OperatorInterface):
         if not task_exe:
             raise BadRequestError(f"TaskExecution not found with uuid: {payload.uuid}")
 
+        # A user may be assigned to at most one in-progress trip at a time. Block
+        # starting this trip if the assignee already has another in-progress trip
+        # assigned to them (their start_trip result.assigned_user_uuid matches).
+        if operator_schema.assigned_user_uuid:
+            from models.common import (
+                WorkflowExecution as WFEModel,
+                TaskExecution as TEModel,
+                Task as TaskModel,
+            )
+            # the assignee is chosen by username (or uuid); resolve to a real
+            # user so we key the check off a UNIQUE identity — never fall back to
+            # matching a non-unique raw string (e.g. a first name).
+            assignee = (
+                uow.user_repository.find_one(uuid=operator_schema.assigned_user_uuid, is_deleted=False)
+                or uow.user_repository.find_one(username=operator_schema.assigned_user_uuid, is_deleted=False)
+            )
+            if not assignee:
+                raise BadRequestError(
+                    f"Assigned user '{operator_schema.assigned_user_uuid}' was not found"
+                )
+            # assignment is stored as either the username or the uuid — match both
+            values = [assignee.uuid, assignee.username]
+            existing = (
+                uow.session.query(WFEModel.uuid)
+                .join(TEModel, TEModel.workflow_execution_uuid == WFEModel.uuid)
+                .join(TaskModel, TaskModel.uuid == TEModel.task_uuid)
+                .filter(
+                    WFEModel.status == WorkflowStatus.IN_PROGRESS.value,
+                    WFEModel.uuid != task_exe.workflow_execution_uuid,
+                    TaskModel.operator == "start_trip_operator",
+                    TEModel.result["assigned_user_uuid"].astext.in_(values),
+                )
+                .first()
+            )
+            if existing:
+                raise BadRequestError(
+                    "This user already has a trip in progress; finish or cancel it "
+                    "before assigning another."
+                )
+
         task_exe.result = operator_schema.model_dump(mode="json")
         task_exe.status = WorkflowStatus.COMPLETED.value
         task_exe.end_time = datetime.now()

--- a/backend/app/dto/task.py
+++ b/backend/app/dto/task.py
@@ -101,7 +101,10 @@ class TaskRead(TaskBase):
                     f.options = [sa.name for sa in service_areas]
                 if f.label == "assigned_user_uuid":
                     users = uow.user_repository.find_all(is_deleted=False)
-                    f.options = [user.first_name for user in users]
+                    # username is unique; first_name is not, and the assignment
+                    # must key off a unique identifier (see the start_trip guard
+                    # and owned_or_assigned_filter, which match on uuid/username).
+                    f.options = [user.username for user in users]
                 if f.label == "customer_categories":
                     categories = [category.value for category in CustomerCategory]
                     f.options = categories


### PR DESCRIPTION
Enforces **at most one in-progress trip per assigned user**: `StartTripOperator.execute` blocks completing `start_trip` if the assignee already has another in-progress trip assigned to them (matched via a `start_trip_operator` task_execution whose `result.assigned_user_uuid` is the user's uuid/username, excluding the trip being started).

**Root-cause fix (found in review):** the Start Trip assignee dropdown was populated with `first_name`, which is **not unique** (e.g. users `zaid` and `zaiddd` both have first name "zaid"). That made the limit unenforceable and was silently **mis-attributing trips in the existing assigned-user filter**. Switched the options to `username` (unique). The guard resolves the assignee to a real user and rejects unresolvable input rather than matching a non-unique string.

**Known limitation (documented):** the check is a SELECT with no DB constraint, so two *simultaneous* start_trip completions for the same user could both pass (TOCTOU). Not addressed here — low practical risk (assignments are sequential); a race-free fix needs a DB-level constraint.

Verified on dev (see PR discussion / testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)