### PR TITLE
Frontend deploys: reclaim droplet disk before pull

### DIFF
--- a/.github/workflows/frontend-deploy-dev.yml
+++ b/.github/workflows/frontend-deploy-dev.yml
@@ -43,6 +43,11 @@ jobs:
           port: 22
           script: |
             cd /root/app/frontend
+            # Auth to GHCR + reclaim disk before pulling the private image.
+            # Without this, expired creds or a full disk make `pull` silently
+            # no-op and stale code keeps running despite a "successful" deploy.
             echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker image prune -af
+            docker builder prune -af
             docker compose -f docker-compose.dev.yaml pull
             docker compose -f docker-compose.dev.yaml up -d --remove-orphans

--- a/.github/workflows/frontend-prod-deploy.yml
+++ b/.github/workflows/frontend-prod-deploy.yml
@@ -82,6 +82,11 @@ jobs:
           port: 22
           script: |
             cd /root/app/frontend
+            # Auth to GHCR + reclaim disk before pulling the private image.
+            # Without this, expired creds or a full disk make `pull` silently
+            # no-op and stale code keeps running despite a "successful" deploy.
             echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            docker image prune -af
+            docker builder prune -af
             docker compose -f docker-compose.prod.yaml pull
             docker compose -f docker-compose.prod.yaml up -d --remove-orphans


### PR DESCRIPTION
The frontend prod droplet ran out of disk during the PR #36 deploy: the pull failed mid-extract, the old container kept serving, and the run still reported success. The backend deploy workflows already prune images before pulling (fix from the earlier stale-deploy incident) — this mirrors it on frontend-prod-deploy and frontend-deploy-dev. Merging triggers a fresh frontend prod deploy which will prune and then serve the blank-page fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)