### PR TITLE
Add customer categories: school, university, hospital

### DIFF
--- a/backend/app/dto/customer.py
+++ b/backend/app/dto/customer.py
@@ -16,6 +16,9 @@ class CustomerCategory(str, Enum):
     MINIMARKET = "minimarket"
     SUPERMARKET = "supermarket"
     DISTRIBUTER = "distributer"
+    SCHOOL = "school"
+    UNIVERSITY = "university"
+    HOSPITAL = "hospital"
 
 
 

--- a/expo_app/app/customers.tsx
+++ b/expo_app/app/customers.tsx
@@ -22,7 +22,7 @@ interface Customer {
   full_address: string;
   business_cards: string | null;
   notes: string | null;
-  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer';
+  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer' | 'school' | 'university' | 'hospital';
   coordinates: string | null;
   created_at: string;
   is_deleted: boolean;
@@ -47,7 +47,7 @@ export default function CustomersScreen() {
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState('');
-  const [categoryFilter, setCategoryFilter] = useState<'all' | 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer'>('all');
+  const [categoryFilter, setCategoryFilter] = useState<'all' | 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer' | 'school' | 'university' | 'hospital'>('all');
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [screenData, setScreenData] = useState(Dimensions.get('window'));
@@ -126,12 +126,12 @@ export default function CustomersScreen() {
       } else {
         console.error('Error fetching categories:', response.error);
         // Fallback to static categories
-        setCategories(['roastery', 'restaurant', 'minimarket', 'supermarket', 'distributer']);
+        setCategories(['roastery', 'restaurant', 'minimarket', 'supermarket', 'distributer', 'school', 'university', 'hospital']);
       }
     } catch (error) {
       console.error('Error fetching categories:', error);
       // Fallback to static categories
-      setCategories(['roastery', 'restaurant', 'minimarket', 'supermarket', 'distributer']);
+      setCategories(['roastery', 'restaurant', 'minimarket', 'supermarket', 'distributer', 'school', 'university', 'hospital']);
     }
   };
 
@@ -404,7 +404,7 @@ export default function CustomersScreen() {
       />
 
       <View style={styles.categoryFilterContainer}>
-        {(['all', 'roastery', 'restaurant', 'minimarket', 'supermarket', 'distributer'] as const).map((category) => (
+        {(['all', 'roastery', 'restaurant', 'minimarket', 'supermarket', 'distributer', 'school', 'university', 'hospital'] as const).map((category) => (
           <TouchableOpacity
             key={category}
             style={[

--- a/expo_app/app/customers/[id].tsx
+++ b/expo_app/app/customers/[id].tsx
@@ -40,7 +40,10 @@ interface Customer {
     | "restaurant"
     | "minimarket"
     | "supermarket"
-    | "distributer";
+    | "distributer"
+    | "school"
+    | "university"
+    | "hospital";
   coordinates: string | null;
   created_at: string;
   is_deleted: boolean;
@@ -511,6 +514,9 @@ export default function CustomerDetailScreen() {
     minimarket: "#5469D4",
     supermarket: "#5469D4",
     distributer: "#5469D4",
+    school: "#5469D4",
+    university: "#5469D4",
+    hospital: "#5469D4",
   };
 
   if (loading) {
@@ -569,6 +575,9 @@ export default function CustomerDetailScreen() {
             "minimarket",
             "supermarket",
             "distributer",
+            "school",
+            "university",
+            "hospital",
           ] as const
         ).map((category) => (
           <TouchableOpacity

--- a/expo_app/app/customers/create.tsx
+++ b/expo_app/app/customers/create.tsx
@@ -17,7 +17,7 @@ interface CustomerForm {
   phone_number: string;
   company_name: string;
   full_address: string;
-  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer';
+  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer' | 'school' | 'university' | 'hospital';
   business_cards: string;
   notes: string;
   coordinates: string;
@@ -38,7 +38,7 @@ export default function CreateCustomerScreen() {
     coordinates: '',
   });
   const [loading, setLoading] = useState(false);
-  const [categories, setCategories] = useState<string[]>(['restaurant', 'roastery', 'minimarket', 'supermarket', 'distributer']);
+  const [categories, setCategories] = useState<string[]>(['restaurant', 'roastery', 'minimarket', 'supermarket', 'distributer', 'school', 'university', 'hospital']);
   const [screenData, setScreenData] = useState(Dimensions.get('window'));
   const [banner, setBanner] = useState<{type: 'success' | 'error', message: string} | null>(null);
   const bannerAnimation = useState(new Animated.Value(0))[0];

--- a/expo_app/components/CustomerLocationMap.tsx
+++ b/expo_app/components/CustomerLocationMap.tsx
@@ -12,7 +12,7 @@ interface Customer {
   full_address: string;
   business_cards: string | null;
   notes: string | null;
-  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer';
+  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer' | 'school' | 'university' | 'hospital';
   coordinates: string | null;
   created_at: string;
   is_deleted: boolean;

--- a/expo_app/components/CustomerLocationMap.web.tsx
+++ b/expo_app/components/CustomerLocationMap.web.tsx
@@ -11,7 +11,7 @@ interface Customer {
   full_address: string;
   business_cards: string | null;
   notes: string | null;
-  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer';
+  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer' | 'school' | 'university' | 'hospital';
   coordinates: string | null;
   created_at: string;
   is_deleted: boolean;

--- a/expo_app/components/MapView.tsx
+++ b/expo_app/components/MapView.tsx
@@ -14,7 +14,7 @@ interface Customer {
   full_address: string;
   business_cards: string | null;
   notes: string | null;
-  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer';
+  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer' | 'school' | 'university' | 'hospital';
   coordinates: string | null;
   created_at: string;
   is_deleted: boolean;

--- a/expo_app/components/MapView.web.tsx
+++ b/expo_app/components/MapView.web.tsx
@@ -11,7 +11,7 @@ interface Customer {
   full_address: string;
   business_cards: string | null;
   notes: string | null;
-  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer';
+  category: 'roastery' | 'restaurant' | 'minimarket' | 'supermarket' | 'distributer' | 'school' | 'university' | 'hospital';
   coordinates: string | null;
   created_at: string;
   is_deleted: boolean;

--- a/expo_app/i18n/enums.ts
+++ b/expo_app/i18n/enums.ts
@@ -10,6 +10,9 @@ const ENUM_AR: Record<string, string> = {
   minimarket: 'ميني ماركت',
   supermarket: 'سوبر ماركت',
   distributer: 'موزّع',
+  school: 'مدرسة',
+  university: 'جامعة',
+  hospital: 'مشفى',
   // currencies (Currency)
   USD: 'دولار',
   SYP: 'ل.س',


### PR DESCRIPTION
Adds three customer categories to the backend enum (validates customer create/update, feeds /customer/categories, and the start-trip routing form via read-time enrichment — no task-definition data change needed) and to every hardcoded list in the Expo app, with Arabic labels (مدرسة / جامعة / مشفى) in the enum mapper. The web app picks them up dynamically.

Verified locally: /customer/categories returns all 8 values with the updated backend.

Note: the app-side changes (Arabic labels + category chips) ride the next TestFlight build; the backend part deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)