### PR TITLE
Trip Inventory: exclude sales of deleted orders from sold map

### DIFF
--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -1947,6 +1947,13 @@ class Trip(Base):
             for ev in stop.vehicle_inventory_events:
                 if ev.is_deleted or ev.event_type != "sale":
                     continue
+                # skip sales of deleted (voided) orders — new voids soft-delete
+                # the event itself, but orders deleted before that cascade
+                # existed left their sale events alive
+                item = ev.customer_order_item
+                order = item.customer_order if item else None
+                if (item and item.is_deleted) or (order and order.is_deleted):
+                    continue
                 sold[ev.material_uuid] = sold.get(ev.material_uuid, 0) - ev.quantity
         return sold
 


### PR DESCRIPTION
Follow-up to #43 — the Trip Inventory (reconciliation) table reads sold_inventory_map, which only checked the sale event's own is_deleted flag; legacy non-cascaded order deletions left events alive, so Sold kept counting deleted orders. Applies the same deleted-order guard used in trip activity. Verified locally: live order → sold 10; order flagged deleted → excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)