### PR TITLE
Frontend deploys: free droplet disk before file copies

### DIFF
--- a/.github/workflows/frontend-deploy-dev.yml
+++ b/.github/workflows/frontend-deploy-dev.yml
@@ -14,6 +14,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Free disk on server (before any file copies)
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.FRONTEND_DEV_DROPLET_HOST }}
+          username: root
+          password: ${{ secrets.FRONTEND_DEV_DROPLET_PASSWORD }}
+          port: 22
+          script: |
+            docker image prune -af || true
+            docker builder prune -af || true
+            docker container prune -f || true
+            journalctl --vacuum-size=100M || true
+            df -h /
+
       - name: Copy compose to server
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/.github/workflows/frontend-prod-deploy.yml
+++ b/.github/workflows/frontend-prod-deploy.yml
@@ -53,6 +53,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Free disk on server (before any file copies)
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.FRONTEND_PROD_DROPLET_HOST }}
+          username: root
+          password: ${{ secrets.FRONTEND_PROD_DROPLET_PASSWORD }}
+          port: 22
+          script: |
+            docker image prune -af || true
+            docker builder prune -af || true
+            docker container prune -f || true
+            journalctl --vacuum-size=100M || true
+            df -h /
+
       - name: Copy compose to prod server
         uses: appleboy/scp-action@v0.1.7
         with:


### PR DESCRIPTION
Follow-up to #37: the disk was so full that even the scp step failed, so the in-script prune never executed. Adds a dedicated SSH cleanup step before any file copies on both frontend deploy workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)