### PR TITLE
Trip flow: manual-mode service areas (web) + sales/driver stop visibility (backend)

### DIFF
--- a/backend/app/entrypoint/routes/material/routes.py
+++ b/backend/app/entrypoint/routes/material/routes.py
@@ -85,7 +85,10 @@ def delete_material(uuid: str):
 @jwt_required()
 @scopes_required(PermissionScope.ADMIN.value,
                  PermissionScope.SUPER_ADMIN.value,
-                 PermissionScope.OPERATION_MANAGER.value)
+                 PermissionScope.OPERATION_MANAGER.value,
+                 # drivers/sales pick materials when creating an order at a trip stop
+                 PermissionScope.DRIVER.value,
+                 PermissionScope.SALES.value)
 def list_materials():
     # Parse & validate pagination params
     params = MaterialListParams(**request.args)

--- a/backend/app/entrypoint/routes/task/routes.py
+++ b/backend/app/entrypoint/routes/task/routes.py
@@ -43,7 +43,11 @@ def create_task():
     PermissionScope.ADMIN.value,
     PermissionScope.SUPER_ADMIN.value,
     PermissionScope.OPERATION_MANAGER.value,
-    PermissionScope.OPERATOR.value)
+    PermissionScope.OPERATOR.value,
+    # the mobile trip screen reads each stop's task; assignees can be
+    # drivers or sales (same audience as the workflow-execution routes)
+    PermissionScope.DRIVER.value,
+    PermissionScope.SALES.value)
 def get_task(uuid: str):
     with SqlAlchemyUnitOfWork() as uow:
         task = uow.task_repository.find_one(uuid=uuid, is_deleted=False)

--- a/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
@@ -705,9 +705,11 @@ export default function WorkflowExecutionTaskDetail() {
   };
   const orderContext = getTripStopOrderContext();
 
-  // manual-stops mode: when checked on the start_trip form, hide the routing inputs
+  // manual-stops mode: when checked on the start_trip form, hide the routing
+  // inputs. service_areas intentionally stays visible: manual trips also carry
+  // a service area (parity with the mobile app's start-trip form).
   const ROUTING_FIELD_NAMES = new Set([
-    "service_areas", "start_warehouse_name", "end_warehouse_name", "start_point", "end_point",
+    "start_warehouse_name", "end_warehouse_name", "start_point", "end_point",
     "customer_categories", "last_visit_threshold_days", "max_stops", "min_stops",
   ]);
   const manualStopsValue = form.watch("manual_stops" as any);


### PR DESCRIPTION
## Trip flow fixes

Two fixes for the trip flow, both verified end-to-end against the local stack:

### Web: service area picker hidden in manual mode
The manual_stops toggle on the start-trip form hid all routing inputs including `service_areas`, so web-created manual trips always stored an empty service-area list — unlike the mobile app, which deliberately keeps the picker visible. Removed `service_areas` from the hidden set. Verified: manual trip created via the web form stores `service_area_names = {"DISTRIBUTION 2"}`.

### Backend: sales/driver users saw an empty stops sheet in the app
The mobile trip screen loads each stop via `GET /task/<uuid>`, which was missing the `DRIVER` and `SALES` scopes (every other trip-flow endpoint already had them) — assigned sales users got a 403 per stop and the slide-up sheet rendered empty while admins saw the stops. Also fixed the same gap one step later: `GET /material/` (used by the create-order screen at a stop) was admin/OM-only. Verified with a sales-scoped user: both endpoints return 200 with full payloads.

Server-side only for the app fix — existing app installs are fixed as soon as the backend deploys, no app update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
