### PR TITLE
Expenses: Analytics tab (cumulative over time + category-stacked bars)

### DIFF
--- a/backend/app/entrypoint/routes/expense/routes.py
+++ b/backend/app/entrypoint/routes/expense/routes.py
@@ -209,14 +209,18 @@ def expense_analytics_over_time():
             )
         }
         if not per_currency:
+            # every key the populated response has, or the client reads
+            # undefined off the "no expenses yet" case and blows up
             return jsonify({
                 "bucket": bucket,
                 "currency": currency,
                 "currencies": {},
                 "categories": [],
+                "category_totals": {},
                 "buckets": [],
                 "total": 0.0,
                 "paid": 0.0,
+                "unpaid": 0.0,
                 "count": 0,
             }), 200
 

--- a/backend/app/entrypoint/routes/expense/routes.py
+++ b/backend/app/entrypoint/routes/expense/routes.py
@@ -152,3 +152,135 @@ def list_expenses():
 def list_expense_categories():
     categories = [category.value for category in ExpenseCategory]
     return jsonify(categories), 200
+
+# ----------------------------- EXPENSE ANALYTICS -----------------------------
+# Read-only aggregates for the Expenses > Analytics tab. Raw session queries
+# here bypass repository scoping, so each one filters account_uuid itself.
+#
+# Amounts are NEVER summed across currencies: the caller picks one currency and
+# every series is in it. `currencies` reports the totals per currency so the UI
+# can offer the picker and default to the busiest one.
+
+@expense_blueprint.route('/analytics/over-time', methods=['GET'])
+@jwt_required()
+@scopes_required(PermissionScope.ADMIN.value,
+                 PermissionScope.SUPER_ADMIN.value,
+                 PermissionScope.ACCOUNTANT.value)
+def expense_analytics_over_time():
+    from sqlalchemy import func
+    from app.entrypoint.routes.common.analytics import (
+        bucket_arg,
+        csv_arg,
+        parse_dt,
+    )
+
+    bucket = bucket_arg("month")
+    start = parse_dt(request.args.get("start_date"))
+    end = parse_dt(request.args.get("end_date"), end_of_day=True)
+    categories = csv_arg("categories")
+    vendor_uuid = request.args.get("vendor_uuid")
+    currency = request.args.get("currency")
+
+    with SqlAlchemyUnitOfWork() as uow:
+        base = [
+            ExpenseModel.account_uuid == uow.account_uuid,
+            ExpenseModel.is_deleted == False,
+        ]
+        if start:
+            base.append(ExpenseModel.created_at >= start)
+        if end:
+            base.append(ExpenseModel.created_at <= end)
+        if categories:
+            base.append(ExpenseModel.category.in_(categories))
+        if vendor_uuid:
+            base.append(ExpenseModel.vendor_uuid == vendor_uuid)
+
+        # totals per currency drive the picker; also the honest answer to
+        # "how much did we spend" when several currencies are in play
+        per_currency = {
+            cur: round(float(total or 0), 2)
+            for cur, total in (
+                uow.session.query(
+                    ExpenseModel.currency, func.sum(ExpenseModel.amount)
+                )
+                .filter(*base)
+                .group_by(ExpenseModel.currency)
+                .all()
+            )
+        }
+        if not per_currency:
+            return jsonify({
+                "bucket": bucket,
+                "currency": currency,
+                "currencies": {},
+                "categories": [],
+                "buckets": [],
+                "total": 0.0,
+                "paid": 0.0,
+                "count": 0,
+            }), 200
+
+        # default to the currency carrying the most spend, so the first paint
+        # shows the meaningful chart rather than an arbitrary one
+        if currency not in per_currency:
+            currency = max(per_currency, key=lambda c: per_currency[c])
+        scoped = base + [ExpenseModel.currency == currency]
+
+        period = func.date_trunc(bucket, ExpenseModel.created_at)
+        rows = (
+            uow.session.query(
+                period.label("period"),
+                ExpenseModel.category,
+                func.sum(ExpenseModel.amount),
+            )
+            .filter(*scoped)
+            .group_by(period, ExpenseModel.category)
+            .order_by(period)
+            .all()
+        )
+
+        by_period: dict = {}
+        cat_totals: dict = {}
+        for p, cat, amount in rows:
+            amount = round(float(amount or 0), 2)
+            key = p.isoformat()
+            entry = by_period.setdefault(key, {})
+            entry[cat] = round(entry.get(cat, 0.0) + amount, 2)
+            cat_totals[cat] = round(cat_totals.get(cat, 0.0) + amount, 2)
+
+        # biggest spend first, so the stack order and the legend agree and the
+        # colours stay stable as the window changes
+        ordered_categories = sorted(cat_totals, key=lambda c: cat_totals[c], reverse=True)
+
+        buckets = [
+            {
+                "period": key,
+                "amounts": amounts,
+                "total": round(sum(amounts.values()), 2),
+            }
+            for key, amounts in sorted(by_period.items())
+        ]
+
+        paid, count = (
+            uow.session.query(
+                func.coalesce(func.sum(ExpenseModel.amount_paid), 0),
+                func.count(ExpenseModel.uuid),
+            )
+            .filter(*scoped)
+            .first()
+        )
+
+        total = round(sum(b["total"] for b in buckets), 2)
+        result = {
+            "bucket": bucket,
+            "currency": currency,
+            "currencies": per_currency,
+            "categories": ordered_categories,
+            "category_totals": cat_totals,
+            "buckets": buckets,
+            "total": total,
+            "paid": round(float(paid or 0), 2),
+            "unpaid": round(total - float(paid or 0), 2),
+            "count": int(count or 0),
+        }
+    return jsonify(result), 200

--- a/frontend/client/src/components/analytics/shared.tsx
+++ b/frontend/client/src/components/analytics/shared.tsx
@@ -60,7 +60,13 @@ export function fmtDate(v?: string | null) {
   return v ? new Date(v).toLocaleDateString() : "—";
 }
 
-export function fmtMoney(v: number) {
+/**
+ * Tolerates undefined/null/NaN on purpose: these tiles read straight off API
+ * payloads, and one missing field should show a dash, not white-screen the
+ * whole page.
+ */
+export function fmtMoney(v: number | null | undefined) {
+  if (v === null || v === undefined || Number.isNaN(v)) return "—";
   return v.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,

--- a/frontend/client/src/components/expenses/ExpensesAnalytics.tsx
+++ b/frontend/client/src/components/expenses/ExpensesAnalytics.tsx
@@ -1,0 +1,358 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  CartesianGrid,
+} from "recharts";
+import { Layers, PieChart, Wallet } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { apiRequest } from "@/lib/queryClient";
+import { useLanguage } from "@/contexts/LanguageContext";
+import {
+  ModeToggle,
+  MultiSelect,
+  RANGES,
+  RangeKey,
+  fmtMoney,
+  fmtPeriod,
+  rangeStart,
+} from "@/components/analytics/shared";
+
+/**
+ * Colour is keyed by CATEGORY NAME, not by position: the backend orders
+ * categories by spend, which shifts as the window changes, so an index-based
+ * palette would recolour the whole chart when you switch range.
+ */
+const CATEGORY_COLORS: Record<string, string> = {
+  rent: "hsl(245,58%,57%)",
+  electricity: "#f59e0b",
+  water: "#0ea5e9",
+  maintenance: "#ef4444",
+  equipment: "#8b5cf6",
+  supplies: "#10b981",
+  travel: "#14b8a6",
+  meals: "#f97316",
+  other: "#6b7280",
+};
+const FALLBACK_COLORS = ["#64748b", "#a855f7", "#22c55e", "#eab308"];
+
+function colorFor(category: string, idx: number) {
+  return CATEGORY_COLORS[category] ?? FALLBACK_COLORS[idx % FALLBACK_COLORS.length];
+}
+
+interface OverTime {
+  bucket: string;
+  currency: string | null;
+  currencies: Record<string, number>;
+  categories: string[];
+  category_totals: Record<string, number>;
+  buckets: { period: string; amounts: Record<string, number>; total: number }[];
+  total: number;
+  paid: number;
+  unpaid: number;
+  count: number;
+}
+
+export function ExpensesAnalytics() {
+  const { t, te } = useLanguage();
+  const [range, setRange] = useState<RangeKey>("12m");
+  const [currency, setCurrency] = useState<string>("");
+  const [categorySel, setCategorySel] = useState<string[]>([]);
+  const [mode, setMode] = useState<"bar" | "cumulative">("bar");
+
+  const bucket = RANGES[range].bucket;
+  const start = rangeStart(range);
+  const qs =
+    `?bucket=${bucket}` +
+    (start ? `&start_date=${start}` : "") +
+    (currency ? `&currency=${currency}` : "") +
+    (categorySel.length ? `&categories=${categorySel.join(",")}` : "");
+
+  const { data, isError } = useQuery<OverTime>({
+    queryKey: ["/expense/analytics/over-time", qs],
+    queryFn: () => apiRequest(`/expense/analytics/over-time${qs}`),
+  });
+
+  const { data: categories } = useQuery<string[]>({
+    queryKey: ["/expense/categories"],
+    queryFn: () => apiRequest("/expense/categories"),
+  });
+
+  // one row per period, one key per category — recharts stacks the keys, which
+  // is what gives each bar its colour-coded breakdown
+  const chartData = useMemo(() => {
+    const buckets = data?.buckets ?? [];
+    const cats = data?.categories ?? [];
+    const running: Record<string, number> = {};
+    cats.forEach((c) => (running[c] = 0));
+    return buckets.map((b) => {
+      const row: any = { label: fmtPeriod(b.period, bucket) };
+      cats.forEach((c) => {
+        const v = b.amounts[c] ?? 0;
+        running[c] += v;
+        row[c] = mode === "bar" ? v : Math.round(running[c] * 100) / 100;
+      });
+      row.__total = mode === "bar" ? b.total : Object.values(running).reduce((a, b2) => a + b2, 0);
+      return row;
+    });
+  }, [data, mode, bucket]);
+
+  const cats = data?.categories ?? [];
+  const currencyList = Object.keys(data?.currencies ?? {});
+  // fall back to the user's pick while the refetch is in flight, otherwise the
+  // currency box blanks out for a beat on every switch
+  const activeCurrency = data?.currency ?? currency ?? "";
+
+  const categoryBars = useMemo(() => {
+    const totals = data?.category_totals ?? {};
+    return cats.map((c, i) => ({
+      category: c,
+      label: te(c),
+      value: totals[c] ?? 0,
+      pct: data?.total ? ((totals[c] ?? 0) / data.total) * 100 : 0,
+      color: colorFor(c, i),
+    }));
+  }, [cats, data, te]);
+
+  return (
+    <div className="space-y-6" data-testid="expenses-analytics">
+      {/* filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Select value={range} onValueChange={(v) => setRange(v as RangeKey)}>
+          <SelectTrigger className="w-36 h-9" data-testid="expenses-range">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="30d">{t("dashboard.range30")}</SelectItem>
+            <SelectItem value="90d">{t("dashboard.range90")}</SelectItem>
+            <SelectItem value="6m">{t("customers.range6m")}</SelectItem>
+            <SelectItem value="12m">{t("customers.range12m")}</SelectItem>
+            <SelectItem value="all">{t("customers.rangeAll")}</SelectItem>
+          </SelectContent>
+        </Select>
+
+        {/* Amounts never sum across currencies, so one is charted at a time. */}
+        {currencyList.length > 0 && (
+          <Select
+            value={activeCurrency}
+            onValueChange={(v) => setCurrency(v)}
+          >
+            <SelectTrigger className="w-28 h-9" data-testid="expenses-currency">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {currencyList.map((c) => (
+                <SelectItem key={c} value={c}>
+                  {te(c)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+
+        <MultiSelect
+          label={t("expenses.categoriesFilter")}
+          options={(categories ?? []).map((c) => ({ value: c, label: te(c) }))}
+          selected={categorySel}
+          onChange={setCategorySel}
+          t={t}
+          testId="expenses-categories"
+        />
+      </div>
+
+      {/* summary */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-gray-500 mb-1">{t("expenses.totalSpend")}</p>
+            <p className="text-2xl font-semibold" data-testid="expenses-total">
+              {data ? fmtMoney(data.total) : "—"}{" "}
+              {data && (
+                <span className="text-xs font-normal text-gray-500">
+                  {te(activeCurrency)}
+                </span>
+              )}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-gray-500 mb-1">{t("expenses.paidOut")}</p>
+            <p className="text-2xl font-semibold text-green-700" data-testid="expenses-paid">
+              {data ? fmtMoney(data.paid) : "—"}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-gray-500 mb-1">{t("expenses.stillOwed")}</p>
+            <p className="text-2xl font-semibold text-amber-700" data-testid="expenses-unpaid">
+              {data ? fmtMoney(data.unpaid) : "—"}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-4">
+            <p className="text-xs text-gray-500 mb-1">{t("expenses.entryCount")}</p>
+            <p className="text-2xl font-semibold" data-testid="expenses-count">
+              {data ? data.count : "—"}
+            </p>
+            {currencyList.length > 1 && (
+              <p className="text-xs text-gray-500">
+                {t("expenses.otherCurrencies", {
+                  list: currencyList
+                    .filter((c) => c !== activeCurrency)
+                    .map((c) => `${fmtMoney(data!.currencies[c])} ${c}`)
+                    .join(", "),
+                })}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* over time — stacked by category in both modes, so the colour
+          breakdown survives the switch to cumulative */}
+      <Card>
+        <CardHeader className="pb-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <CardTitle className="text-base font-semibold flex items-center gap-2">
+              <Wallet className="w-4 h-4" />
+              {t("expenses.overTime")}
+            </CardTitle>
+            <ModeToggle
+              mode={mode}
+              onChange={setMode}
+              testPrefix="expenses"
+              barLabel={t("customers.bars")}
+              cumulativeLabel={t("customers.cumulative")}
+            />
+          </div>
+          <p className="text-xs text-gray-500">
+            {mode === "bar"
+              ? t("expenses.barsNote")
+              : t("expenses.cumulativeNote")}
+          </p>
+        </CardHeader>
+        <CardContent>
+          {isError ? (
+            <p className="text-sm text-red-600 py-12 text-center">{t("common.error")}</p>
+          ) : !data ? (
+            <p className="text-sm text-gray-400 py-12 text-center">
+              {t("common.loading")}
+            </p>
+          ) : chartData.length === 0 ? (
+            <p className="text-sm text-gray-400 py-12 text-center">
+              {t("customers.noData")}
+            </p>
+          ) : (
+            <div className="h-80" dir="ltr" data-testid="expenses-chart">
+              <ResponsiveContainer width="100%" height="100%" key={mode}>
+                {mode === "bar" ? (
+                  <BarChart data={chartData} margin={{ top: 8, right: 12, left: 4, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                    <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                    <YAxis tick={{ fontSize: 11 }} width={72} />
+                    <Tooltip formatter={(v: any) => fmtMoney(Number(v))} />
+                    <Legend wrapperStyle={{ fontSize: 12 }} />
+                    {cats.map((c, i) => (
+                      <Bar
+                        key={c}
+                        dataKey={c}
+                        name={te(c)}
+                        stackId="spend"
+                        fill={colorFor(c, i)}
+                        isAnimationActive={false}
+                      />
+                    ))}
+                  </BarChart>
+                ) : (
+                  <AreaChart data={chartData} margin={{ top: 8, right: 12, left: 4, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                    <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                    <YAxis tick={{ fontSize: 11 }} width={72} />
+                    <Tooltip formatter={(v: any) => fmtMoney(Number(v))} />
+                    <Legend wrapperStyle={{ fontSize: 12 }} />
+                    {cats.map((c, i) => (
+                      <Area
+                        key={c}
+                        type="monotone"
+                        dataKey={c}
+                        name={te(c)}
+                        stackId="spend"
+                        stroke={colorFor(c, i)}
+                        fill={colorFor(c, i)}
+                        fillOpacity={0.75}
+                        isAnimationActive={false}
+                      />
+                    ))}
+                  </AreaChart>
+                )}
+              </ResponsiveContainer>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* category breakdown */}
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base font-semibold flex items-center gap-2">
+            <Layers className="w-4 h-4" />
+            {t("expenses.byCategory")}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {!data || categoryBars.length === 0 ? (
+            <p className="text-sm text-gray-400 py-6 text-center">
+              {t("customers.noData")}
+            </p>
+          ) : (
+            <div className="space-y-3" data-testid="expenses-by-category">
+              {categoryBars.map((b) => (
+                <div key={b.category} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="inline-block h-2.5 w-2.5 rounded-sm"
+                        style={{ backgroundColor: b.color }}
+                      />
+                      {b.label}
+                    </span>
+                    <span className="font-medium">
+                      {fmtMoney(b.value)}{" "}
+                      <span className="text-xs text-gray-500">
+                        {b.pct.toFixed(1)}%
+                      </span>
+                    </span>
+                  </div>
+                  <div className="h-2 rounded-full bg-gray-100 overflow-hidden">
+                    <div
+                      className="h-full rounded-full"
+                      style={{ width: `${b.pct}%`, backgroundColor: b.color }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/client/src/i18n/translations/expenses.ts
+++ b/frontend/client/src/i18n/translations/expenses.ts
@@ -93,6 +93,16 @@ export const en: Record<string, string> = {
   'enum.travel': 'Travel',
   'enum.meals': 'Meals',
   'enum.other': 'Other',
+  'expenses.categoriesFilter': 'Categories',
+  'expenses.totalSpend': 'Total Spend',
+  'expenses.paidOut': 'Paid Out',
+  'expenses.stillOwed': 'Still Owed',
+  'expenses.entryCount': 'Expenses',
+  'expenses.otherCurrencies': 'Also: {list}',
+  'expenses.overTime': 'Expenses Over Time',
+  'expenses.byCategory': 'Spend by Category',
+  'expenses.barsNote': 'Each bar is one period, split by category.',
+  'expenses.cumulativeNote': 'Running total from the start of the window, split by category.',
 };
 
 export const ar: Record<string, string> = {
@@ -184,4 +194,14 @@ export const ar: Record<string, string> = {
   'enum.travel': 'سفر',
   'enum.meals': 'وجبات',
   'enum.other': 'أخرى',
+  'expenses.categoriesFilter': 'الفئات',
+  'expenses.totalSpend': 'إجمالي المصروف',
+  'expenses.paidOut': 'المدفوع',
+  'expenses.stillOwed': 'المتبقي',
+  'expenses.entryCount': 'المصروفات',
+  'expenses.otherCurrencies': 'كذلك: {list}',
+  'expenses.overTime': 'المصروفات عبر الزمن',
+  'expenses.byCategory': 'المصروف حسب الفئة',
+  'expenses.barsNote': 'كل عمود يمثل فترة واحدة، مقسّماً حسب الفئة.',
+  'expenses.cumulativeNote': 'الإجمالي التراكمي من بداية الفترة، مقسّماً حسب الفئة.',
 };

--- a/frontend/client/src/pages/Expenses.tsx
+++ b/frontend/client/src/pages/Expenses.tsx
@@ -12,6 +12,8 @@ import { useToast } from "@/hooks/use-toast";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { ExpenseFilters } from "@/components/expenses/ExpenseFilters";
+import { ExpensesAnalytics } from "@/components/expenses/ExpensesAnalytics";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { format } from "date-fns";
 
 interface Expense {
@@ -184,6 +186,21 @@ export default function Expenses() {
           </Button>
         </div>
 
+        <Tabs defaultValue="list">
+          <TabsList>
+            <TabsTrigger value="list" data-testid="expenses-tab-list">
+              {t('nav.expenses')}
+            </TabsTrigger>
+            <TabsTrigger value="analytics" data-testid="expenses-tab-analytics">
+              {t('customers.analytics')}
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="analytics" className="mt-6">
+            <ExpensesAnalytics />
+          </TabsContent>
+
+          <TabsContent value="list" className="mt-6 space-y-8">
         {/* Filters */}
         <ExpenseFilters 
           filters={filters} 
@@ -334,6 +351,8 @@ export default function Expenses() {
             )}
           </CardContent>
         </Card>
+          </TabsContent>
+        </Tabs>
       </div>
     </AppLayout>
   );


### PR DESCRIPTION
## Summary
**List / Analytics** tabs on the expenses page. The Analytics tab shows:

- **Summary** — total spend, paid out, still owed, entry count.
- **Expenses Over Time** with a **Bars | Cumulative** toggle. Both modes **stack by category**, so the colour breakdown survives the switch: bars are one period each, cumulative is the running total from the start of the window.
- **Spend by Category** — totals with share-of-spend bars.
- Filters: time window, currency, categories.

One new read-only endpoint (`GET /expense/analytics/over-time`). No migration.

## Design decisions worth knowing
- **Colour is keyed by category name, not position.** The backend orders categories by spend, which shifts as the window changes — an index-based palette would recolour the entire chart every time you change range.
- **Amounts never sum across currencies.** The endpoint reports the total *per* currency, charts exactly one, and defaults to whichever carries the most spend so the first paint is meaningful. The others are noted beside the entry count ("Also: 1,610.00 USD").
- **Paid** comes from `Expense.amount_paid`, which has a real SQL expression, so it's one aggregate rather than a per-row hybrid read (no N+1).

## Two recharts traps handled
- Swapping `BarChart` ↔ `AreaChart` inside one `ResponsiveContainer` leaves the entry-animation `clipPath` stuck at `width="0"` — the series render with **correct geometry but clipped to nothing** (I hit exactly this: 8 areas in the DOM, empty plot). Fixed by keying the container on the mode and disabling the entry animation.
- The currency `Select` now falls back to the pending pick while a refetch is in flight; otherwise the box blanks out for a beat on every switch.

## Verification
Seeded 23 expenses across 6 months, 8 categories and 2 currencies (with payouts on some), then checked:
- Each bucket total equals the sum of its category segments; buckets sum to the reported total (**10,498,000 SYP**); the cumulative stack lands on that same total.
- **Paid 3,225,000** matches the seeded payouts exactly; unpaid = total − paid.
- Category percentages sum to 100%.
- Switching to **USD** shows its own **1,610.00** across 3 categories (55.9 / 28.0 / 16.1%) with no cross-currency mixing.
- Role presets regenerated → `parity_check` **LOST=0**. tsc 70 = unchanged baseline, 0 new.
- Seed data deleted afterwards (0 expenses left in the local DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)