### PR TITLE
Trip flow: SYP default, admin soft-delete, language-agnostic dates

### DIFF
--- a/backend/app/domains/task_execution/domain.py
+++ b/backend/app/domains/task_execution/domain.py
@@ -105,6 +105,10 @@ class TaskExecutionDomain:
         if task_exe.status in [WorkflowStatus.CANCELLED.value, WorkflowStatus.FAILED.value,WorkflowStatus.NOT_STARTED]:
             raise BadRequestError(f"TaskExecution cannot be completed with status: {task_exe.status}")
 
+        # a soft-deleted execution must be inert, not just hidden
+        if task_exe.workflow_execution and task_exe.workflow_execution.is_deleted:
+            raise NotFoundError(f"TaskExecution not found with uuid: {payload.uuid}")
+
         # execute
         OperatorEntryPoint().execute(
             uow=uow,

--- a/backend/app/domains/task_execution/workflow_operators/start_trip_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/start_trip_operator.py
@@ -99,6 +99,7 @@ class StartTripOperator(OperatorInterface):
                 .join(TaskModel, TaskModel.uuid == TEModel.task_uuid)
                 .filter(
                     WFEModel.status == WorkflowStatus.IN_PROGRESS.value,
+                    WFEModel.is_deleted.is_(False),
                     WFEModel.uuid != task_exe.workflow_execution_uuid,
                     TaskModel.operator == "start_trip_operator",
                     TEModel.result["assigned_user_uuid"].astext.in_(values),

--- a/backend/app/domains/trip/domain.py
+++ b/backend/app/domains/trip/domain.py
@@ -22,7 +22,7 @@ class TripDomain:
 
     @staticmethod
     def update_trip(uow: SqlAlchemyUnitOfWork, uuid: str, payload: TripUpdate) -> TripRead:
-        trip = uow.trip_repository.find_one(uuid=uuid)
+        trip = uow.trip_repository.find_one(uuid=uuid, is_deleted=False)
         if not trip:
             raise NotFoundError('Trip not found')
 

--- a/backend/app/domains/workflow_execution/domain.py
+++ b/backend/app/domains/workflow_execution/domain.py
@@ -48,7 +48,7 @@ class WorkflowExecutionDomain:
     def cancel_workflow_execution(
         uow: SqlAlchemyUnitOfWork, uuid: str
     ) -> WorkflowExecutionRead:
-        workflow_execution = uow.workflow_execution_repository.find_one(uuid=uuid)
+        workflow_execution = uow.workflow_execution_repository.find_one(uuid=uuid, is_deleted=False)
         if not workflow_execution:
             raise NotFoundError(f"WorkflowExecution not found with uuid: {uuid}")
 

--- a/backend/app/entrypoint/routes/task_execution/routes.py
+++ b/backend/app/entrypoint/routes/task_execution/routes.py
@@ -51,6 +51,12 @@ def list_task_executions():
     if params.end_time:
         filters.append(TaskExecutionModel.end_time <= params.end_time)
 
+    # never list children of a soft-deleted execution
+    from models.common import WorkflowExecution as WorkflowExecutionModel
+    filters.append(
+        TaskExecutionModel.workflow_execution.has(WorkflowExecutionModel.is_deleted.is_(False))
+    )
+
     with SqlAlchemyUnitOfWork() as uow:
         page = uow.task_execution_repository.find_all_by_filters_paginated(
             filters=filters,
@@ -114,7 +120,7 @@ def list_task_operators():
 def get_task_execution(uuid: str):
     with SqlAlchemyUnitOfWork() as uow:
         task_exe = uow.task_execution_repository.find_one(uuid=uuid)
-        if not task_exe:
+        if not task_exe or (task_exe.workflow_execution and task_exe.workflow_execution.is_deleted):
             raise NotFoundError(f"task_exe not found with uuid: {uuid}")
 
         dto = TaskExecutionRead.from_orm(task_exe).model_dump(mode="json")

--- a/backend/app/entrypoint/routes/trip/routes.py
+++ b/backend/app/entrypoint/routes/trip/routes.py
@@ -51,7 +51,7 @@ def create_trip():
 )
 def get_trip(uuid: str):
     with SqlAlchemyUnitOfWork() as uow:
-        m = uow.trip_repository.find_one(uuid=uuid)
+        m = uow.trip_repository.find_one(uuid=uuid, is_deleted=False)
         if not m:
             raise NotFoundError("Trip not found")
         dto = TripRead.from_orm(m).model_dump(mode="json")
@@ -73,7 +73,7 @@ def get_trip_activity(uuid: str):
     from app.utils.geom_utils import wkt_or_wkb_to_lat_lon
 
     with SqlAlchemyUnitOfWork() as uow:
-        trip = uow.trip_repository.find_one(uuid=uuid)
+        trip = uow.trip_repository.find_one(uuid=uuid, is_deleted=False)
         if not trip:
             raise NotFoundError("Trip not found")
 
@@ -206,6 +206,8 @@ def list_trips():
         geom_expr = func.ST_GeomFromText(params.intersects_area, 4326)
         filters.append(func.ST_Intersects(TripModel.geometry, geom_expr))
 
+    filters.append(TripModel.is_deleted.is_(False))
+
     with SqlAlchemyUnitOfWork() as uow:
         page = uow.trip_repository.find_all_by_filters_paginated(
             filters=filters,
@@ -222,3 +224,48 @@ def list_trips():
             pages=page.pages,
         ).model_dump(mode="json")
     return jsonify(result), 200
+
+
+@trip_blueprint.route("/<string:uuid>", methods=["DELETE"])
+@jwt_required()
+@scopes_required(
+    PermissionScope.ADMIN.value,
+    PermissionScope.SUPER_ADMIN.value,
+)
+def delete_trip(uuid: str):
+    """Soft-delete a trip (admins only). An active trip is cancelled first
+    (stops + task executions included) so the deleted trip is inert, not just
+    hidden. The paired workflow execution is soft-deleted with it — unless it
+    still has other live trips."""
+    from app.domains.workflow_execution.domain import WorkflowExecutionDomain
+    from app.dto.trip import TripStatus
+    from app.dto.workflow_execution import WorkflowStatus
+
+    with SqlAlchemyUnitOfWork() as uow:
+        trip = uow.trip_repository.find_one(uuid=uuid, is_deleted=False)
+        if not trip:
+            raise NotFoundError("Trip not found")
+
+        wfe = (
+            uow.workflow_execution_repository.find_one(uuid=trip.workflow_execution_uuid)
+            if trip.workflow_execution_uuid else None
+        )
+        # cancel anything still running so nothing keeps writing to a deleted trip
+        if wfe and wfe.status not in (
+            WorkflowStatus.COMPLETED.value, WorkflowStatus.CANCELLED.value, WorkflowStatus.FAILED.value
+        ):
+            WorkflowExecutionDomain.cancel_workflow_execution(uow=uow, uuid=wfe.uuid)
+        if trip.status not in (TripStatus.COMPLETED.value, TripStatus.CANCELLED.value):
+            TripDomain.cancel_trip(uow=uow, uuid=trip.uuid)
+
+        trip.is_deleted = True
+        uow.trip_repository.save(model=trip, commit=False)
+        if wfe:
+            live_siblings = [
+                t for t in (wfe.trips or []) if t.uuid != trip.uuid and not t.is_deleted
+            ]
+            if not live_siblings:
+                wfe.is_deleted = True
+                uow.workflow_execution_repository.save(model=wfe, commit=False)
+        uow.commit()
+    return jsonify({"uuid": uuid, "is_deleted": True}), 200

--- a/backend/app/entrypoint/routes/trip_stop/routes.py
+++ b/backend/app/entrypoint/routes/trip_stop/routes.py
@@ -53,6 +53,8 @@ def create_trip_stop():
 def get_trip_stop(uuid: str):
     with SqlAlchemyUnitOfWork() as uow:
         m = uow.trip_stop_repository.find_one(uuid=uuid)
+        if m and m.trip and m.trip.is_deleted:
+            m = None
         if not m:
             raise NotFoundError("TripStop not found")
         dto = TripStopRead.from_orm(m).model_dump(mode="json")
@@ -117,6 +119,8 @@ def list_trip_stops():
         filters.append(func.ST_Intersects(TripStopModel.coordinates, geom_expr))
 
     with SqlAlchemyUnitOfWork() as uow:
+        from models.common import Trip as TripModel
+        filters.append(TripStopModel.trip.has(TripModel.is_deleted.is_(False)))
         page = uow.trip_stop_repository.find_all_by_filters_paginated(
             filters=filters,
             page=params.page,

--- a/backend/app/entrypoint/routes/workflow_execution/routes.py
+++ b/backend/app/entrypoint/routes/workflow_execution/routes.py
@@ -145,7 +145,7 @@ def create_workflow_execution():
     PermissionScope.SALES.value)
 def get_workflow_execution(uuid: str):
     with SqlAlchemyUnitOfWork() as uow:
-        workflow_exe = uow.workflow_execution_repository.find_one(uuid=uuid)
+        workflow_exe = uow.workflow_execution_repository.find_one(uuid=uuid, is_deleted=False)
         if not workflow_exe:
             raise NotFoundError(f"workflow_exe not found with uuid: {uuid}")
 
@@ -177,7 +177,7 @@ def add_manual_stop(uuid: str):
     current_uuid = get_jwt_identity()
     payload = ManualStopCreate(**request.json)
     with SqlAlchemyUnitOfWork() as uow:
-        workflow_exe = uow.workflow_execution_repository.find_one(uuid=uuid)
+        workflow_exe = uow.workflow_execution_repository.find_one(uuid=uuid, is_deleted=False)
         if not workflow_exe:
             raise NotFoundError(f"workflow_exe not found with uuid: {uuid}")
         _assert_execution_access(uow, workflow_exe)
@@ -327,7 +327,7 @@ def set_current_stop(uuid: str):
 
     params = SetCurrentStopParams(**request.json)
     with SqlAlchemyUnitOfWork() as uow:
-        workflow_exe = uow.workflow_execution_repository.find_one(uuid=uuid)
+        workflow_exe = uow.workflow_execution_repository.find_one(uuid=uuid, is_deleted=False)
         if not workflow_exe:
             raise NotFoundError(f"workflow_exe not found with uuid: {uuid}")
         _assert_execution_access(uow, workflow_exe)
@@ -477,6 +477,7 @@ def list_workflow_executions():
             if target:
                 filters.append(owned_or_assigned_filter(target))
 
+        filters.append(WorkflowExecutionModel.is_deleted.is_(False))
         page = uow.workflow_execution_repository.find_all_by_filters_paginated(
             filters=filters,
             page=params.page,
@@ -524,3 +525,37 @@ def list_workflow_status():
 
     values = [cat.value for cat in WorkflowStatus]
     return jsonify(values), 200
+
+
+@workflow_execution_blueprint.route("/<string:uuid>", methods=["DELETE"])
+@jwt_required()
+@scopes_required(
+    PermissionScope.ADMIN.value,
+    PermissionScope.SUPER_ADMIN.value,
+)
+def delete_workflow_execution(uuid: str):
+    """Soft-delete a workflow execution (admins only). An active execution is
+    cancelled first (trips, stops and task executions included) so the deleted
+    execution is inert, not just hidden. Its trips are soft-deleted with it."""
+    from app.domains.trip.domain import TripDomain
+    from app.dto.trip import TripStatus
+
+    with SqlAlchemyUnitOfWork() as uow:
+        workflow_exe = uow.workflow_execution_repository.find_one(uuid=uuid, is_deleted=False)
+        if not workflow_exe:
+            raise NotFoundError(f"workflow_exe not found with uuid: {uuid}")
+
+        if workflow_exe.status not in (
+            WorkflowStatus.COMPLETED.value, WorkflowStatus.CANCELLED.value, WorkflowStatus.FAILED.value
+        ):
+            WorkflowExecutionDomain.cancel_workflow_execution(uow=uow, uuid=uuid)
+
+        workflow_exe.is_deleted = True
+        uow.workflow_execution_repository.save(model=workflow_exe, commit=False)
+        for trip in workflow_exe.trips or []:
+            if trip.status not in (TripStatus.COMPLETED.value, TripStatus.CANCELLED.value):
+                TripDomain.cancel_trip(uow=uow, uuid=trip.uuid)
+            trip.is_deleted = True
+            uow.trip_repository.save(model=trip, commit=False)
+        uow.commit()
+    return jsonify({"uuid": uuid, "is_deleted": True}), 200

--- a/backend/location_ingest/__main__.py
+++ b/backend/location_ingest/__main__.py
@@ -113,6 +113,8 @@ class Ingestor:
             .join(TaskModel, TaskModel.uuid == TaskExecutionModel.task_uuid)
             .filter(
                 TripModel.status == "in_progress",
+                TripModel.is_deleted.is_(False),
+                WFEModel.is_deleted.is_(False),
                 TaskModel.operator == "start_trip_operator",
                 TaskExecutionModel.result["assigned_user_uuid"].astext.in_(values),
             )

--- a/backend/migrations/versions/c7e2a9d4f1b8_soft_delete_trip_wfe.py
+++ b/backend/migrations/versions/c7e2a9d4f1b8_soft_delete_trip_wfe.py
@@ -1,0 +1,31 @@
+"""Soft delete for trips and workflow executions
+
+Revision ID: c7e2a9d4f1b8
+Revises: a1c5e8f2b7d4
+Create Date: 2026-07-13
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'c7e2a9d4f1b8'
+down_revision = 'a1c5e8f2b7d4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'trip',
+        sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        'workflow_execution',
+        sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade():
+    op.drop_column('workflow_execution', 'is_deleted')
+    op.drop_column('trip', 'is_deleted')

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -1739,6 +1739,7 @@ class WorkflowExecution(Base):
     __tablename__ = "workflow_execution"
 
     uuid = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    is_deleted = Column(Boolean, nullable=False, default=False, server_default=false())
     created_by_uuid = Column(String(36), ForeignKey('user.uuid'), nullable=True)
     workflow_uuid = Column(String(36), ForeignKey("workflow.uuid"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
@@ -1877,6 +1878,7 @@ class Trip(Base):
     uuid        = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
     created_by_uuid = Column(String(36), ForeignKey('user.uuid'), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    is_deleted = Column(Boolean, nullable=False, default=False, server_default=false())
     vehicle_uuid = Column(String(36), ForeignKey("vehicle.uuid"), nullable=False)
     distribution_area = Column(Geometry("POLYGON", srid=4326), nullable=True)  # Area covered by the trip
     notes = Column(Text, nullable=True)

--- a/expo_app/app/customers/[id].tsx
+++ b/expo_app/app/customers/[id].tsx
@@ -24,6 +24,7 @@ import Svg, { Path } from 'react-native-svg';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Location from 'expo-location';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { formatMonthDayTime, formatNumericDate } from '@/utils/date';
 
 interface Customer {
   uuid: string;
@@ -487,11 +488,7 @@ export default function CustomerDetailScreen() {
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
+    return formatNumericDate(new Date(dateString));
   };
 
   const getTotalBalance = () => {

--- a/expo_app/app/distribution.tsx
+++ b/expo_app/app/distribution.tsx
@@ -18,6 +18,7 @@ import { BottomNavigation } from '@/components/layout/BottomNavigation';
 import { apiCall } from '@/utils/api';
 import { useAuth } from '@/contexts/AuthContext';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { formatMonthDayTime } from '@/utils/date';
 
 const TRIP_WORKFLOW_NAME = 'simple_trip_workflow';
 
@@ -73,12 +74,7 @@ const toDate = (s?: string | null) => {
 const formatDateTime = (s?: string | null) => {
   const d = toDate(s);
   if (!d) return '—';
-  return d.toLocaleString([], {
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
+  return formatMonthDayTime(d);
 };
 
 export default function DistributionScreen() {

--- a/expo_app/app/distribution/[uuid].tsx
+++ b/expo_app/app/distribution/[uuid].tsx
@@ -17,6 +17,7 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { TripMap, TripMapArea, TripMapStop } from '@/components/TripMap';
 import { StopsSheet } from '@/components/StopsSheet';
 import { parseWktPolygons } from '@/utils/wkt';
+import { formatMonthDayTime } from '@/utils/date';
 
 interface TaskExecution {
   uuid: string;
@@ -84,7 +85,7 @@ const toDate = (s?: string | null) => {
 };
 const fmt = (s?: string | null) => {
   const d = toDate(s);
-  return d ? d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '—';
+  return d ? formatMonthDayTime(d) : '—';
 };
 const taskLabel = (te: TaskExecution, t: (key: string, vars?: Record<string, string | number>) => string) => {
   if (te.operator === 'trip_stop_operator') {

--- a/expo_app/app/distribution/create-order.tsx
+++ b/expo_app/app/distribution/create-order.tsx
@@ -17,7 +17,7 @@ import { NativeHeader } from '@/components/layout/NativeHeader';
 import { apiCall } from '@/utils/api';
 import { useLanguage } from '@/contexts/LanguageContext';
 
-const CURRENCIES = ['USD', 'SYP'];
+const CURRENCIES = ['SYP', 'USD'];
 
 interface Material {
   uuid: string;
@@ -41,7 +41,7 @@ export default function CreateOrderScreen() {
     customerName?: string;
   }>();
 
-  const [currency, setCurrency] = useState('USD');
+  const [currency, setCurrency] = useState('SYP');
   const [items, setItems] = useState<LineItem[]>([{ material_uuid: '', quantity: '', price_per_unit: '' }]);
   const [markFulfilled, setMarkFulfilled] = useState(true);
   const [markPaid, setMarkPaid] = useState(true);

--- a/expo_app/app/distribution/order.tsx
+++ b/expo_app/app/distribution/order.tsx
@@ -14,6 +14,7 @@ import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
 import { NativeHeader } from '@/components/layout/NativeHeader';
 import { apiCall } from '@/utils/api';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { formatMonthDayTime } from '@/utils/date';
 
 export default function OrderActionsScreen() {
   const { t, te } = useLanguage();
@@ -88,7 +89,7 @@ export default function OrderActionsScreen() {
   const fmtDate = (s?: string) => {
     if (!s) return '';
     const d = new Date(/[zZ]|[+-]\d{2}:?\d{2}$/.test(s) ? s : s + 'Z');
-    return isNaN(d.getTime()) ? s : d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+    return isNaN(d.getTime()) ? s : formatMonthDayTime(d);
   };
 
   return (

--- a/expo_app/app/distribution/stop/[taskExecutionUuid].tsx
+++ b/expo_app/app/distribution/stop/[taskExecutionUuid].tsx
@@ -16,6 +16,7 @@ import { Stack, useFocusEffect, useLocalSearchParams, useRouter } from 'expo-rou
 import { NativeHeader } from '@/components/layout/NativeHeader';
 import { apiCall } from '@/utils/api';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { formatMonthDayTime } from '@/utils/date';
 
 interface Field {
   name: string;
@@ -33,7 +34,7 @@ const toDate = (s?: string | null) => {
 };
 const fmt = (s?: string | null) => {
   const d = toDate(s);
-  return d ? d.toLocaleString([], { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '';
+  return d ? formatMonthDayTime(d) : '';
 };
 
 export default function StopDetailScreen() {

--- a/expo_app/utils/date.ts
+++ b/expo_app/utils/date.ts
@@ -1,0 +1,12 @@
+// Language-agnostic date formatting: numeric month/day and 24h time render
+// identically for every UI language (no "Jul", no localized AM/PM digits).
+
+const pad = (n: number) => String(n).padStart(2, '0');
+
+/** "07/11 07:02" — for list rows and compact labels. */
+export const formatMonthDayTime = (d: Date): string =>
+  `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+
+/** "07/11/2026" — when the year matters. */
+export const formatNumericDate = (d: Date): string =>
+  `${pad(d.getMonth() + 1)}/${pad(d.getDate())}/${d.getFullYear()}`;

--- a/frontend/client/src/contexts/AuthContext.tsx
+++ b/frontend/client/src/contexts/AuthContext.tsx
@@ -8,6 +8,8 @@ interface User {
   lastName: string;
   email?: string;
   permissionScope?: string;
+  /** comma-separated scopes as returned by /auth/me, e.g. "superuser,admin" */
+  permission_scope?: string;
   phoneNumber?: string;
   language?: string;
 }
@@ -18,6 +20,7 @@ interface AuthContextType {
   logout: () => void;
   isLoading: boolean;
   isAuthenticated: boolean;
+  isAdmin: boolean;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -118,12 +121,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null);
   };
 
+  const scopes = (user?.permission_scope ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
   const value: AuthContextType = {
     user,
     login,
     logout,
     isLoading,
     isAuthenticated: !!user,
+    isAdmin: scopes.includes('admin') || scopes.includes('superuser'),
   };
 
   return (

--- a/frontend/client/src/pages/TripDetail.tsx
+++ b/frontend/client/src/pages/TripDetail.tsx
@@ -9,7 +9,18 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { ArrowLeft, Edit3, Save, X, Copy, Check, Truck, Banknote, ChevronLeft, ChevronRight } from "lucide-react";
+import { ArrowLeft, Edit3, Save, X, Copy, Check, Truck, Banknote, ChevronLeft, ChevronRight, Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useAuth } from "@/contexts/AuthContext";
 import { format } from "date-fns";
 import { toast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
@@ -26,6 +37,22 @@ export default function TripDetail() {
   const [isEditing, setIsEditing] = useState(false);
   const [editedNotes, setEditedNotes] = useState("");
   const [copiedField, setCopiedField] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const { isAdmin } = useAuth();
+
+  const deleteTripMutation = useMutation({
+    mutationFn: () => apiRequest(`/trip/${params?.uuid}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/trip/"] });
+      queryClient.invalidateQueries({ queryKey: ["/workflow-execution/"] });
+      toast({ title: "Trip deleted" });
+      setLocation("/trips");
+    },
+    onError: (e: Error) => {
+      toast({ title: "Failed to delete trip", description: e.message, variant: "destructive" });
+      setConfirmDelete(false);
+    },
+  });
 
   const { data: trip, isLoading, error } = useQuery<Trip>({
     queryKey: ["/trip/", params?.uuid],
@@ -212,11 +239,47 @@ export default function TripDetail() {
               </div>
               <p className="text-gray-500" data-testid="text-header-trip-uuid">Trip UUID: {trip.uuid}</p>
             </div>
-            <Badge className={getStatusBadgeClass(trip.status)} data-testid="badge-status">
-              {formatStatus(trip.status)}
-            </Badge>
+            <div className="flex items-center gap-3">
+              <Badge className={getStatusBadgeClass(trip.status)} data-testid="badge-status">
+                {formatStatus(trip.status)}
+              </Badge>
+              {isAdmin && (
+                <Button
+                  variant="outline"
+                  className="text-red-600 border-red-200 hover:bg-red-50"
+                  onClick={() => setConfirmDelete(true)}
+                  data-testid="button-delete-trip"
+                >
+                  <Trash2 className="h-4 w-4 mr-2" />
+                  Delete Trip
+                </Button>
+              )}
+            </div>
           </div>
         </div>
+
+        <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete this trip?</AlertDialogTitle>
+              <AlertDialogDescription>
+                The trip and its workflow execution will be removed from all lists. This
+                cannot be undone from the app.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel data-testid="button-cancel-delete-trip">Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-red-600 hover:bg-red-700"
+                disabled={deleteTripMutation.isPending}
+                onClick={() => deleteTripMutation.mutate()}
+                data-testid="button-confirm-delete-trip"
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         <div className="grid gap-6 md:grid-cols-2">
           {/* General Information */}

--- a/frontend/client/src/pages/Trips.tsx
+++ b/frontend/client/src/pages/Trips.tsx
@@ -1,10 +1,22 @@
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useLocation } from "wouter";
 import { apiRequest } from "@/lib/queryClient";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { Button } from "@/components/ui/button";
-import { Truck, Plus } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useAuth } from "@/contexts/AuthContext";
+import { useToast } from "@/hooks/use-toast";
+import { Truck, Plus, Trash2 } from "lucide-react";
 import { TripFilters } from "@/components/trips/TripFilters";
 import { AddTripDialog } from "@/components/trips/AddTripDialog";
 import { format } from "date-fns";
@@ -17,6 +29,25 @@ export default function Trips() {
   const [perPage, setPerPage] = useState(20);
   const [activeTab, setActiveTab] = useState('all');
   const [showAddDialog, setShowAddDialog] = useState(false);
+  const [deleteTargetUuid, setDeleteTargetUuid] = useState<string | null>(null);
+  const { isAdmin } = useAuth();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const deleteTripMutation = useMutation({
+    mutationFn: (uuid: string) => apiRequest(`/trip/${uuid}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/trip/"] });
+      // the paired workflow execution is soft-deleted too
+      queryClient.invalidateQueries({ queryKey: ["/workflow-execution/"] });
+      if (trips.length === 1 && currentPage > 1) setCurrentPage(currentPage - 1);
+      toast({ title: "Trip deleted" });
+    },
+    onError: (e: Error) => {
+      toast({ title: "Failed to delete trip", description: e.message, variant: "destructive" });
+    },
+    onSettled: () => setDeleteTargetUuid(null),
+  });
 
   const {
     data: tripData,
@@ -235,12 +266,17 @@ export default function Trips() {
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                     Created
                   </th>
+                  {isAdmin && (
+                    <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                      Actions
+                    </th>
+                  )}
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                 {isLoading ? (
                   <tr>
-                    <td colSpan={7} className="px-6 py-16 text-center">
+                    <td colSpan={isAdmin ? 8 : 7} className="px-6 py-16 text-center">
                       <div className="animate-pulse space-y-4">
                         <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-32 mx-auto"></div>
                         <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-48 mx-auto"></div>
@@ -251,7 +287,7 @@ export default function Trips() {
                   </tr>
                 ) : trips.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="px-6 py-16 text-center">
+                    <td colSpan={isAdmin ? 8 : 7} className="px-6 py-16 text-center">
                       <Truck className="h-12 w-12 text-gray-400 mx-auto mb-4" />
                       <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
                         {error ? "Error loading trips" : "No trips"}
@@ -314,6 +350,22 @@ export default function Trips() {
                           {format(new Date(trip.created_at), 'MMM d, yyyy')}
                         </span>
                       </td>
+                      {isAdmin && (
+                        <td className="px-6 py-4 whitespace-nowrap text-right">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="text-gray-400 hover:text-red-600"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setDeleteTargetUuid(trip.uuid);
+                            }}
+                            data-testid={`button-delete-trip-${trip.uuid}`}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </td>
+                      )}
                     </tr>
                   ))
                 )}
@@ -353,7 +405,30 @@ export default function Trips() {
       </div>
 
       {/* Create Trip Dialog */}
-      <AddTripDialog 
+      <AlertDialog open={!!deleteTargetUuid} onOpenChange={(open) => !open && setDeleteTargetUuid(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this trip?</AlertDialogTitle>
+            <AlertDialogDescription>
+              The trip and its workflow execution will be removed from all lists. This
+              cannot be undone from the app.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel data-testid="button-cancel-delete-trip">Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 hover:bg-red-700"
+              disabled={deleteTripMutation.isPending}
+              onClick={() => deleteTargetUuid && deleteTripMutation.mutate(deleteTargetUuid)}
+              data-testid="button-confirm-delete-trip"
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AddTripDialog
         open={showAddDialog}
         onOpenChange={setShowAddDialog}
         onSuccess={() => {

--- a/frontend/client/src/pages/WorkflowExecutionDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionDetail.tsx
@@ -38,9 +38,21 @@ import {
   XCircle,
   AlertCircle,
   Loader2,
+  Trash2,
 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { useAuth } from "@/contexts/AuthContext";
 import { useToast } from "@/hooks/use-toast";
 import type { Workflow } from "@shared/schema";
 import type {
@@ -70,6 +82,26 @@ export default function WorkflowExecutionDetail() {
   const [showFiltersModal, setShowFiltersModal] = useState(false);
   const [showExecuteDialog, setShowExecuteDialog] = useState(false);
   const [tempFilters, setTempFilters] = useState(filters);
+  const [deleteTargetUuid, setDeleteTargetUuid] = useState<string | null>(null);
+  const { isAdmin } = useAuth();
+
+  const deleteExecutionMutation = useMutation({
+    mutationFn: (uuid: string) => apiRequest(`/workflow-execution/${uuid}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/workflow-execution/"] });
+      // any trip the execution created is soft-deleted too
+      queryClient.invalidateQueries({ queryKey: ["/trip/"] });
+      toast({ title: "Execution deleted" });
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Failed to delete execution",
+        description: error.message,
+        variant: "destructive",
+      });
+    },
+    onSettled: () => setDeleteTargetUuid(null),
+  });
 
   // Fetch workflow details
   const { data: workflow } = useQuery<Workflow>({
@@ -326,6 +358,7 @@ export default function WorkflowExecutionDetail() {
                       <TableHead>Ended</TableHead>
                       <TableHead>Duration</TableHead>
                       <TableHead>Tags</TableHead>
+                      {isAdmin && <TableHead className="text-right">Actions</TableHead>}
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -366,10 +399,54 @@ export default function WorkflowExecutionDetail() {
                             )}
                           </div>
                         </TableCell>
+                        {isAdmin && (
+                          <TableCell className="text-right">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="text-gray-400 hover:text-red-600"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setDeleteTargetUuid(execution.uuid);
+                              }}
+                              data-testid={`button-delete-execution-${execution.uuid}`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </TableCell>
+                        )}
                       </TableRow>
                     ))}
                   </TableBody>
                 </Table>
+
+                <AlertDialog
+                  open={!!deleteTargetUuid}
+                  onOpenChange={(open) => !open && setDeleteTargetUuid(null)}
+                >
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Delete this execution?</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        The execution and any trip it created will be removed from all
+                        lists. This cannot be undone from the app.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel data-testid="button-cancel-delete-execution">
+                        Cancel
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        className="bg-red-600 hover:bg-red-700"
+                        disabled={deleteExecutionMutation.isPending}
+                        onClick={() => deleteTargetUuid && deleteExecutionMutation.mutate(deleteTargetUuid)}
+                        data-testid="button-confirm-delete-execution"
+                      >
+                        Delete
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
 
                 {/* Pagination */}
                 {totalPages > 1 && (

--- a/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
-import { useRoute, Link } from "wouter";
+import { useRoute, Link, useLocation} from "wouter";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -38,7 +38,9 @@ import {
   AlertCircle,
   Loader2,
   Ban,
+  Trash2,
 } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { TaskExecutionProgress } from "@/components/TaskExecutionProgress";
 import { TripOperatorMap } from "@/components/map/TripOperatorMap";
@@ -55,11 +57,14 @@ import type { TaskInputField, FieldType } from "@/types/taskInputs";
 
 export default function WorkflowExecutionTaskDetail() {
   const [, params] = useRoute("/workflow-execution/:workflow_uuid/:execution_uuid");
+  const [, setLocation] = useLocation();
   const workflowUuid = params?.workflow_uuid || "";
   const executionUuid = params?.execution_uuid || "";
   const { toast } = useToast();
+  const { isAdmin } = useAuth();
   const [selectedTaskExecutionUuid, setSelectedTaskExecutionUuid] = useState<string | null>(null);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   // Fetch workflow execution details (includes task_executions)
   const { data: workflowExecution, isLoading: executionLoading } = useQuery<WorkflowExecution>({
@@ -361,6 +366,29 @@ export default function WorkflowExecutionTaskDetail() {
         variant: "destructive",
       });
       setShowCancelDialog(false);
+    },
+  });
+
+  // Soft-delete workflow execution (admins only)
+  const deleteExecutionMutation = useMutation({
+    mutationFn: async () => {
+      return await apiRequest(`/workflow-execution/${executionUuid}`, {
+        method: "DELETE",
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/workflow-execution/"] });
+      queryClient.invalidateQueries({ queryKey: ["/trip/"] });
+      toast({ title: "Execution deleted" });
+      setLocation(`/workflow-execution/${workflowUuid}`);
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Failed to delete execution",
+        description: error.message,
+        variant: "destructive",
+      });
+      setShowDeleteDialog(false);
     },
   });
 
@@ -1069,12 +1097,48 @@ export default function WorkflowExecutionTaskDetail() {
                     {cancelExecutionMutation.isPending ? "Cancelling..." : "Cancel Execution"}
                   </Button>
                 )}
+                {isAdmin && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="text-red-600 border-red-200 hover:bg-red-50"
+                    onClick={() => setShowDeleteDialog(true)}
+                    disabled={deleteExecutionMutation.isPending}
+                    data-testid="button-delete-execution"
+                  >
+                    <Trash2 className="h-4 w-4 mr-2" />
+                    {deleteExecutionMutation.isPending ? "Deleting..." : "Delete"}
+                  </Button>
+                )}
                 <Badge variant={getStatusBadgeVariant(workflowExecution.status)}>
                   {workflowExecution.status}
                 </Badge>
               </div>
             )}
           </div>
+
+          <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete this execution?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  The execution and any trip it created will be removed from all lists.
+                  This cannot be undone from the app.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel data-testid="button-cancel-delete-execution">Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-red-600 hover:bg-red-700"
+                  disabled={deleteExecutionMutation.isPending}
+                  onClick={() => deleteExecutionMutation.mutate()}
+                  data-testid="button-confirm-delete-execution"
+                >
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
 
           {isLoading ? (
             <div className="flex justify-center items-center h-64">


### PR DESCRIPTION
## Three changes

### App: create-order defaults to SYP
Orders created at a trip stop defaulted to USD; the business bills in SYP. SYP is now the default chip (USD still selectable).

### Web: admin soft-delete for trips and workflow executions
- `is_deleted` on `trip` + `workflow_execution` (migration `c7e2a9d4f1b8`)
- `DELETE /trip/<uuid>` / `DELETE /workflow-execution/<uuid>` — **admin/superadmin only**. An active entity is **cancelled first** (trip, stops, task executions) so deletion makes it inert, not just hidden; pairs are deleted together.
- Deleted rows are excluded from every read/write path: lists, gets, manual-stop, set-current-stop, task-execution + trip-stop reads, trip updates, cancels, task completion, the one-trip-per-user rule, and location-ingest trip stamping.
- Web UI: delete buttons + confirm dialogs on the Trips list, Trip detail, executions list, and execution detail pages, gated on a new `isAdmin` from AuthContext.

Adversarially reviewed with a 21-agent workflow (3 dimensions, per-finding verification) — 18 confirmed findings, all fixed except two accepted/noted: completed stops of deleted trips still count as a customer's last visit (the visit did happen), and `GET /location/trip` of a deleted trip stays readable (admin-only anyway).

Verified E2E on the local stack: deleting an in-progress trip with 34 live stops cancelled everything, freed the assignee, hid it from all lists, 404'd writes, and blocked non-admins (403).

### App: language-agnostic dates
Trip lists, the trip/stop/order screens, and the customer page showed English month names ("Jul 11 at 7:02 AM") in every UI language. Dates are now numeric (`07/11 07:02`, 24h) via a shared `utils/date.ts`, identical in all locales.

The two app-code changes need a TestFlight build after merge; the soft-delete ships with the web/backend deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
