### PR TITLE
Trip detail: comments column in the trip stops table

### DIFF
--- a/backend/app/entrypoint/routes/trip/routes.py
+++ b/backend/app/entrypoint/routes/trip/routes.py
@@ -142,6 +142,7 @@ def get_trip_activity(uuid: str):
                 "customer_name": customer_name(stop.customer),
                 "status": task_exe.status if task_exe else stop.status,
                 "outcome": stop.outcome,
+                "notes": stop.notes,
                 "coordinates": latlon,  # "lat,lon"
                 "created_at": stop.created_at.isoformat() if stop.created_at else None,
                 "completed_at": task_exe.end_time.isoformat() if task_exe and task_exe.end_time else None,

--- a/frontend/client/src/pages/TripDetail.tsx
+++ b/frontend/client/src/pages/TripDetail.tsx
@@ -513,6 +513,7 @@ export default function TripDetail() {
                       <th className="py-2 pe-4 font-medium">{t('trips.customer')}</th>
                       <th className="py-2 pe-4 font-medium">{t('common.status')}</th>
                       <th className="py-2 pe-4 font-medium">{t('trips.outcome')}</th>
+                      <th className="py-2 pe-4 font-medium">{t('customers.comments')}</th>
                       <th className="py-2 font-medium">{t('trips.colCompleted')}</th>
                     </tr>
                   </thead>
@@ -527,6 +528,12 @@ export default function TripDetail() {
                           </Badge>
                         </td>
                         <td className="py-2 pe-4 max-w-[240px] truncate">{s.outcome ? te(s.outcome) : "—"}</td>
+                        <td
+                          className="py-2 pe-4 max-w-[260px] truncate text-gray-600"
+                          title={s.notes || undefined}
+                        >
+                          {s.notes || "—"}
+                        </td>
                         <td className="py-2 whitespace-nowrap">{s.completed_at ? formatDateTime(s.completed_at) : "—"}</td>
                       </tr>
                     ))}


### PR DESCRIPTION
## Summary
Adds a **Comments** column to the Trip Stops table on the trip detail page, between Outcome and Completed.

The trip activity payload (`GET /trip/<uuid>/activity`) wasn't returning the stop's `notes` at all, so this adds that one field next to `outcome`.

- Long comments truncate with the full text as a `title` tooltip, so a wordy note can't stretch the column.
- Stops with no comment show an em dash.
- Reuses the existing `customers.comments` key — already EN/AR, no new translations.

## Verification
Local stack, browser + API:
- `notes` present on every stop in the activity response; 3 of 13 stops on the test trip carry comments.
- Table renders `# / Customer / Status / Outcome / **Comments** / Completed`, and the populated rows show "Ran out of time on the route", "Shop closed, will revisit next week", "Customer bought 3 boxes, paid cash".
- Confirmed the `title` attribute carries the untruncated string on each of those rows.
- tsc: 70 errors = unchanged baseline, 0 new. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)