### PR TITLE
Customer detail: orders + trip-stops sections (paginated)

### DIFF
--- a/backend/app/dto/trip_stop.py
+++ b/backend/app/dto/trip_stop.py
@@ -116,6 +116,9 @@ class TripStopRead(BaseModel):
     index: Optional[int] = None
     outcome: Optional[str] = None
     sales: Optional[dict] = None
+    # resolved from the stop's trip -> workflow execution -> start_trip
+    # operator; the driver assigned to the trip (enriched by the list route)
+    assigned_username: Optional[str] = None
 
 
     @field_validator("coordinates", mode="before")

--- a/backend/app/entrypoint/routes/trip_stop/routes.py
+++ b/backend/app/entrypoint/routes/trip_stop/routes.py
@@ -126,8 +126,55 @@ def list_trip_stops():
             page=params.page,
             per_page=params.per_page,
         )
-        items = [TripStopRead.from_orm(m).model_dump(mode="json") for m in page.items]
-        print(items)
+        # enrich each stop with the driver assigned to its trip (stop -> trip
+        # -> workflow execution -> start_trip operator result), batched
+        from models.common import (
+            TaskExecution as TaskExecutionModel,
+            Task as TaskModel,
+            User as UserModel,
+        )
+        trip_uuids = list({m.trip_uuid for m in page.items if m.trip_uuid})
+        trip_to_wfe = dict(
+            uow.session.query(TripModel.uuid, TripModel.workflow_execution_uuid)
+            .filter(TripModel.uuid.in_(trip_uuids))
+            .all()
+        ) if trip_uuids else {}
+        wfe_uuids = [w for w in trip_to_wfe.values() if w]
+        assigned_by_wfe: dict = {}
+        if wfe_uuids:
+            rows = (
+                uow.session.query(
+                    TaskExecutionModel.workflow_execution_uuid,
+                    TaskExecutionModel.result["assigned_user_uuid"].astext,
+                )
+                .join(TaskModel, TaskModel.uuid == TaskExecutionModel.task_uuid)
+                .filter(
+                    TaskExecutionModel.workflow_execution_uuid.in_(wfe_uuids),
+                    TaskExecutionModel.account_uuid == uow.account_uuid,
+                    TaskModel.operator == "start_trip_operator",
+                )
+                .all()
+            )
+            values = {v for _, v in rows if v}
+            users = (
+                uow.session.query(UserModel.uuid, UserModel.username)
+                .filter(
+                    UserModel.uuid.in_(values) | UserModel.username.in_(values),
+                    UserModel.account_uuid == uow.account_uuid,
+                )
+                .all()
+            ) if values else []
+            uuid_to_name = {u[0]: u[1] for u in users}
+            usernames = {u[1] for u in users}
+            for wfe_uuid, v in rows:
+                if v:
+                    assigned_by_wfe[wfe_uuid] = uuid_to_name.get(v) or v
+
+        items = []
+        for m in page.items:
+            dto = TripStopRead.from_orm(m)
+            dto.assigned_username = assigned_by_wfe.get(trip_to_wfe.get(m.trip_uuid))
+            items.append(dto.model_dump(mode="json"))
         result = TripStopPage(
             items=items,
             total_count=page.total,

--- a/frontend/client/src/components/customers/CustomerActivity.tsx
+++ b/frontend/client/src/components/customers/CustomerActivity.tsx
@@ -1,0 +1,242 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { ChevronLeft, ChevronRight, ClipboardList, MapPin } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { apiRequest } from "@/lib/queryClient";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const PER_PAGE = 5;
+
+interface OrdersResponse {
+  orders: any[];
+  total_count: number;
+  page: number;
+  pages: number;
+}
+interface StopsResponse {
+  items: any[];
+  total_count: number;
+  page: number;
+  pages: number;
+}
+
+function fmtDate(v?: string) {
+  return v ? new Date(v).toLocaleDateString() : "—";
+}
+
+function Pager({
+  page,
+  pages,
+  total,
+  onPrev,
+  onNext,
+  testPrefix,
+  t,
+}: {
+  page: number;
+  pages: number;
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
+  testPrefix: string;
+  t: (k: string, v?: Record<string, string | number>) => string;
+}) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-t border-gray-100">
+      <p className="text-xs text-gray-500">
+        {t("customers.tablePageOf", { page, pages: Math.max(pages, 1), total })}
+      </p>
+      <div className="flex gap-1">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onPrev}
+          disabled={page <= 1}
+          data-testid={`${testPrefix}-prev`}
+        >
+          <ChevronLeft className="h-4 w-4 rtl:rotate-180" />
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onNext}
+          disabled={page >= pages}
+          data-testid={`${testPrefix}-next`}
+        >
+          <ChevronRight className="h-4 w-4 rtl:rotate-180" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function CustomerActivity({ customerUuid }: { customerUuid: string }) {
+  const { t, te } = useLanguage();
+  const [ordersPage, setOrdersPage] = useState(1);
+  const [stopsPage, setStopsPage] = useState(1);
+
+  const { data: orders } = useQuery<OrdersResponse>({
+    queryKey: ["/customer-order/", customerUuid, "orders", ordersPage],
+    queryFn: () =>
+      apiRequest(
+        `/customer-order/?customer_uuid=${customerUuid}&page=${ordersPage}&per_page=${PER_PAGE}`
+      ),
+  });
+
+  const { data: stops } = useQuery<StopsResponse>({
+    queryKey: ["/trip-stop/", customerUuid, "stops", stopsPage],
+    queryFn: () =>
+      apiRequest(
+        `/trip-stop/?customer_uuid=${customerUuid}&page=${stopsPage}&per_page=${PER_PAGE}`
+      ),
+  });
+
+  return (
+    <div className="mt-8 space-y-8">
+      {/* Orders */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+          <ClipboardList className="w-5 h-5 me-2" />
+          {t("customers.ordersSection")}
+        </h3>
+        <Card>
+          <CardContent className="p-0">
+            <Table data-testid="customer-orders-table">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("common.date")}</TableHead>
+                  <TableHead>{t("common.total")}</TableHead>
+                  <TableHead>{t("customers.payment")}</TableHead>
+                  <TableHead>{t("customers.fulfillment")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!orders ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center text-gray-400 py-6">
+                      {t("common.loading")}
+                    </TableCell>
+                  </TableRow>
+                ) : orders.orders.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center text-gray-400 py-6">
+                      {t("customers.noOrders")}
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  orders.orders.map((o) => (
+                    <TableRow key={o.uuid} className="hover:bg-gray-50">
+                      <TableCell>
+                        <Link
+                          href={`/customer-orders/${o.uuid}`}
+                          className="text-[hsl(245,58%,57%)] hover:underline"
+                        >
+                          {fmtDate(o.created_at)}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="font-medium">
+                        {(o.total_amount ?? o.total_adjusted_amount ?? 0).toLocaleString()}{" "}
+                        <span className="text-xs text-gray-500">{te(o.currency)}</span>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className={o.is_paid ? "bg-green-100 text-green-700" : "bg-amber-100 text-amber-700"}>
+                          {o.is_paid ? te("paid") : te("unpaid")}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className={o.is_fulfilled ? "bg-green-100 text-green-700" : "bg-gray-100 text-gray-600"}>
+                          {o.is_fulfilled ? te("fulfilled") : te("pending")}
+                        </Badge>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+            {orders && orders.total_count > 0 && (
+              <Pager
+                page={orders.page}
+                pages={orders.pages}
+                total={orders.total_count}
+                onPrev={() => setOrdersPage((p) => Math.max(1, p - 1))}
+                onNext={() => setOrdersPage((p) => p + 1)}
+                testPrefix="customer-orders"
+                t={t}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Trip stops */}
+      <div>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4 flex items-center">
+          <MapPin className="w-5 h-5 me-2" />
+          {t("customers.tripStopsSection")}
+        </h3>
+        <Card>
+          <CardContent className="p-0">
+            <Table data-testid="customer-tripstops-table">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("common.date")}</TableHead>
+                  <TableHead>{t("customers.assignedUser")}</TableHead>
+                  <TableHead>{t("customers.result")}</TableHead>
+                  <TableHead>{t("customers.comments")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!stops ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center text-gray-400 py-6">
+                      {t("common.loading")}
+                    </TableCell>
+                  </TableRow>
+                ) : stops.items.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="text-center text-gray-400 py-6">
+                      {t("customers.noTripStops")}
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  stops.items.map((s) => (
+                    <TableRow key={s.uuid} className="hover:bg-gray-50">
+                      <TableCell>{fmtDate(s.created_at)}</TableCell>
+                      <TableCell>{s.assigned_username || "—"}</TableCell>
+                      <TableCell>{s.outcome ? te(s.outcome) : "—"}</TableCell>
+                      <TableCell className="max-w-xs truncate text-gray-600">
+                        {s.notes || "—"}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+            {stops && stops.total_count > 0 && (
+              <Pager
+                page={stops.page}
+                pages={stops.pages}
+                total={stops.total_count}
+                onPrev={() => setStopsPage((p) => Math.max(1, p - 1))}
+                onNext={() => setStopsPage((p) => p + 1)}
+                testPrefix="customer-tripstops"
+                t={t}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/client/src/i18n/translations/customers.ts
+++ b/frontend/client/src/i18n/translations/customers.ts
@@ -87,6 +87,16 @@ export const en: Record<string, string> = {
   'customers.resultsPerPage': 'Results per page',
   'customers.applyFilters': 'Apply Filters',
   'customers.clear': 'Clear',
+  'customers.ordersSection': 'Orders',
+  'customers.tripStopsSection': 'Trip Stops',
+  'customers.payment': 'Payment',
+  'customers.fulfillment': 'Fulfillment',
+  'customers.assignedUser': 'Assigned User',
+  'customers.result': 'Result',
+  'customers.comments': 'Comments',
+  'customers.noOrders': 'No orders yet.',
+  'customers.noTripStops': 'No trip stops yet.',
+  'customers.tablePageOf': 'Page {page} of {pages} · {total} total',
 };
 
 export const ar: Record<string, string> = {
@@ -174,4 +184,14 @@ export const ar: Record<string, string> = {
   'customers.resultsPerPage': 'عدد النتائج في الصفحة',
   'customers.applyFilters': 'تطبيق عوامل التصفية',
   'customers.clear': 'مسح',
+  'customers.ordersSection': 'الطلبات',
+  'customers.tripStopsSection': 'محطات الرحلات',
+  'customers.payment': 'الدفع',
+  'customers.fulfillment': 'التسليم',
+  'customers.assignedUser': 'المستخدم المسؤول',
+  'customers.result': 'النتيجة',
+  'customers.comments': 'الملاحظات',
+  'customers.noOrders': 'لا توجد طلبات بعد.',
+  'customers.noTripStops': 'لا توجد محطات رحلات بعد.',
+  'customers.tablePageOf': 'صفحة {page} من {pages} · {total} إجمالاً',
 };

--- a/frontend/client/src/pages/CustomerDetail.tsx
+++ b/frontend/client/src/pages/CustomerDetail.tsx
@@ -25,6 +25,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { CustomerActivity } from "@/components/customers/CustomerActivity";
 import type { Customer } from "@/lib/types";
 import { EditCustomerDialog } from "@/components/customers/EditCustomerDialog";
 import { CustomerDetailMap } from "@/components/map/CustomerDetailMap";
@@ -420,6 +421,9 @@ export default function CustomerDetail() {
             )}
           </div>
         </div>
+
+        {/* Orders + trip stops */}
+        <CustomerActivity customerUuid={customer.uuid} />
 
         {/* Customer Location Map */}
         <div className="mt-8">


### PR DESCRIPTION
Stacked on #51 (super_admin_tabs) — base collapses to `main` once that merges.

## Summary
Two new sections on the customer detail page, each a table paginated at 5/page with prev/next, newest first:
- **Orders** — date, total, payment (paid/unpaid), fulfillment. Reuses `GET /customer-order/?customer_uuid=`.
- **Trip Stops** — date, **assigned user**, result, comments. The trip-stop list route now enriches each stop with the driver assigned to its trip (stop → trip → workflow execution → `start_trip` operator, batched), exposed as `assigned_username` on `TripStopRead`. Result renders via `te()` so bilingual outcome composites localize.

## Verified (local)
Customer with 21 orders / 10 stops: both tables 5 rows newest-first; orders "Page 2 of 5 · 21 total"; trip-stops Next disables on last page; assignee resolves; result shows "sale". tsc: 0 new. Bilingual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)