### PR TITLE
Mobile app CI/CD: EAS build + store submit workflows

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -131,7 +131,6 @@ jobs:
 
       - name: Submit iOS to TestFlight
         env:
-          ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -1,8 +1,9 @@
 name: CI – Build Mobile Apps (TestFlight & Play Internal)
 
 # Builds run on EAS. Triggered by:
-#  - a commit message starting with [build_apps] on any branch, or
-#  - manual dispatch (choose which targets to build).
+#  - a commit message starting with [build_apps] on any branch
+#    ([build_apps:ios] / [build_apps:android] to build one platform), or
+#  - manual dispatch (choose targets + platform).
 on:
   push:
     branches:
@@ -18,6 +19,15 @@ on:
           - all
           - stores-only
           - preview-only
+      platforms:
+        description: 'Which platforms to build'
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - ios
+          - android
 
 jobs:
   check-trigger:
@@ -25,6 +35,8 @@ jobs:
     outputs:
       build_preview: ${{ steps.check.outputs.build_preview }}
       build_stores: ${{ steps.check.outputs.build_stores }}
+      ios: ${{ steps.check.outputs.ios }}
+      android: ${{ steps.check.outputs.android }}
     steps:
       - name: Decide what to build
         id: check
@@ -33,22 +45,28 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TARGETS="${{ github.event.inputs.targets }}"
+            PLATFORMS="${{ github.event.inputs.platforms }}"
             [[ "$TARGETS" == "all" || "$TARGETS" == "preview-only" ]] && PREVIEW=true || PREVIEW=false
             [[ "$TARGETS" == "all" || "$TARGETS" == "stores-only" ]] && STORES=true || STORES=false
           else
+            PREVIEW=false; STORES=false; PLATFORMS=all
             if [[ "$COMMIT_MSG" == \[build_apps\]* ]]; then
               PREVIEW=true; STORES=true
-            else
-              PREVIEW=false; STORES=false
+              [[ "$COMMIT_MSG" == \[build_apps:ios\]* ]] && PLATFORMS=ios
+              [[ "$COMMIT_MSG" == \[build_apps:android\]* ]] && PLATFORMS=android
             fi
           fi
+          [[ "$PLATFORMS" == "all" || "$PLATFORMS" == "ios" ]] && IOS=true || IOS=false
+          [[ "$PLATFORMS" == "all" || "$PLATFORMS" == "android" ]] && ANDROID=true || ANDROID=false
           echo "build_preview=$PREVIEW" >> "$GITHUB_OUTPUT"
           echo "build_stores=$STORES" >> "$GITHUB_OUTPUT"
+          echo "ios=$IOS" >> "$GITHUB_OUTPUT"
+          echo "android=$ANDROID" >> "$GITHUB_OUTPUT"
 
   build-ios-preview:
     name: iOS ad-hoc (internal install)
     needs: check-trigger
-    if: needs.check-trigger.outputs.build_preview == 'true'
+    if: needs.check-trigger.outputs.build_preview == 'true' && needs.check-trigger.outputs.ios == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -81,7 +99,7 @@ jobs:
   build-ios-testflight:
     name: iOS store build → TestFlight
     needs: check-trigger
-    if: needs.check-trigger.outputs.build_stores == 'true'
+    if: needs.check-trigger.outputs.build_stores == 'true' && needs.check-trigger.outputs.ios == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -128,7 +146,7 @@ jobs:
   build-android-preview:
     name: Android APK (internal install)
     needs: check-trigger
-    if: needs.check-trigger.outputs.build_preview == 'true'
+    if: needs.check-trigger.outputs.build_preview == 'true' && needs.check-trigger.outputs.android == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -161,7 +179,7 @@ jobs:
   build-android-google-play:
     name: Android store build → Play internal track
     needs: check-trigger
-    if: needs.check-trigger.outputs.build_stores == 'true'
+    if: needs.check-trigger.outputs.build_stores == 'true' && needs.check-trigger.outputs.android == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -1,0 +1,203 @@
+name: CI – Build Mobile Apps (TestFlight & Play Internal)
+
+# Builds run on EAS. Triggered by:
+#  - a commit message starting with [build_apps] on any branch, or
+#  - manual dispatch (choose which targets to build).
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'Which builds to run'
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - stores-only
+          - preview-only
+
+jobs:
+  check-trigger:
+    runs-on: ubuntu-latest
+    outputs:
+      build_preview: ${{ steps.check.outputs.build_preview }}
+      build_stores: ${{ steps.check.outputs.build_stores }}
+    steps:
+      - name: Decide what to build
+        id: check
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TARGETS="${{ github.event.inputs.targets }}"
+            [[ "$TARGETS" == "all" || "$TARGETS" == "preview-only" ]] && PREVIEW=true || PREVIEW=false
+            [[ "$TARGETS" == "all" || "$TARGETS" == "stores-only" ]] && STORES=true || STORES=false
+          else
+            if [[ "$COMMIT_MSG" == \[build_apps\]* ]]; then
+              PREVIEW=true; STORES=true
+            else
+              PREVIEW=false; STORES=false
+            fi
+          fi
+          echo "build_preview=$PREVIEW" >> "$GITHUB_OUTPUT"
+          echo "build_stores=$STORES" >> "$GITHUB_OUTPUT"
+
+  build-ios-preview:
+    name: iOS ad-hoc (internal install)
+    needs: check-trigger
+    if: needs.check-trigger.outputs.build_preview == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: expo_app
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: expo_app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build iOS (ad-hoc)
+        run: eas build --platform ios --profile preview --non-interactive
+
+  build-ios-testflight:
+    name: iOS store build → TestFlight
+    needs: check-trigger
+    if: needs.check-trigger.outputs.build_stores == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: expo_app
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: expo_app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build iOS (store)
+        run: eas build --platform ios --profile production --non-interactive
+
+      - name: Submit iOS to TestFlight
+        env:
+          ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+        run: |
+          echo "$APPLE_API_KEY_P8_BASE64" | base64 --decode > asc-api-key.p8
+          eas submit --platform ios --profile preview --non-interactive --latest
+
+      - name: Cleanup secrets
+        if: always()
+        run: rm -f asc-api-key.p8
+
+  build-android-preview:
+    name: Android APK (internal install)
+    needs: check-trigger
+    if: needs.check-trigger.outputs.build_preview == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: expo_app
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: expo_app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android (internal distribution)
+        run: eas build --platform android --profile preview --non-interactive
+
+  build-android-google-play:
+    name: Android store build → Play internal track
+    needs: check-trigger
+    if: needs.check-trigger.outputs.build_stores == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: expo_app
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: expo_app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android (store)
+        run: eas build --platform android --profile production --non-interactive
+
+      - name: Submit Android to Google Play (internal track)
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64 }}
+        run: |
+          echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 --decode > google-service-account-key.json
+          eas submit --platform android --profile preview --non-interactive --latest
+
+      - name: Cleanup secrets
+        if: always()
+        run: rm -f google-service-account-key.json

--- a/.github/workflows/publish-apps.yml
+++ b/.github/workflows/publish-apps.yml
@@ -103,7 +103,6 @@ jobs:
       - name: Submit iOS to App Store
         if: contains(fromJSON('["all","ios"]'), github.event.inputs.platforms)
         env:
-          ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}

--- a/.github/workflows/publish-apps.yml
+++ b/.github/workflows/publish-apps.yml
@@ -1,0 +1,125 @@
+name: CD – Publish Mobile Apps to Stores
+
+# Manual release: bumps the app version, builds both platforms on EAS,
+# submits to the App Store + Google Play production track, and tags the repo.
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: expo_app
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CR_PAT }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: expo_app/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Bump version in app.json
+        id: version
+        run: |
+          CURRENT_VERSION=$(node -e "console.log(require('./app.json').expo.version)")
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+          case "${{ github.event.inputs.version_bump }}" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+          node -e "
+            const fs = require('fs');
+            const app = JSON.parse(fs.readFileSync('app.json', 'utf8'));
+            app.expo.version = '${NEW_VERSION}';
+            fs.writeFileSync('app.json', JSON.stringify(app, null, 2) + '\n');
+          "
+
+          echo "Bumped version: $CURRENT_VERSION -> $NEW_VERSION"
+
+      - name: Commit version bump
+        run: |
+          cd ..
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add expo_app/app.json
+          git commit -m "chore: bump app version to ${{ steps.version.outputs.new_version }}"
+          git push
+
+      - name: Build iOS
+        run: eas build --platform ios --profile production --non-interactive
+
+      - name: Submit iOS to App Store
+        env:
+          ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+          APPLE_API_KEY_P8_BASE64: ${{ secrets.APPLE_API_KEY_P8_BASE64 }}
+        run: |
+          echo "$APPLE_API_KEY_P8_BASE64" | base64 --decode > asc-api-key.p8
+          eas submit --platform ios --profile production --non-interactive --latest
+
+      - name: Cleanup iOS secrets
+        if: always()
+        run: rm -f asc-api-key.p8
+
+      - name: Build Android
+        run: eas build --platform android --profile production --non-interactive
+
+      - name: Submit Android to Google Play (production track)
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64 }}
+        run: |
+          echo "$GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64" | base64 --decode > google-service-account-key.json
+          eas submit --platform android --profile production --non-interactive --latest
+
+      - name: Cleanup Android secrets
+        if: always()
+        run: rm -f google-service-account-key.json
+
+      - name: Create git tag
+        run: |
+          cd ..
+          git tag "app-v${{ steps.version.outputs.new_version }}"
+          git push origin "app-v${{ steps.version.outputs.new_version }}"

--- a/.github/workflows/publish-apps.yml
+++ b/.github/workflows/publish-apps.yml
@@ -13,6 +13,15 @@ on:
           - patch
           - minor
           - major
+      platforms:
+        description: 'Which platforms to release'
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - ios
+          - android
 
 jobs:
   publish:
@@ -88,9 +97,11 @@ jobs:
           git push
 
       - name: Build iOS
+        if: contains(fromJSON('["all","ios"]'), github.event.inputs.platforms)
         run: eas build --platform ios --profile production --non-interactive
 
       - name: Submit iOS to App Store
+        if: contains(fromJSON('["all","ios"]'), github.event.inputs.platforms)
         env:
           ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
@@ -105,9 +116,11 @@ jobs:
         run: rm -f asc-api-key.p8
 
       - name: Build Android
+        if: contains(fromJSON('["all","android"]'), github.event.inputs.platforms)
         run: eas build --platform android --profile production --non-interactive
 
       - name: Submit Android to Google Play (production track)
+        if: contains(fromJSON('["all","android"]'), github.event.inputs.platforms)
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64 }}
         run: |

--- a/expo_app/README.md
+++ b/expo_app/README.md
@@ -38,3 +38,53 @@ In the output, you'll find options to open the app in a
 
 - iOS uses Apple Maps (no key needed)
 - Android uses Google Maps and needs a Maps API key at build time
+
+## Releases (CI/CD)
+
+Builds run on [EAS](https://expo.dev/eas); two GitHub workflows drive them:
+
+- **`CI – Build Mobile Apps`** (`.github/workflows/build-apps.yml`) — push a
+  commit whose message starts with `[build_apps]` (any branch), or run it
+  manually from the Actions tab. Builds an iOS store build → TestFlight, an
+  Android store build → Play **internal** track (draft), plus directly
+  installable ad-hoc iOS / APK Android binaries.
+- **`CD – Publish Mobile Apps to Stores`**
+  (`.github/workflows/publish-apps.yml`) — manual only. Pick patch/minor/major:
+  it bumps `expo.version` in `app.json`, commits the bump, builds both
+  platforms, submits to the App Store + Play **production** track, and tags
+  the repo `app-v<version>`.
+
+Native build numbers (iOS `buildNumber` / Android `versionCode`) are managed
+remotely by EAS (`appVersionSource: remote` + `autoIncrement`) — never edit
+them by hand; only `expo.version` in `app.json` matters, and the publish
+workflow bumps it for you.
+
+### One-time setup (before the first CI build)
+
+The workflows need the EAS project, store apps, and credentials to exist.
+All of this mirrors the shinkleesh repo, so most values can be copied from
+its GitHub secrets / Expo account. From `expo_app/`:
+
+1. **Link the EAS project**: `npx eas init` (logged in as the `albardn2`
+   Expo account) — writes `extra.eas.projectId` into `app.json`; commit it.
+2. **Seed remote versions** so Play/App Store numbering continues from the
+   existing installs: `npx eas build:version:set` per platform (Android
+   versionCode ≥ 3, since app.json was at 2).
+3. **Seed build credentials** by running the first store builds locally and
+   interactively (lets EAS generate/manage the iOS distribution cert +
+   provisioning profile and the Android keystore):
+   `npx eas build --platform ios --profile production` and the same for
+   Android. Subsequent CI builds are non-interactive and just reuse these.
+4. **Store apps**: register `com.karmagrp.business` in App Store Connect and
+   create the app (note its numeric Apple ID → `ASC_APP_ID` secret). Create
+   the Play Console app and upload the *first* AAB manually (Play requires
+   it); grant the shinkleesh service account access to the app.
+5. **EAS env var for Android Maps**: the Google Maps key is read at build
+   time by `app.config.ts` — create it on EAS so build workers see it:
+   `npx eas env:create --name GOOGLE_MAPS_API_KEY --visibility secret`
+   (all environments).
+6. **GitHub secrets** on this repo (values identical to shinkleesh's, except
+   `ASC_APP_ID` which is karma's own): `EXPO_TOKEN`, `APPLE_API_KEY_ID`,
+   `APPLE_API_ISSUER_ID`, `APPLE_API_KEY_P8_BASE64`,
+   `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64`, `ASC_APP_ID`.
+   (`CR_PAT` already exists.)

--- a/expo_app/app.json
+++ b/expo_app/app.json
@@ -11,7 +11,10 @@
     "newArchEnabled": true,
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.karmagrp.business"
+      "bundleIdentifier": "com.karmagrp.business",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "com.karmagrp.business",
@@ -53,6 +56,13 @@
     ],
     "experiments": {
       "typedRoutes": true
+    },
+    "extra": {
+      "apiBaseUrl": "https://api-prod.karma-grp.com",
+      "router": {},
+      "eas": {
+        "projectId": "e559e48d-42a5-444d-ba19-f3cd52d1bc27"
+      }
     }
   }
 }

--- a/expo_app/app.json
+++ b/expo_app/app.json
@@ -2,6 +2,7 @@
   "expo": {
     "name": "karma-group",
     "slug": "karma-group",
+    "owner": "albardn2",
     "version": "1.2.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",

--- a/expo_app/eas.json
+++ b/expo_app/eas.json
@@ -25,6 +25,7 @@
     }
   },
   "submit": {
+    "local": {},
     "preview": {
       "ios": {
         "ascAppId": "${ASC_APP_ID}",

--- a/expo_app/eas.json
+++ b/expo_app/eas.json
@@ -1,5 +1,8 @@
 {
-  "cli": { "version": ">= 13.2.0" },
+  "cli": {
+    "version": ">= 13.2.0",
+    "appVersionSource": "remote"
+  },
   "build": {
     "development": {
       "developmentClient": true,
@@ -10,17 +13,42 @@
     },
     "preview": {
       "distribution": "internal",
+      "autoIncrement": true,
       "android": { "buildType": "apk" },
       "ios": { "simulator": false },
       "env": { "API_BASE_URL": "https://api-dev.karma-grp.com" }
     },
     "production": {
-      "android": { "gradleCommand": ":app:bundleRelease" }, // outputs AAB
-      "ios": { "simulator": false },
+      "distribution": "store",
+      "autoIncrement": true,
       "env": { "API_BASE_URL": "https://api-prod.karma-grp.com" }
     }
   },
   "submit": {
-    "production": {}
+    "preview": {
+      "ios": {
+        "ascAppId": "${ASC_APP_ID}",
+        "ascApiKeyId": "${APPLE_API_KEY_ID}",
+        "ascApiKeyIssuerId": "${APPLE_API_ISSUER_ID}",
+        "ascApiKeyPath": "./asc-api-key.p8"
+      },
+      "android": {
+        "track": "internal",
+        "releaseStatus": "draft",
+        "serviceAccountKeyPath": "./google-service-account-key.json"
+      }
+    },
+    "production": {
+      "ios": {
+        "ascAppId": "${ASC_APP_ID}",
+        "ascApiKeyId": "${APPLE_API_KEY_ID}",
+        "ascApiKeyIssuerId": "${APPLE_API_ISSUER_ID}",
+        "ascApiKeyPath": "./asc-api-key.p8"
+      },
+      "android": {
+        "track": "production",
+        "serviceAccountKeyPath": "./google-service-account-key.json"
+      }
+    }
   }
 }

--- a/expo_app/eas.json
+++ b/expo_app/eas.json
@@ -28,7 +28,7 @@
     "local": {},
     "preview": {
       "ios": {
-        "ascAppId": "${ASC_APP_ID}",
+        "ascAppId": "6753890262",
         "ascApiKeyId": "${APPLE_API_KEY_ID}",
         "ascApiKeyIssuerId": "${APPLE_API_ISSUER_ID}",
         "ascApiKeyPath": "./asc-api-key.p8"
@@ -41,7 +41,7 @@
     },
     "production": {
       "ios": {
-        "ascAppId": "${ASC_APP_ID}",
+        "ascAppId": "6753890262",
         "ascApiKeyId": "${APPLE_API_KEY_ID}",
         "ascApiKeyIssuerId": "${APPLE_API_ISSUER_ID}",
         "ascApiKeyPath": "./asc-api-key.p8"

--- a/expo_app/package-lock.json
+++ b/expo_app/package-lock.json
@@ -4390,7 +4390,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
@@ -4460,7 +4460,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
@@ -4492,7 +4492,7 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -5104,6 +5104,182 @@
         "@urql/core": "^5.0.0"
       }
     },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@webassemblyjs/ast": "1.14.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
@@ -5112,6 +5288,22 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -5147,9 +5339,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -5169,6 +5361,20 @@
         "acorn-walk": "^8.0.2"
       }
     },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -5183,7 +5389,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
       "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.15.0"
@@ -5234,6 +5440,51 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/anser": {
       "version": "1.4.10",
@@ -6085,6 +6336,17 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/chromium-edge-launcher": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
@@ -6514,7 +6776,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -7001,6 +7263,21 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -7157,6 +7434,14 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -7650,7 +7935,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -7663,7 +7948,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -7695,6 +7980,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/execa": {
@@ -11421,6 +11717,21 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
+    "node_modules/loader-runner": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.2.tgz",
+      "integrity": "sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -12192,6 +12503,101 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minimizer-webpack-plugin": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/minimizer-webpack-plugin/-/minimizer-webpack-plugin-5.6.1.tgz",
+      "integrity": "sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jest-worker": "^27.4.5",
+        "schema-utils": "^4.3.0",
+        "terser": "^5.31.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@minify-html/node": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/css": {
+          "optional": true
+        },
+        "@swc/html": {
+          "optional": true
+        },
+        "clean-css": {
+          "optional": true
+        },
+        "cssnano": {
+          "optional": true
+        },
+        "csso": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "html-minifier-terser": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/jest-worker": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/minimizer-webpack-plugin/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -12296,7 +12702,7 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nested-error-stacks": {
@@ -13842,10 +14248,10 @@
       }
     },
     "node_modules/react-server-dom-webpack": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.0.0.tgz",
-      "integrity": "sha512-hLug9KEXLc8vnU9lDNe2b2rKKDaqrp5gNiES4uyu2Up3FZfZJZmdwLFXlWzdA9gTB/6/cWduSB2K1Lfag2pSvw==",
-      "dev": true,
+      "version": "19.0.7",
+      "resolved": "https://registry.npmjs.org/react-server-dom-webpack/-/react-server-dom-webpack-19.0.7.tgz",
+      "integrity": "sha512-UN0KHCtrrCR6zqJCOuCj3Sjzuori6JVW3OhboRvjM6uBAlREdDtJadn9wBPTfYpyZQ3NBD/Xw7OYxjR4NAlJXg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "acorn-loose": "^8.3.0",
@@ -13856,8 +14262,8 @@
         "node": ">=0.10.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^19.0.7",
+        "react-dom": "^19.0.7",
         "webpack": "^5.59.0"
       }
     },
@@ -14345,6 +14751,67 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
+    },
+    "node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/schema-utils/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -15178,6 +15645,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/tar": {
       "version": "7.5.19",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
@@ -15593,7 +16075,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15974,6 +16456,20 @@
       "integrity": "sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==",
       "license": "MIT"
     },
+    "node_modules/watchpack": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.2.tgz",
+      "integrity": "sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -15993,14 +16489,98 @@
         "node": ">=12"
       }
     },
+    "node_modules/webpack": {
+      "version": "5.108.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.108.4.tgz",
+      "integrity": "sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "@types/json-schema": "^7.0.15",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.16.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.28.1",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.22.2",
+        "es-module-lexer": "^2.1.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "graceful-fs": "^4.2.11",
+        "loader-runner": "^4.3.2",
+        "mime-db": "^1.54.0",
+        "minimizer-webpack-plugin": "^5.6.1",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
+        "watchpack": "^2.5.2",
+        "webpack-sources": "^3.5.0"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
-      "dev": true,
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.5.1.tgz",
+      "integrity": "sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webpack/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/whatwg-encoding": {


### PR DESCRIPTION
## Mobile app CI/CD (EAS build + store submit)

Mirrors the shinkleesh setup: EAS builds in GitHub Actions, submits to TestFlight / Google Play.

### Workflows
- **`CI – Build Mobile Apps`** — triggered by a commit message starting with `[build_apps]` (any branch) or manual dispatch (with a targets picker: all / stores-only / preview-only). Jobs: iOS store build → TestFlight, Android store build → Play internal track (draft), plus ad-hoc iOS and APK Android internal-install builds.
- **`CD – Publish Mobile Apps to Stores`** — manual only. Bumps `expo.version` (patch/minor/major), commits the bump, builds both platforms, submits to App Store + Play production track, tags `app-v<version>`.

### Config
- `eas.json`: `appVersionSource: remote` + `autoIncrement` (EAS owns buildNumber/versionCode), `distribution: store` for production, submit profiles with env-substituted `ASC_APP_ID` / Apple API key (same mechanism as shinkleesh).
- `app.json`: `owner: albardn2`.
- README: release flow + one-time setup checklist.

### ⚠️ Not functional until one-time setup is done
The karma repo/EAS project has none of the store plumbing yet. Required (details in `expo_app/README.md`):
1. `eas init` in `expo_app/` (writes the projectId — needs committing)
2. `eas build:version:set` (Android versionCode ≥ 3)
3. First interactive `eas build` per platform to seed signing credentials
4. Create the App Store Connect app (`com.karmagrp.business`) → `ASC_APP_ID`; create the Play app + first manual AAB upload
5. `eas env:create GOOGLE_MAPS_API_KEY` (build workers need it via `app.config.ts`)
6. Repo secrets: `EXPO_TOKEN`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER_ID`, `APPLE_API_KEY_P8_BASE64`, `GOOGLE_PLAY_SERVICE_ACCOUNT_KEY_BASE64`, `ASC_APP_ID` (first five copyable from shinkleesh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
