### PR TITLE
Fix trip figures counting deleted orders; make plain order delete a real void

### DIFF
--- a/backend/app/domains/customer_order/domain.py
+++ b/backend/app/domains/customer_order/domain.py
@@ -181,12 +181,57 @@ class CustomerOrderDomain:
 
     @staticmethod
     def delete_customer_order(uuid:str, uow: SqlAlchemyUnitOfWork) -> CustomerOrderRead:
-        # fetch existing order
+        """Void an order: soft-delete it together with everything it caused —
+        items, invoices, payments, and the inventory/vehicle events its
+        fulfillment created (which restores warehouse/vehicle stock, since
+        quantities are computed from non-deleted events). Unlike the
+        validated delete, this intentionally works on paid/fulfilled orders:
+        it exists to undo mistakes (e.g. an erroneous trip-stop checkout)."""
+        from models.common import (
+            InventoryEvent as InventoryEventModel,
+            VehicleInventoryEvent as VehicleInventoryEventModel,
+        )
+
         order = uow.customer_order_repository.find_one(uuid=uuid, is_deleted=False)
         if not order:
             raise NotFoundError("CustomerOrder not found")
 
-        #TODO: delete all related items
+        item_uuids = []
+        for item in order.customer_order_items:
+            if item.is_deleted:
+                continue
+            item.is_deleted = True
+            item_uuids.append(item.uuid)
+            uow.customer_order_item_repository.save(model=item, commit=False)
+
+        for invoice in order.invoices:
+            if invoice.is_deleted:
+                continue
+            for payment in invoice.payments:
+                if not payment.is_deleted:
+                    payment.is_deleted = True
+                    uow.payment_repository.save(model=payment, commit=False)
+            for inv_item in invoice.invoice_items:
+                if not inv_item.is_deleted:
+                    inv_item.is_deleted = True
+                    uow.invoice_item_repository.save(model=inv_item, commit=False)
+            invoice.is_deleted = True
+            uow.invoice_repository.save(model=invoice, commit=False)
+
+        if item_uuids:
+            # warehouse-side deductions
+            for ev in uow.session.query(InventoryEventModel).filter(
+                InventoryEventModel.customer_order_item_uuid.in_(item_uuids),
+                InventoryEventModel.is_deleted.is_(False),
+            ):
+                ev.is_deleted = True
+            # vehicle-side sale events (trip checkouts)
+            for ev in uow.session.query(VehicleInventoryEventModel).filter(
+                VehicleInventoryEventModel.customer_order_item_uuid.in_(item_uuids),
+                VehicleInventoryEventModel.is_deleted.is_(False),
+            ):
+                ev.is_deleted = True
+
         order.is_deleted = True
         uow.customer_order_repository.save(model=order, commit=False)
         result = CustomerOrderRead.from_orm(order)

--- a/backend/app/entrypoint/routes/trip/routes.py
+++ b/backend/app/entrypoint/routes/trip/routes.py
@@ -145,6 +145,10 @@ def get_trip_activity(uuid: str):
                     continue
                 item = ev.customer_order_item
                 order = item.customer_order if item else None
+                # legacy voids: the order was deleted without cascading — its
+                # leftover sale events must not count as trip activity
+                if (item and item.is_deleted) or (order and order.is_deleted):
+                    continue
                 fulfillments.append({
                     "created_at": ev.created_at.isoformat() if ev.created_at else None,
                     "material_name": material_name(ev.material_uuid),
@@ -157,6 +161,8 @@ def get_trip_activity(uuid: str):
                     continue
                 inv = p.invoice
                 order = inv.customer_order if inv else None
+                if (inv and inv.is_deleted) or (order and order.is_deleted):
+                    continue
                 payments.append({
                     "created_at": p.created_at.isoformat() if p.created_at else None,
                     "amount": p.amount,

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -1923,8 +1923,14 @@ class Trip(Base):
         totals: dict[str, float] = {}
         for stop in self.stops:
             for payment in stop.payments:
-                if not payment.is_deleted:
-                    totals[payment.currency] = totals.get(payment.currency, 0) + payment.amount
+                if payment.is_deleted:
+                    continue
+                inv = payment.invoice
+                order = inv.customer_order if inv else None
+                # ignore money from deleted invoices/orders (legacy non-cascaded voids)
+                if (inv and inv.is_deleted) or (order and order.is_deleted):
+                    continue
+                totals[payment.currency] = totals.get(payment.currency, 0) + payment.amount
         return totals
 
     @property


### PR DESCRIPTION
The plain DELETE /customer-order/<uuid> (used by the web UI) only flagged the order row, leaving payments, invoices, items and inventory/vehicle events alive — trip activity (Paid/Fulfilled) and expected_cash kept counting deleted orders, and voided stock never returned to the vehicle.

- Plain delete now cascades (items, invoice items, invoices, payments, warehouse + vehicle inventory events) — voiding an erroneous trip checkout also restores vehicle stock. Validated delete path unchanged.
- Defensive filters for legacy non-cascaded voids: trip activity and expected_cash skip rows whose order/invoice is deleted.

Verified E2E locally: voided a real paid trip-stop order — activity dropped it, sale events/payments/items/invoices all soft-deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)