### PR TITLE
System improvements: descriptive lists, material analytics, process templates

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -30,6 +30,7 @@ from app.entrypoint.routes.inventory_event import inventory_event_blueprint
 from app.entrypoint.routes.debit_note import debit_note_item_blueprint
 from app.entrypoint.routes.credit_note import credit_note_item_blueprint
 from app.entrypoint.routes.process import process_blueprint
+from app.entrypoint.routes.process_template import process_template_blueprint
 from app.entrypoint.routes.auth import auth_blueprint
 from app.entrypoint.routes.workflow import workflow_blueprint
 from app.entrypoint.routes.task import task_blueprint
@@ -99,6 +100,7 @@ def create_app(config_object=Config):
     app.register_blueprint(debit_note_item_blueprint, url_prefix='/debit-note-item')
     app.register_blueprint(credit_note_item_blueprint, url_prefix='/credit-note-item')
     app.register_blueprint(process_blueprint, url_prefix='/process')
+    app.register_blueprint(process_template_blueprint, url_prefix='/process-template')
     app.register_blueprint(auth_blueprint, url_prefix='/auth')
     app.register_blueprint(workflow_blueprint, url_prefix='/workflow')
     app.register_blueprint(task_blueprint, url_prefix='/task')

--- a/backend/app/adapters/repositories/_abstract_repo.py
+++ b/backend/app/adapters/repositories/_abstract_repo.py
@@ -153,6 +153,9 @@ class AbstractRepository(Generic[BASE]):
             query = query.filter(*filters)
         if ordering:
             query = query.order_by(*ordering)
+        elif hasattr(self._type, "created_at"):
+            # list pages default to newest-first
+            query = query.order_by(self._type.created_at.desc())
         total = query.count()
         offset = (page - 1) * per_page
         items = query.offset(offset).limit(per_page).all()

--- a/backend/app/adapters/repositories/process_template_repository.py
+++ b/backend/app/adapters/repositories/process_template_repository.py
@@ -1,0 +1,8 @@
+from app.adapters.repositories._abstract_repo import AbstractRepository
+from models.common import ProcessTemplate
+
+
+class ProcessTemplateRepository(AbstractRepository[ProcessTemplate]):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._type = ProcessTemplate

--- a/backend/app/adapters/unit_of_work/sqlalchemy_unit_of_work.py
+++ b/backend/app/adapters/unit_of_work/sqlalchemy_unit_of_work.py
@@ -26,6 +26,7 @@ from app.adapters.repositories.inventory_event_repository import InventoryEventR
 from app.adapters.repositories.debit_note_item_repository import DebitNoteItemRepository
 from app.adapters.repositories.credit_note_item_repository import CreditNoteItemRepository
 from app.adapters.repositories.process_repository import ProcessRepository
+from app.adapters.repositories.process_template_repository import ProcessTemplateRepository
 from app.adapters.repositories.user_repository import UserRepository
 from app.adapters.repositories.workflow_repository import WorkflowRepository
 from app.adapters.repositories.task_repository import TaskRepository  # Placeholder for task repository
@@ -72,6 +73,7 @@ class SqlAlchemyUnitOfWork(AbstractUnitOfWork):
         self.debit_note_item_repository = DebitNoteItemRepository(session=self.session)
         self.credit_note_item_repository = CreditNoteItemRepository(session=self.session)
         self.process_repository = ProcessRepository(session=self.session)
+        self.process_template_repository = ProcessTemplateRepository(session=self.session)
         self.user_repository = UserRepository(session=self.session)
         self.workflow_repository = WorkflowRepository(session=self.session)
         self.task_repository = TaskRepository(session=self.session)

--- a/backend/app/dto/customer_order.py
+++ b/backend/app/dto/customer_order.py
@@ -1,5 +1,5 @@
 # app/dto/customer_order.py
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, model_validator
 from typing import Optional, List
 from datetime import datetime
 
@@ -49,6 +49,15 @@ class CustomerOrderRead(CustomerOrderBase):
     net_amount_due: Optional[float] = None
     net_amount_paid: Optional[float] = None
     trip_stop_uuid: Optional[str] = None
+    # display names resolved from the customer relationship
+    customer_company_name: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices(
+            "customer_company_name", AliasPath("customer", "company_name")))
+    customer_full_name: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices(
+            "customer_full_name", AliasPath("customer", "full_name")))
     is_paid: Optional[bool] = None
     currency: Optional[Currency] = None
 

--- a/backend/app/dto/inventory.py
+++ b/backend/app/dto/inventory.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field
 from typing import Optional, List
 from datetime import datetime
 from app.dto.common_enums import UnitOfMeasure, Currency
@@ -43,6 +43,9 @@ class InventoryRead(InventoryBase):
     created_at: datetime
     is_deleted: bool
     total_original_cost: Optional[float] = None
+    material_name: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices("material_name", AliasPath("material", "name")))
 
 class InventoryListParams(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/backend/app/dto/inventory_event.py
+++ b/backend/app/dto/inventory_event.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, model_validator
 from typing import Optional, List
 from datetime import datetime
 from app.entrypoint.routes.common.errors import BadRequestError
@@ -74,6 +74,9 @@ class InventoryEventRead(InventoryEventBase):
     material_uuid: str
     created_at: datetime
     is_deleted: bool
+    material_name: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices("material_name", AliasPath("material", "name")))
 
 
 class InventoryEventListParams(BaseModel):

--- a/backend/app/dto/process_template.py
+++ b/backend/app/dto/process_template.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProcessTemplateCreate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    created_by_uuid: Optional[str] = None
+    name: str = Field(..., min_length=1, max_length=255)
+    type: str
+    notes: Optional[str] = None
+    data: dict = Field(default_factory=dict)
+
+
+class ProcessTemplateRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+    uuid: str
+    created_by_uuid: Optional[str] = None
+    created_at: datetime
+    name: str
+    type: str
+    notes: Optional[str] = None
+    data: Optional[dict] = None
+    is_deleted: bool
+
+
+class ProcessTemplateListParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: Optional[str] = None
+    page: int = Field(1, gt=0)
+    per_page: int = Field(20, gt=0, le=100)
+
+
+class ProcessTemplatePage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    items: List[ProcessTemplateRead]
+    total_count: int
+    page: int
+    per_page: int
+    pages: int

--- a/backend/app/dto/trip.py
+++ b/backend/app/dto/trip.py
@@ -1,7 +1,7 @@
 # app/dto/trip.py
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, AliasPath, BaseModel, ConfigDict, Field, field_validator
 from typing import Optional, List
 from datetime import datetime
 
@@ -183,6 +183,12 @@ class TripRead(BaseModel):
     workflow_execution_uuid: Optional[str] = None
     start_inventory: Optional[dict] = None
     end_inventory: Optional[dict] = None
+    # display fields: plate from the vehicle relationship; assignee is
+    # enriched by the list route (it lives on the start_trip task result)
+    vehicle_plate: Optional[str] = Field(
+        None,
+        validation_alias=AliasChoices("vehicle_plate", AliasPath("vehicle", "plate_number")))
+    assigned_username: Optional[str] = None
     inventory_reconciliation: Optional[dict] = None
     expected_cash: Optional[dict] = None  # {currency: amount} collected at this trip's stops
 

--- a/backend/app/entrypoint/routes/material/routes.py
+++ b/backend/app/entrypoint/routes/material/routes.py
@@ -122,6 +122,69 @@ def list_materials():
     return jsonify(result), 200
 
 
+@material_blueprint.route('/<string:uuid>/inventory-summary', methods=['GET'])
+@jwt_required()
+@scopes_required(PermissionScope.ADMIN.value,
+                 PermissionScope.SUPER_ADMIN.value,
+                 PermissionScope.OPERATION_MANAGER.value)
+def material_inventory_summary(uuid: str):
+    """Stock-over-time series + per-lot cost breakdown for one material.
+
+    - events: every inventory-event delta, oldest first (the client
+      cumulative-sums them into the total-stock series)
+    - lots: non-deleted inventories with remaining stock (> 0), each with its
+      cost per unit computed the same way the inventory detail does
+      (event costs -> purchase item prices -> process output costing)
+    """
+    from models.common import InventoryEvent as InventoryEventModel
+    from app.domains.inventory.domain import InventoryDomain
+    from app.dto.inventory import InventoryRead
+
+    with SqlAlchemyUnitOfWork() as uow:
+        m = uow.material_repository.find_one(uuid=uuid, is_deleted=False)
+        if not m:
+            return jsonify({'message': 'Material not found'}), 404
+
+        rows = (
+            uow.session.query(InventoryEventModel.created_at, InventoryEventModel.quantity)
+            .filter(
+                InventoryEventModel.material_uuid == uuid,
+                InventoryEventModel.is_deleted.is_(False),
+            )
+            .order_by(InventoryEventModel.created_at.asc())
+            .all()
+        )
+        events = [
+            {"t": r[0].isoformat() if r[0] else None, "quantity": r[1]}
+            for r in rows
+        ]
+
+        lots = []
+        for inv in uow.inventory_repository.find_all(material_uuid=uuid, is_deleted=False):
+            qty = inv.current_quantity
+            if not qty or qty <= 0:
+                continue  # empty lots are noise — hidden by design
+            dto = InventoryRead.from_orm(inv)
+            InventoryDomain.enrich_cost_per_unit(uow=uow, inventory_dto=dto)
+            currency = inv.currency or next(
+                (e.currency for e in inv.inventory_events if not e.is_deleted and e.currency),
+                None,
+            )
+            lots.append({
+                "uuid": inv.uuid,
+                "lot_id": inv.lot_id,
+                "warehouse_name": inv.warehouse.name if inv.warehouse else None,
+                "current_quantity": qty,
+                "unit": inv.unit,
+                "cost_per_unit": dto.cost_per_unit,
+                "currency": currency,
+                "created_at": inv.created_at.isoformat() if inv.created_at else None,
+                "expiration_date": inv.expiration_date.isoformat() if inv.expiration_date else None,
+            })
+        lots.sort(key=lambda l: l["created_at"] or "")
+    return jsonify({"events": events, "lots": lots}), 200
+
+
 # unit of measure enum list route
 @material_blueprint.route('/unit-of-measure', methods=['GET'])
 def list_unit_of_measure():

--- a/backend/app/entrypoint/routes/process_template/__init__.py
+++ b/backend/app/entrypoint/routes/process_template/__init__.py
@@ -1,0 +1,6 @@
+from flask import Blueprint
+
+process_template_blueprint = Blueprint('process_template', __name__)
+
+# Import routes so they are registered with the blueprint
+from . import routes

--- a/backend/app/entrypoint/routes/process_template/routes.py
+++ b/backend/app/entrypoint/routes/process_template/routes.py
@@ -1,0 +1,72 @@
+from flask import request, jsonify
+from flask_jwt_extended import get_jwt_identity, jwt_required
+
+from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+from app.dto.auth import PermissionScope
+from app.dto.process_template import (
+    ProcessTemplateCreate,
+    ProcessTemplateRead,
+    ProcessTemplateListParams,
+    ProcessTemplatePage,
+)
+from app.entrypoint.routes.common.auth import scopes_required, add_logged_user_to_payload
+from app.entrypoint.routes.common.errors import NotFoundError
+from app.entrypoint.routes.process_template import process_template_blueprint
+from models.common import ProcessTemplate as ProcessTemplateModel
+
+# same audience as process create — templates only pre-fill that form
+SCOPES = (
+    PermissionScope.ADMIN.value,
+    PermissionScope.SUPER_ADMIN.value,
+    PermissionScope.OPERATOR.value,
+    PermissionScope.OPERATION_MANAGER.value,
+)
+
+
+@process_template_blueprint.route("/", methods=["POST"])
+@jwt_required()
+@scopes_required(*SCOPES)
+def create_process_template():
+    payload = ProcessTemplateCreate(**request.json)
+    current_user_uuid = get_jwt_identity()
+    with SqlAlchemyUnitOfWork() as uow:
+        add_logged_user_to_payload(uow=uow, user_uuid=current_user_uuid, payload=payload)
+        m = ProcessTemplateModel(**payload.model_dump(mode="json"))
+        uow.process_template_repository.save(model=m, commit=True)
+        result = ProcessTemplateRead.from_orm(m).model_dump(mode="json")
+    return jsonify(result), 201
+
+
+@process_template_blueprint.route("/", methods=["GET"])
+@jwt_required()
+@scopes_required(*SCOPES)
+def list_process_templates():
+    params = ProcessTemplateListParams(**request.args)
+    filters = [ProcessTemplateModel.is_deleted.is_(False)]
+    if params.name:
+        filters.append(ProcessTemplateModel.name.ilike(f"%{params.name}%"))
+    with SqlAlchemyUnitOfWork() as uow:
+        page = uow.process_template_repository.find_all_by_filters_paginated(
+            filters=filters, page=params.page, per_page=params.per_page
+        )
+        result = ProcessTemplatePage(
+            items=[ProcessTemplateRead.from_orm(m).model_dump(mode="json") for m in page.items],
+            total_count=page.total,
+            page=page.page,
+            per_page=page.per_page,
+            pages=page.pages,
+        ).model_dump(mode="json")
+    return jsonify(result), 200
+
+
+@process_template_blueprint.route("/<string:uuid>", methods=["DELETE"])
+@jwt_required()
+@scopes_required(*SCOPES)
+def delete_process_template(uuid: str):
+    with SqlAlchemyUnitOfWork() as uow:
+        m = uow.process_template_repository.find_one(uuid=uuid, is_deleted=False)
+        if not m:
+            raise NotFoundError("Process template not found")
+        m.is_deleted = True
+        uow.process_template_repository.save(model=m, commit=True)
+    return jsonify({"uuid": uuid, "is_deleted": True}), 200

--- a/backend/app/entrypoint/routes/trip/routes.py
+++ b/backend/app/entrypoint/routes/trip/routes.py
@@ -228,8 +228,47 @@ def list_trips():
             page=params.page,
             per_page=params.per_page,
         )
-        # Convert each geometry field to WKT via TripRead validator
-        items = [TripRead.from_orm(m).model_dump(mode="json") for m in page.items]
+
+        # batch-resolve each trip's assignee (start_trip result, stored as
+        # username or uuid) — two queries for the whole page, no N+1
+        from models.common import (
+            TaskExecution as TaskExecutionModel,
+            Task as TaskModel,
+            User as UserModel,
+        )
+        wfe_uuids = [t.workflow_execution_uuid for t in page.items if t.workflow_execution_uuid]
+        assigned_by_wfe: dict = {}
+        if wfe_uuids:
+            rows = (
+                uow.session.query(
+                    TaskExecutionModel.workflow_execution_uuid,
+                    TaskExecutionModel.result["assigned_user_uuid"].astext,
+                )
+                .join(TaskModel, TaskModel.uuid == TaskExecutionModel.task_uuid)
+                .filter(
+                    TaskExecutionModel.workflow_execution_uuid.in_(wfe_uuids),
+                    TaskModel.operator == "start_trip_operator",
+                )
+                .all()
+            )
+            values = {v for _, v in rows if v}
+            users = (
+                uow.session.query(UserModel.uuid, UserModel.username)
+                .filter(UserModel.uuid.in_(values) | UserModel.username.in_(values))
+                .all()
+            ) if values else []
+            uuid_to_name = {u[0]: u[1] for u in users}
+            usernames = {u[1] for u in users}
+            for wfe_uuid, v in rows:
+                if not v:
+                    continue
+                assigned_by_wfe[wfe_uuid] = uuid_to_name.get(v) or (v if v in usernames else v)
+
+        items = []
+        for m in page.items:
+            dto = TripRead.from_orm(m)
+            dto.assigned_username = assigned_by_wfe.get(m.workflow_execution_uuid)
+            items.append(dto.model_dump(mode="json"))
         result = TripPage(
             items=items,
             total_count=page.total,

--- a/backend/migrations/versions/d4f8b2c7e9a1_process_template.py
+++ b/backend/migrations/versions/d4f8b2c7e9a1_process_template.py
@@ -1,0 +1,36 @@
+"""Process templates
+
+Revision ID: d4f8b2c7e9a1
+Revises: c7e2a9d4f1b8
+Create Date: 2026-07-16
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'd4f8b2c7e9a1'
+down_revision = 'c7e2a9d4f1b8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'process_template',
+        sa.Column('uuid', sa.String(length=36), nullable=False),
+        sa.Column('created_by_uuid', sa.String(length=36), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=False),
+        sa.Column('type', sa.String(length=120), nullable=False),
+        sa.Column('notes', sa.Text(), nullable=True),
+        sa.Column('data', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('is_deleted', sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.ForeignKeyConstraint(['created_by_uuid'], ['user.uuid']),
+        sa.PrimaryKeyConstraint('uuid'),
+    )
+
+
+def downgrade():
+    op.drop_table('process_template')

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -1330,6 +1330,20 @@ class FixedAsset(Base):
         return self.price_per_unit * self.quantity
 
 
+class ProcessTemplate(Base):
+    """Named, reusable pre-fill for the process create form (type, notes,
+    inputs/outputs). Pure convenience data — no FK side effects."""
+    __tablename__ = "process_template"
+    uuid = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    created_by_uuid = Column(String(36), ForeignKey('user.uuid'), nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    name = Column(String(255), nullable=False)
+    type = Column(String(120), nullable=False)
+    notes = Column(Text, nullable=True)
+    data = Column(MutableDict.as_mutable(JSONB), default=dict)
+    is_deleted = Column(Boolean, default=False, nullable=False, server_default=false())
+
+
 class Process(Base):
     __tablename__ = "process"
 

--- a/frontend/client/src/components/materials/MaterialInventorySection.tsx
+++ b/frontend/client/src/components/materials/MaterialInventorySection.tsx
@@ -1,0 +1,200 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { apiRequest } from "@/lib/queryClient";
+
+interface SeriesEvent {
+  t: string | null;
+  quantity: number;
+}
+
+interface InventoryLot {
+  uuid: string;
+  lot_id?: string | null;
+  warehouse_name?: string | null;
+  current_quantity?: number | null;
+  cost_per_unit?: number | null;
+  currency?: string | null;
+  unit?: string | null;
+  created_at?: string | null;
+  expiration_date?: string | null;
+}
+
+// backend timestamps are naive UTC — parse as UTC (same convention as the
+// vehicle inventory chart)
+const toMs = (s: string) => {
+  const hasTz = /[zZ]|[+-]\d{2}:?\d{2}$/.test(s);
+  return new Date(hasTz ? s : s + "Z").getTime();
+};
+
+const fmt = (n: number) =>
+  n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+
+const DAY = 24 * 60 * 60 * 1000;
+
+export function MaterialInventorySection({ materialUuid }: { materialUuid: string }) {
+  const { data: summary } = useQuery<{ events: SeriesEvent[]; lots: InventoryLot[] }>({
+    queryKey: ["/material/", materialUuid, "inventory-summary"],
+    queryFn: () => apiRequest(`/material/${materialUuid}/inventory-summary`),
+    enabled: !!materialUuid,
+  });
+
+  // cumulative total-stock series
+  const chartRows = useMemo(() => {
+    const events = (summary?.events || []).filter((e) => e.t);
+    let bal = 0;
+    return events.map((e) => {
+      bal += e.quantity || 0;
+      return { t: toMs(e.t as string), total: Math.round(bal * 100) / 100 };
+    });
+  }, [summary]);
+
+  // lots come pre-filtered from the API: only lots with remaining stock
+  const lots: InventoryLot[] = summary?.lots || [];
+
+  // weighted average cost per currency over remaining stock
+  const avgCost = useMemo(() => {
+    const acc: Record<string, { qty: number; value: number }> = {};
+    for (const l of lots) {
+      if (l.cost_per_unit == null) continue;
+      const cur = l.currency || "?";
+      (acc[cur] ||= { qty: 0, value: 0 });
+      acc[cur].qty += l.current_quantity || 0;
+      acc[cur].value += (l.current_quantity || 0) * l.cost_per_unit;
+    }
+    return Object.entries(acc)
+      .filter(([, v]) => v.qty > 0)
+      .map(([cur, v]) => ({ currency: cur, avg: v.value / v.qty, qty: v.qty, value: v.value }));
+  }, [lots]);
+
+  const spanMs = chartRows.length ? chartRows[chartRows.length - 1].t - chartRows[0].t : 0;
+  const tickFmt = (t: number) =>
+    spanMs <= 2 * DAY
+      ? new Date(t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+      : new Date(t).toLocaleDateString();
+
+  const fmtDate = (s?: string | null) => (s ? new Date(s).toLocaleDateString() : "—");
+
+  return (
+    <div className="mt-6 space-y-6">
+      {/* total stock over time */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Total Inventory Over Time</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {chartRows.length === 0 ? (
+            <p className="text-sm text-gray-500 py-8 text-center" data-testid="material-series-empty">
+              No inventory events for this material yet.
+            </p>
+          ) : (
+            <ResponsiveContainer width="100%" height={300}>
+              <LineChart data={chartRows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis
+                  dataKey="t"
+                  type="number"
+                  scale="time"
+                  domain={["dataMin", "dataMax"]}
+                  tickFormatter={tickFmt}
+                  fontSize={12}
+                />
+                <YAxis allowDecimals fontSize={12} />
+                <Tooltip
+                  labelFormatter={(t) => new Date(t as number).toLocaleString()}
+                  formatter={(v: any) => [fmt(v as number), "Total stock"]}
+                />
+                <Line
+                  type="stepAfter"
+                  dataKey="total"
+                  stroke="#5469D4"
+                  dot={false}
+                  strokeWidth={2}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* cost per lot */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Inventory Lots &amp; Cost</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {lots.length === 0 ? (
+            <p className="text-sm text-gray-500 py-8 text-center" data-testid="material-lots-empty">
+              No lots with remaining stock.
+            </p>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm" data-testid="table-material-lots">
+                  <thead>
+                    <tr className="text-left text-gray-500 border-b">
+                      <th className="py-2 pr-4 font-medium">Lot</th>
+                      <th className="py-2 pr-4 font-medium">Warehouse</th>
+                      <th className="py-2 pr-4 font-medium text-right">On hand</th>
+                      <th className="py-2 pr-4 font-medium">Unit</th>
+                      <th className="py-2 pr-4 font-medium text-right">Cost / unit</th>
+                      <th className="py-2 pr-4 font-medium text-right">Stock value</th>
+                      <th className="py-2 pr-4 font-medium">Received</th>
+                      <th className="py-2 font-medium">Expires</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {lots.map((l) => (
+                      <tr key={l.uuid} className="border-b last:border-0" data-testid={`row-lot-${l.uuid}`}>
+                        <td className="py-2 pr-4 font-mono text-xs">{l.lot_id || l.uuid.slice(0, 8)}</td>
+                        <td className="py-2 pr-4">{l.warehouse_name || "—"}</td>
+                        <td className="py-2 pr-4 text-right font-semibold tabular-nums">
+                          {fmt(l.current_quantity || 0)}
+                        </td>
+                        <td className="py-2 pr-4 text-gray-500">{l.unit || "—"}</td>
+                        <td className="py-2 pr-4 text-right tabular-nums">
+                          {l.cost_per_unit != null ? `${fmt(l.cost_per_unit)} ${l.currency || ""}` : "—"}
+                        </td>
+                        <td className="py-2 pr-4 text-right tabular-nums">
+                          {l.cost_per_unit != null
+                            ? `${fmt((l.current_quantity || 0) * l.cost_per_unit)} ${l.currency || ""}`
+                            : "—"}
+                        </td>
+                        <td className="py-2 pr-4 whitespace-nowrap">{fmtDate(l.created_at)}</td>
+                        <td className="py-2 whitespace-nowrap">{fmtDate(l.expiration_date)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* weighted average cost of remaining stock */}
+              <div className="mt-4 flex flex-wrap gap-x-8 gap-y-2 text-sm" data-testid="material-avg-cost">
+                {avgCost.length === 0 ? (
+                  <span className="text-gray-500">No cost data on remaining lots.</span>
+                ) : (
+                  avgCost.map((a) => (
+                    <span key={a.currency} className="text-gray-600">
+                      Avg cost ({a.currency}):{" "}
+                      <b data-testid={`avg-cost-${a.currency}`}>{fmt(a.avg)}</b>
+                      <span className="text-gray-400"> · {fmt(a.qty)} on hand · value {fmt(a.value)}</span>
+                    </span>
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/client/src/lib/types.ts
+++ b/frontend/client/src/lib/types.ts
@@ -508,6 +508,8 @@ export interface Trip {
   end_point?: string;
   data?: TripData;
   workflow_execution_uuid?: string;
+  vehicle_plate?: string | null;
+  assigned_username?: string | null;
   start_inventory?: Record<string, number> | null;
   end_inventory?: Record<string, number> | null;
   inventory_reconciliation?: Record<

--- a/frontend/client/src/pages/CustomerOrders.tsx
+++ b/frontend/client/src/pages/CustomerOrders.tsx
@@ -13,6 +13,8 @@ interface CustomerOrder {
   created_by_uuid?: string;
   customer_uuid: string;
   customer_name?: string;
+  customer_company_name?: string;
+  customer_full_name?: string;
   created_at: string;
   is_fulfilled: boolean;
   fulfilled_at?: string;
@@ -302,6 +304,9 @@ export default function CustomerOrders() {
                     Net Amount Paid
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                    Company
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                     Customer
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
@@ -321,7 +326,7 @@ export default function CustomerOrders() {
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                 {isLoading ? (
                   <tr>
-                    <td colSpan={7} className="px-6 py-16 text-center">
+                    <td colSpan={8} className="px-6 py-16 text-center">
                       <div className="animate-pulse space-y-4">
                         <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-32 mx-auto"></div>
                         <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-48 mx-auto"></div>
@@ -332,7 +337,7 @@ export default function CustomerOrders() {
                   </tr>
                 ) : customerOrders.length === 0 ? (
                   <tr>
-                    <td colSpan={7} className="px-6 py-16 text-center">
+                    <td colSpan={8} className="px-6 py-16 text-center">
                       <ShoppingBag className="h-12 w-12 text-gray-400 mx-auto mb-4" />
                       <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
                         {error ? "Authentication Required" : "No customer orders"}
@@ -382,8 +387,13 @@ export default function CustomerOrders() {
                         </span>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <span className="text-sm text-gray-900 dark:text-gray-100">
-                          {order.customer_name || order.customer_uuid}
+                        <span className="text-sm text-gray-900 dark:text-gray-100" data-testid={`text-order-company-${order.uuid}`}>
+                          {order.customer_company_name || "—"}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className="text-sm text-gray-900 dark:text-gray-100" data-testid={`text-order-customer-${order.uuid}`}>
+                          {order.customer_full_name || order.customer_name || order.customer_uuid.slice(0, 8)}
                         </span>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">

--- a/frontend/client/src/pages/Inventory.tsx
+++ b/frontend/client/src/pages/Inventory.tsx
@@ -14,6 +14,7 @@ import { Package, Building } from "lucide-react";
 interface Inventory {
   uuid: string;
   material_uuid: string;
+  material_name?: string | null;
   warehouse_uuid: string | null;
   created_by_uuid: string | null;
   notes: string | null;
@@ -163,8 +164,10 @@ export default function Inventory() {
                               <Package className="h-5 w-5 text-white" />
                             </div>
                             <div>
-                              <h3 className="font-semibold text-lg">{inventory.material_uuid}</h3>
-                              <p className="text-sm text-muted-foreground">Material UUID: {inventory.material_uuid}</p>
+                              <h3 className="font-semibold text-lg" data-testid={`text-inventory-material-${inventory.uuid}`}>
+                                {inventory.material_name || inventory.material_uuid}
+                              </h3>
+                              <p className="text-sm text-muted-foreground">Lot: {inventory.lot_id || "—"}</p>
                             </div>
                           </div>
                           

--- a/frontend/client/src/pages/InventoryEvents.tsx
+++ b/frontend/client/src/pages/InventoryEvents.tsx
@@ -16,6 +16,7 @@ interface InventoryEvent {
   uuid: string;
   inventory_uuid: string;
   material_uuid: string;
+  material_name?: string | null;
   event_type: string;
   quantity: number;
   notes?: string;
@@ -166,8 +167,10 @@ export default function InventoryEvents() {
                           
                           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mt-4">
                             <div>
-                              <p className="text-sm font-medium text-muted-foreground">Inventory UUID</p>
-                              <p className="text-sm">{event.inventory_uuid}</p>
+                              <p className="text-sm font-medium text-muted-foreground">Material</p>
+                              <p className="text-sm" data-testid={`text-event-material-${event.uuid}`}>
+                                {event.material_name || event.material_uuid}
+                              </p>
                             </div>
                             <div>
                               <p className="text-sm font-medium text-muted-foreground">Quantity</p>

--- a/frontend/client/src/pages/MaterialDetail.tsx
+++ b/frontend/client/src/pages/MaterialDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useLocation } from "wouter";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { MaterialInventorySection } from "@/components/materials/MaterialInventorySection";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -538,6 +539,8 @@ export default function MaterialDetail() {
           </CardContent>
         </Card>
       </div>
+
+      <MaterialInventorySection materialUuid={material.uuid} />
     </div>
   );
 }

--- a/frontend/client/src/pages/ProcessCreate.tsx
+++ b/frontend/client/src/pages/ProcessCreate.tsx
@@ -4,7 +4,14 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 import { useForm, useFieldArray, SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { ArrowLeft, Plus, Trash2, Factory, Package, ArrowRight } from "lucide-react";
+import { ArrowLeft, Plus, Trash2, Factory, Package, ArrowRight, BookmarkPlus } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -87,6 +94,59 @@ export default function ProcessCreate() {
   const { data: warehouses, isLoading: warehousesLoading, error: warehousesError } = useQuery({
     queryKey: ["/warehouse/"],
     queryFn: () => apiRequest("/warehouse/?per_page=100"),
+  });
+
+  // ---- presets: saved templates + recent processes (both just pre-fill
+  // the form; everything stays editable before submit) ----
+  const [showSaveTemplate, setShowSaveTemplate] = useState(false);
+  const [templateName, setTemplateName] = useState("");
+
+  const { data: templates } = useQuery({
+    queryKey: ["/process-template/"],
+    queryFn: () => apiRequest("/process-template/?per_page=100"),
+  });
+  const { data: recentProcesses } = useQuery({
+    queryKey: ["/process/", "recent-for-clone"],
+    queryFn: () => apiRequest("/process/?page=1&per_page=25"),
+  });
+
+  // strip execution enrichment (inventory_uuid, cost_per_unit, ...) down to
+  // what the create schema accepts
+  const applyPreset = (preset: { type?: string; notes?: string | null; data?: any }) => {
+    const cleanRows = (rows: any[] | undefined) =>
+      (rows || [])
+        .map((r) => ({ material_uuid: r.material_uuid || "", quantity: Number(r.quantity) || 0 }))
+        .filter((r) => r.material_uuid);
+    const inputs = cleanRows(preset.data?.inputs);
+    const outputs = cleanRows(preset.data?.outputs);
+    form.reset({
+      type: (preset.type as ProcessType) || ProcessType.COATED_PEANUT_BATCH,
+      notes: preset.notes || "",
+      data: {
+        inputs: inputs.length ? inputs : [{ material_uuid: "", quantity: 0 }],
+        outputs: outputs.length ? outputs : [{ material_uuid: "", quantity: 0 }],
+        output_warehouse_uuid: preset.data?.output_warehouse_uuid || "",
+      },
+    });
+    toast({ title: "Form pre-filled", description: "Review and adjust before submitting." });
+  };
+
+  const saveTemplateMutation = useMutation({
+    mutationFn: async () => {
+      const v = form.getValues();
+      return apiRequest("/process-template/", {
+        method: "POST",
+        body: { name: templateName.trim(), type: v.type, notes: v.notes || null, data: v.data },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/process-template/"] });
+      toast({ title: "Template saved", description: `"${templateName.trim()}" can now pre-fill new processes.` });
+      setShowSaveTemplate(false);
+      setTemplateName("");
+    },
+    onError: (e: Error) =>
+      toast({ title: "Failed to save template", description: e.message, variant: "destructive" }),
   });
 
 
@@ -177,6 +237,75 @@ export default function ProcessCreate() {
         </div>
 
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          {/* Start from a template or an existing process */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Start From (optional)</CardTitle>
+              <CardDescription>
+                Pre-fill the form from a saved template or a previous process — you can
+                still edit everything before submitting.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="flex flex-wrap items-end gap-4">
+              <div className="min-w-[260px]">
+                <Label className="mb-1 block">Template</Label>
+                <Select
+                  value=""
+                  onValueChange={(uuid) => {
+                    const t = (templates?.items || []).find((t: any) => t.uuid === uuid);
+                    if (t) applyPreset(t);
+                  }}
+                >
+                  <SelectTrigger data-testid="select-process-template">
+                    <SelectValue placeholder="Load a template..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(templates?.items || []).length === 0 ? (
+                      <SelectItem value="__none" disabled>No templates saved yet</SelectItem>
+                    ) : (
+                      (templates?.items || []).map((t: any) => (
+                        <SelectItem key={t.uuid} value={t.uuid}>
+                          {t.name}
+                        </SelectItem>
+                      ))
+                    )}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="min-w-[260px]">
+                <Label className="mb-1 block">Clone a recent process</Label>
+                <Select
+                  value=""
+                  onValueChange={(uuid) => {
+                    const p = (recentProcesses?.items || []).find((p: any) => p.uuid === uuid);
+                    if (p) applyPreset(p);
+                  }}
+                >
+                  <SelectTrigger data-testid="select-process-clone">
+                    <SelectValue placeholder="Clone from recent..." />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(recentProcesses?.items || []).map((p: any) => (
+                      <SelectItem key={p.uuid} value={p.uuid}>
+                        {(ProcessTypeLabels as any)[p.type] || p.type} · {new Date(p.created_at).toLocaleDateString()}
+                        {p.notes ? ` · ${String(p.notes).slice(0, 30)}` : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setShowSaveTemplate(true)}
+                data-testid="button-save-template"
+              >
+                <BookmarkPlus className="h-4 w-4 mr-2" />
+                Save current as template
+              </Button>
+            </CardContent>
+          </Card>
+
           {/* Process Information */}
           <Card>
             <CardHeader>
@@ -412,6 +541,35 @@ export default function ProcessCreate() {
           </div>
         </form>
       </div>
+
+      <Dialog open={showSaveTemplate} onOpenChange={setShowSaveTemplate}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Save as template</DialogTitle>
+          </DialogHeader>
+          <div>
+            <Label className="mb-1 block">Template name</Label>
+            <Input
+              value={templateName}
+              onChange={(e) => setTemplateName(e.target.value)}
+              placeholder="e.g. Standard coated peanut batch"
+              data-testid="input-template-name"
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setShowSaveTemplate(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!templateName.trim() || saveTemplateMutation.isPending}
+              onClick={() => saveTemplateMutation.mutate()}
+              data-testid="button-confirm-save-template"
+            >
+              {saveTemplateMutation.isPending ? "Saving..." : "Save template"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </AppLayout>
   );
 }

--- a/frontend/client/src/pages/Trips.tsx
+++ b/frontend/client/src/pages/Trips.tsx
@@ -252,6 +252,9 @@ export default function Trips() {
                     Vehicle
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
+                    Assigned To
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
                     Status
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">
@@ -276,7 +279,7 @@ export default function Trips() {
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                 {isLoading ? (
                   <tr>
-                    <td colSpan={isAdmin ? 8 : 7} className="px-6 py-16 text-center">
+                    <td colSpan={isAdmin ? 9 : 8} className="px-6 py-16 text-center">
                       <div className="animate-pulse space-y-4">
                         <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-32 mx-auto"></div>
                         <div className="h-4 bg-gray-200 dark:bg-gray-600 rounded w-48 mx-auto"></div>
@@ -287,7 +290,7 @@ export default function Trips() {
                   </tr>
                 ) : trips.length === 0 ? (
                   <tr>
-                    <td colSpan={isAdmin ? 8 : 7} className="px-6 py-16 text-center">
+                    <td colSpan={isAdmin ? 9 : 8} className="px-6 py-16 text-center">
                       <Truck className="h-12 w-12 text-gray-400 mx-auto mb-4" />
                       <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
                         {error ? "Error loading trips" : "No trips"}
@@ -321,8 +324,13 @@ export default function Trips() {
                         </span>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <span className="text-sm text-gray-900 dark:text-gray-100">
-                          {trip.vehicle_uuid.substring(0, 8)}...
+                        <span className="text-sm text-gray-900 dark:text-gray-100" data-testid={`text-trip-vehicle-${trip.uuid}`}>
+                          {trip.vehicle_plate || `${trip.vehicle_uuid.substring(0, 8)}...`}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span className="text-sm text-gray-900 dark:text-gray-100" data-testid={`text-trip-assigned-${trip.uuid}`}>
+                          {trip.assigned_username || "—"}
                         </span>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">


### PR DESCRIPTION
Batch of six improvements, each verified locally:

1. **Material detail**: Total Inventory Over Time chart + Inventory Lots & Cost table (per-lot cost via the domain costing chain, weighted avg cost per currency, zero-stock lots hidden). New `GET /material/<uuid>/inventory-summary`.
2. **All list endpoints**: default newest-first ordering (created_at DESC) in the shared repository — applies to web and app lists.
3. **Customer orders list**: Company + Customer (full name) columns instead of uuid; names resolved on `CustomerOrderRead`.
4. **Trips list**: vehicle plate instead of uuid + Assigned To column (batch-resolved from start_trip results, no N+1).
5. **Inventory + inventory-event lists**: material names instead of uuids.
6. **Process create**: reusable named templates (`process_template` entity + endpoints, **includes migration**) and clone-from-recent-process — both pre-fill the still-editable form; save-current-as-template included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)