### PR TITLE
Menu: sales/driver-only users see just Distribution

### DIFF
--- a/expo_app/app/(tabs)/index.tsx
+++ b/expo_app/app/(tabs)/index.tsx
@@ -18,6 +18,37 @@ interface MenuItem {
   color: string;
 }
 
+const ALL_MENU_ITEMS: MenuItem[] = [
+  {
+    id: 1,
+    title: 'Customers',
+    description: 'Manage customer information and relationships',
+    icon: '👥',
+    section: 'customers',
+    color: '#5469D4',
+  },
+  {
+    id: 2,
+    title: 'Customer Orders',
+    description: 'Track and manage customer orders',
+    icon: '📋',
+    section: 'customer_orders',
+    color: '#e74c3c',
+  },
+  {
+    id: 3,
+    title: 'Distribution',
+    description: 'Trip executions and deliveries',
+    icon: '🚚',
+    section: 'distribution',
+    color: '#16a34a',
+  },
+];
+
+// field crews (sales/drivers with no other role) only work the trip flow —
+// their menu shows Distribution alone
+const FIELD_ROLES = new Set(['sales', 'driver']);
+
 export default function HomeScreen() {
   const { user, logout } = useAuth();
   const router = useRouter();
@@ -26,32 +57,16 @@ export default function HomeScreen() {
   const [activeTab, setActiveTab] = useState<'home' | 'menu'>(tab === 'menu' ? 'menu' : 'home');
   const insets = useSafeAreaInsets();
 
-  const menuItems: MenuItem[] = [
-    {
-      id: 1,
-      title: 'Customers',
-      description: 'Manage customer information and relationships',
-      icon: '👥',
-      section: 'customers',
-      color: '#5469D4',
-    },
-    {
-      id: 2,
-      title: 'Customer Orders',
-      description: 'Track and manage customer orders',
-      icon: '📋',
-      section: 'customer_orders',
-      color: '#e74c3c',
-    },
-    {
-      id: 3,
-      title: 'Distribution',
-      description: 'Trip executions and deliveries',
-      icon: '🚚',
-      section: 'distribution',
-      color: '#16a34a',
-    },
-  ];
+  const menuItems: MenuItem[] = useMemo(() => {
+    const scopes: string[] = (user?.permission_scope || '')
+      .split(',')
+      .map((s: string) => s.trim())
+      .filter(Boolean);
+    const fieldOnly = scopes.length > 0 && scopes.every((s) => FIELD_ROLES.has(s));
+    return fieldOnly
+      ? ALL_MENU_ITEMS.filter((i) => i.section === 'distribution')
+      : ALL_MENU_ITEMS;
+  }, [user?.permission_scope]);
 
   const handleLogout = () => {
     Alert.alert(


### PR DESCRIPTION
Users whose roles are all within `{sales, driver}` now get a menu showing only the **Distribution** module — Customers and Customer Orders are hidden. Anyone holding any other role (admin, superuser, operation_manager, operator, accountant) keeps the full menu, so mixed roles like driver+admin still see everything.

Roles come from the comma-separated `permission_scope` on `/auth/me` (same derivation the Distribution screen already uses).

## Verified (iOS simulator)
- Admin user (`zaid`) → all 3 modules render unchanged
- Simulated `driver` scope through the real filter path → only Distribution renders

expo_app-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)