### PR TITLE
Trip map: draw picked service-area boundaries

### DIFF
--- a/expo_app/app/distribution/[uuid].tsx
+++ b/expo_app/app/distribution/[uuid].tsx
@@ -13,8 +13,9 @@ import { ThemedView } from '@/components/ThemedView';
 import { Stack, useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 import { NativeHeader } from '@/components/layout/NativeHeader';
 import { apiCall } from '@/utils/api';
-import { TripMap, TripMapStop } from '@/components/TripMap';
+import { TripMap, TripMapArea, TripMapStop } from '@/components/TripMap';
 import { StopsSheet } from '@/components/StopsSheet';
+import { parseWktPolygons } from '@/utils/wkt';
 
 interface TaskExecution {
   uuid: string;
@@ -163,6 +164,8 @@ export default function ExecutionDetailScreen() {
   // shared "Set current" armed selection (map pin tap or list long-press);
   // lifted here so a tap elsewhere on either surface dismisses it.
   const [armedStopUuid, setArmedStopUuid] = useState<string | null>(null);
+  // service areas picked in the trip setup, drawn on the map as boundaries
+  const [serviceAreas, setServiceAreas] = useState<TripMapArea[]>([]);
 
   useFocusEffect(React.useCallback(() => { setRefreshKey((k) => k + 1); }, []));
 
@@ -205,6 +208,34 @@ export default function ExecutionDetailScreen() {
     () => (execution?.task_executions || []).find((t) => t.operator === 'trip_finish_operator') || null,
     [execution]
   );
+
+  // service areas picked in the start_trip setup (names from its result)
+  const pickedAreaNames = useMemo(() => {
+    const setup = (execution?.task_executions || []).find((t) => t.operator === 'start_trip_operator');
+    const names = setup?.result?.service_areas;
+    return Array.isArray(names) ? (names as string[]).filter(Boolean) : [];
+  }, [execution]);
+  const pickedAreaSignature = pickedAreaNames.join('|');
+
+  // load the picked areas' geometries once the map view is active
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!tripPhase || pickedAreaNames.length === 0) { setServiceAreas([]); return; }
+      const res = await apiCall<{ items: { uuid: string; name: string; geometry?: string | null }[] }>(
+        '/service-area/?per_page=100'
+      );
+      if (cancelled) return;
+      const wanted = new Set(pickedAreaNames);
+      const areas = (res.data?.items || [])
+        .filter((sa) => wanted.has(sa.name))
+        .map((sa) => ({ uuid: sa.uuid, name: sa.name, polygons: parseWktPolygons(sa.geometry || '') }))
+        .filter((a) => a.polygons.length > 0);
+      setServiceAreas(areas);
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tripPhase, pickedAreaSignature]);
 
   // stop tasks + a stable signature so the per-stop fetch only re-runs when the
   // set of stops or their statuses actually change (not on every focus refresh)
@@ -403,6 +434,7 @@ export default function ExecutionDetailScreen() {
             armedStopUuid={armedStopUuid}
             onArm={setArmedStopUuid}
             onSetCurrent={setCurrentStop}
+            areas={serviceAreas}
           />
           {stopsLoading && (
             <View style={styles.stopsLoading}><ActivityIndicator color="#5469D4" /></View>

--- a/expo_app/app/distribution/start.tsx
+++ b/expo_app/app/distribution/start.tsx
@@ -18,9 +18,10 @@ import { useAuth } from '@/contexts/AuthContext';
 
 const TRIP_WORKFLOW_NAME = 'simple_trip_workflow';
 
-// routing-only fields; hidden when manual_stops is on (backend validates per mode)
+// routing-only fields; hidden when manual_stops is on (backend validates per
+// mode). service_areas intentionally NOT here: it also shows in manual mode
+// (optional) so the trip map can draw the picked areas' boundaries.
 const ROUTING_FIELDS = new Set([
-  'service_areas',
   'start_warehouse_name',
   'end_warehouse_name',
   'start_point',

--- a/expo_app/components/TripMap.tsx
+++ b/expo_app/components/TripMap.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import MapView, { Marker, PROVIDER_GOOGLE, Region } from 'react-native-maps';
+import MapView, { Marker, Polygon, PROVIDER_GOOGLE, Region } from 'react-native-maps';
+import type { PolygonRings } from '@/utils/wkt';
 
 export interface TripMapStop {
   taskExecutionUuid: string;
@@ -10,6 +11,13 @@ export interface TripMapStop {
   lat: number | null;
   lng: number | null;
   index: number;
+}
+
+// a service area drawn as translucent polygon(s) under the stop pins
+export interface TripMapArea {
+  uuid: string;
+  name: string;
+  polygons: PolygonRings[];
 }
 
 const statusColor = (status: string, isCurrent: boolean) => {
@@ -34,6 +42,7 @@ export function TripMap({
   armedStopUuid = null,
   onArm,
   onSetCurrent,
+  areas = [],
 }: {
   stops: TripMapStop[];
   currentStopUuid: string | null;
@@ -41,6 +50,7 @@ export function TripMap({
   armedStopUuid?: string | null;
   onArm?: (uuid: string | null) => void;
   onSetCurrent?: (stop: TripMapStop) => void;
+  areas?: TripMapArea[];
 }) {
   const mapRef = useRef<MapView>(null);
   const [ready, setReady] = useState(false);
@@ -89,8 +99,14 @@ export function TripMap({
         pinned.map((s) => ({ latitude: s.lat as number, longitude: s.lng as number })),
         { edgePadding: { top: 90, right: 80, bottom: 280, left: 80 }, animated: true }
       );
+    } else if (areas.length > 0) {
+      // no stops yet (fresh manual trip) — frame the picked service areas
+      mapRef.current.fitToCoordinates(
+        areas.flatMap((a) => a.polygons.flatMap((p) => p.coordinates)),
+        { edgePadding: { top: 90, right: 80, bottom: 280, left: 80 }, animated: true }
+      );
     }
-  }, [ready, current?.tripStopUuid, current?.lat, current?.lng, pinned.length]);
+  }, [ready, current?.tripStopUuid, current?.lat, current?.lng, pinned.length, areas.length]);
 
   return (
     <View style={StyleSheet.absoluteFill}>
@@ -110,6 +126,21 @@ export function TripMap({
         showsMyLocationButton
         loadingEnabled
       >
+        {/* picked service-area boundaries, under the stop pins */}
+        {areas.map((a) =>
+          a.polygons.map((p, i) => (
+            <Polygon
+              key={`${a.uuid}:${i}`}
+              coordinates={p.coordinates}
+              holes={p.holes.length ? p.holes : undefined}
+              fillColor="rgba(84,105,212,0.16)"
+              strokeColor="rgba(84,105,212,0.85)"
+              strokeWidth={2}
+              tappable={false}
+            />
+          ))
+        )}
+
         {pinned.map((s) => {
           const isCurrent = s.tripStopUuid === currentStopUuid;
           return (

--- a/expo_app/components/TripMap.web.tsx
+++ b/expo_app/components/TripMap.web.tsx
@@ -22,6 +22,7 @@ export function TripMap({ stops, currentStopUuid }: {
   armedStopUuid?: string | null;
   onArm?: (uuid: string | null) => void;
   onSetCurrent?: (stop: TripMapStop) => void;
+  areas?: { uuid: string; name: string; polygons: unknown[] }[];
 }) {
   const current = stops.find((s) => s.tripStopUuid === currentStopUuid);
   const pinned = stops.filter((s) => s.lat != null && s.lng != null);

--- a/expo_app/utils/wkt.ts
+++ b/expo_app/utils/wkt.ts
@@ -1,0 +1,69 @@
+// Minimal WKT parser for service-area geometries.
+// Backend stores service areas as WKT POLYGON (MULTIPOLYGON tolerated), with
+// coordinates in standard WKT "x y" = "lon lat" order.
+
+export interface LatLng {
+  latitude: number;
+  longitude: number;
+}
+
+export interface PolygonRings {
+  /** outer ring */
+  coordinates: LatLng[];
+  /** inner rings (holes), if any */
+  holes: LatLng[][];
+}
+
+const parseRing = (txt: string): LatLng[] =>
+  txt
+    .split(',')
+    .map((pair) => {
+      const [x, y] = pair.trim().split(/\s+/).map(Number);
+      return { latitude: y, longitude: x };
+    })
+    .filter((p) => Number.isFinite(p.latitude) && Number.isFinite(p.longitude));
+
+/**
+ * Parse a WKT POLYGON or MULTIPOLYGON into polygon ring sets usable by
+ * react-native-maps' <Polygon>. Returns [] for anything else.
+ */
+export function parseWktPolygons(wkt: string): PolygonRings[] {
+  if (!wkt) return [];
+  const upper = wkt.trim().toUpperCase();
+  const isMulti = upper.startsWith('MULTIPOLYGON');
+  const isPoly = !isMulti && upper.startsWith('POLYGON');
+  if (!isMulti && !isPoly) return [];
+
+  // Walk the string tracking paren depth: a polygon group opens at `polyDepth`
+  // and each of its rings one level deeper. POLYGON ((r1),(r2)) → polyDepth 1;
+  // MULTIPOLYGON (((r1)),((r2))) → polyDepth 2.
+  const polyDepth = isMulti ? 2 : 1;
+  const polys: LatLng[][][] = [];
+  let current: LatLng[][] | null = null;
+  let ringStart = -1;
+  let depth = 0;
+  for (let i = 0; i < wkt.length; i++) {
+    const c = wkt[i];
+    if (c === '(') {
+      depth++;
+      if (depth === polyDepth) current = [];
+      else if (depth === polyDepth + 1) ringStart = i + 1;
+    } else if (c === ')') {
+      if (depth === polyDepth + 1 && ringStart >= 0 && current) {
+        current.push(parseRing(wkt.slice(ringStart, i)));
+        ringStart = -1;
+      } else if (depth === polyDepth && current) {
+        polys.push(current);
+        current = null;
+      }
+      depth--;
+    }
+  }
+
+  return polys
+    .map((rings) => ({
+      coordinates: rings[0] || [],
+      holes: rings.slice(1).filter((r) => r.length >= 3),
+    }))
+    .filter((p) => p.coordinates.length >= 3);
+}


### PR DESCRIPTION
When the trip setup has service areas picked, the trip-stop map now renders each picked area as a translucent polygon with a visible boundary, underneath the stop pins. On a fresh manual trip with no stops yet, the map frames the picked areas instead of the default region.

The **service_areas checklist now also shows in manual-stops mode** (optional there; still required for routed trips) so ad-hoc trips get boundaries too — the backend already accepted and stored it.

Adds `utils/wkt.ts`, a small WKT POLYGON/MULTIPOLYGON parser (backend serves service-area geometry as WKT, lon/lat order).

## E2E verification (dev + iOS simulator)
- Trip with `['malki','DISTRIBUTION 2']` → renders malki's exact 7-vertex shape (compared against a plot of the raw WKT)
- **Isolation control**: trip with only `DISTRIBUTION 2` → map auto-zooms to it, renders its C-shape vertex-for-vertex, malki absent — only picked areas draw
- **Negative control**: trip with no areas → no polygons
- Manual-mode Start Trip form renders the Service areas checklist; routing-only fields stay hidden
- Parser unit-tested with real dev WKTs + synthetic MULTIPOLYGON-with-holes + garbage input

🤖 Generated with [Claude Code](https://claude.com/claude-code)