### PR TITLE
Vehicle detail: current-inventory table + live chart/table updates

### DIFF
--- a/frontend/client/src/components/vehicles/VehicleInventoryChart.tsx
+++ b/frontend/client/src/components/vehicles/VehicleInventoryChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   ResponsiveContainer,
@@ -77,6 +77,7 @@ export function VehicleInventoryChart({
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
   const [selected, setSelected] = useState<Set<string>>(new Set());
+  const seenRef = useRef<Set<string>>(new Set());
 
   const { data: invData } = useQuery({
     queryKey: ["/vehicle-inventory/", vehicleUuid, "chart"],
@@ -84,10 +85,21 @@ export function VehicleInventoryChart({
   });
   const inventories: VehicleInventory[] = invData?.vehicle_inventories || [];
 
-  // default: all materials selected (once they load)
+  // default: all materials selected; materials added later auto-select too
+  // (without re-selecting ones the user unchecked)
   useEffect(() => {
-    if (inventories.length && selected.size === 0) {
+    if (!inventories.length) return;
+    const firstLoad = seenRef.current.size === 0;
+    const fresh = inventories.filter((i) => !seenRef.current.has(i.uuid));
+    seenRef.current = new Set(inventories.map((i) => i.uuid));
+    if (firstLoad) {
       setSelected(new Set(inventories.map((i) => i.uuid)));
+    } else if (fresh.length) {
+      setSelected((prev) => {
+        const next = new Set(prev);
+        fresh.forEach((i) => next.add(i.uuid));
+        return next;
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [invData]);

--- a/frontend/client/src/components/vehicles/VehicleInventoryDialog.tsx
+++ b/frontend/client/src/components/vehicles/VehicleInventoryDialog.tsx
@@ -105,8 +105,13 @@ export function VehicleInventoryDialog({ vehicleUuid }: { vehicleUuid: string })
   const materials = materialsData?.materials || [];
 
   const refresh = () => {
+    // prefix-matches the dialog list, the Current Inventory table, and the
+    // chart's inventory query (["/vehicle-inventory/", vehicleUuid, ...])
     queryClient.invalidateQueries({ queryKey: invKey });
     queryClient.refetchQueries({ queryKey: invKey });
+    // the chart's line data lives under its own key — without this the chart
+    // doesn't move until a full page reload
+    queryClient.invalidateQueries({ queryKey: ["/vehicle-inventory-event/series"] });
   };
 
   const createInventory = useMutation({

--- a/frontend/client/src/components/vehicles/VehicleInventoryTable.tsx
+++ b/frontend/client/src/components/vehicles/VehicleInventoryTable.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { apiRequest } from "@/lib/queryClient";
+
+interface VehicleInventory {
+  uuid: string;
+  material_uuid: string;
+  material_name?: string | null;
+  unit?: string | null;
+  current_quantity?: number | null;
+}
+
+/**
+ * Current on-hand stock per material for a vehicle. Shares the
+ * ["/vehicle-inventory/", vehicleUuid] query prefix with the inventory
+ * dialog, so applying an add/adjust/unload refreshes this table live.
+ */
+export function VehicleInventoryTable({ vehicleUuid }: { vehicleUuid: string }) {
+  const { data, isLoading } = useQuery({
+    queryKey: ["/vehicle-inventory/", vehicleUuid, "table"],
+    queryFn: async () =>
+      apiRequest(`/vehicle-inventory/?vehicle_uuid=${vehicleUuid}&per_page=100`),
+  });
+  const inventories: VehicleInventory[] = data?.vehicle_inventories || [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Current Inventory</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="text-sm text-gray-500 py-6 text-center">Loading...</div>
+        ) : inventories.length === 0 ? (
+          <div className="text-sm text-gray-500 py-6 text-center">
+            No inventory on this vehicle yet.
+          </div>
+        ) : (
+          <Table data-testid="table-vehicle-inventory">
+            <TableHeader>
+              <TableRow>
+                <TableHead>Material</TableHead>
+                <TableHead className="text-right">On hand</TableHead>
+                <TableHead>Unit</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {inventories.map((inv) => (
+                <TableRow key={inv.uuid} data-testid={`row-vinv-${inv.uuid}`}>
+                  <TableCell className="font-medium">
+                    {inv.material_name || inv.material_uuid}
+                  </TableCell>
+                  <TableCell
+                    className="text-right font-semibold tabular-nums"
+                    data-testid={`text-vinv-qty-${inv.uuid}`}
+                  >
+                    {inv.current_quantity ?? 0}
+                  </TableCell>
+                  <TableCell className="text-gray-500">{inv.unit || "—"}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/client/src/pages/VehicleDetail.tsx
+++ b/frontend/client/src/pages/VehicleDetail.tsx
@@ -37,6 +37,7 @@ import { queryClient, apiRequest } from "@/lib/queryClient";
 import { VehicleStatus, type Vehicle, type VehicleUpdateData } from "@/lib/types";
 import { VehicleInventoryDialog } from "@/components/vehicles/VehicleInventoryDialog";
 import { VehicleInventoryChart } from "@/components/vehicles/VehicleInventoryChart";
+import { VehicleInventoryTable } from "@/components/vehicles/VehicleInventoryTable";
 
 const vehicleUpdateSchema = z.object({
   plate_number: z.string().min(1, "Plate number is required").optional(),
@@ -600,6 +601,11 @@ export default function VehicleDetail() {
               </CardContent>
             </Card>
           </div>
+        </div>
+
+        {/* Current inventory per material */}
+        <div className="mt-6">
+          <VehicleInventoryTable vehicleUuid={uuid as string} />
         </div>
 
         {/* Inventory time series chart */}


### PR DESCRIPTION
Adds a Current Inventory table (material / on-hand / unit) to the vehicle detail page, and makes both the table and the Inventory Over Time chart update live when inventory events are applied from the Inventory dialog (the dialog previously only invalidated its own list, so the chart never refreshed without a reload). Newly added materials now auto-appear as chart lines too.

Verified E2E on the local stack: applied +25 flour and +10 modified starch through the dialog — table quantities and chart lines updated without any page reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)