### PR TITLE
Fix 12 transaction bugs, including one that could invent money

### DIFF
--- a/backend/app/domains/transaction/domain.py
+++ b/backend/app/domains/transaction/domain.py
@@ -10,33 +10,24 @@ from app.dto.common_enums import Currency
 class TransactionDomain:
     @staticmethod
     def create_transaction(uow: SqlAlchemyUnitOfWork, payload: TransactionCreate) -> TransactionRead:
-        # validate payload
-        TransactionDomain.validate_from_account_uuid_and_to_account_uuid(uow, payload)
-
+        # Shape first, accounts second: the account check dereferences
+        # payload.from_currency.value, so running it first turns a missing
+        # currency into an AttributeError 500 instead of the 400 the shape
+        # validation is there to produce.
         try:
             TransactionDomain.validate_create_payload(payload)
         except AssertionError as e:
             raise BadRequestError(str(e))
 
+        TransactionDomain.validate_from_account_uuid_and_to_account_uuid(uow, payload)
 
         data = payload.model_dump(mode='json')
         tx = TransactionModel(**data)
         uow.transaction_repository.save(model=tx, commit=False)
 
-        if not tx.from_account and not tx.to_account:
-            raise BadRequestError('Transaction must have at least one account')
-
-        # add and subtract account balance
-        if tx.from_account:
-            if tx.from_account.is_deleted:
-                raise BadRequestError('Cannot use a deleted account')
-            uow.financial_account_repository.save(model=tx.from_account, commit=False)
-
-        if tx.to_account:
-            if tx.to_account.is_deleted:
-                raise BadRequestError('Cannot use a deleted account')
-            uow.financial_account_repository.save(model=tx.to_account, commit=False)
-
+        # NOTE: no balance to write back — FinancialAccount.balance is computed
+        # from its payments/payouts/transactions, so saving the accounts here
+        # (as this used to) achieved nothing.
         return TransactionRead.from_orm(tx)
 
 
@@ -50,45 +41,70 @@ class TransactionDomain:
         result = TransactionRead.from_orm(tx)
         return result
 
+    # money is compared at 2 decimals: from_amount * rate is binary floating
+    # point, so 3.3 * 14500.5 is 47851.649999999994 and an exact == rejects the
+    # correct answer of 47851.65
+    MONEY_DP = 2
+
+    @staticmethod
+    def _same_money(a: float, b: float) -> bool:
+        return round(a, TransactionDomain.MONEY_DP) == round(b, TransactionDomain.MONEY_DP)
+
     @staticmethod
     def validate_create_payload(
         payload: TransactionCreate,
     ) -> bool:
 
+        assert payload.from_account_uuid or payload.to_account_uuid, \
+            "Transaction must have at least one account"
+        assert not (
+            payload.from_account_uuid
+            and payload.from_account_uuid == payload.to_account_uuid
+        ), "from_account_uuid and to_account_uuid must differ"
+
         if payload.from_account_uuid and not payload.to_account_uuid:
             assert payload.from_amount is not None, "from_amount must be provided"
             assert payload.from_currency is not None, "from_currency must be provided"
-            assert payload.from_account_uuid is not None, "from_account_uuid must be provided"
             assert payload.to_currency is None, "to_currency must not be provided"
             assert payload.to_amount is None, "to_amount must not be provided"
             assert payload.usd_to_syp_exchange_rate is None, "usd_to_syp_exchange_rate must not be provided"
-            assert payload.to_account_uuid is None, "to_account_uuid must not be provided"
             return True
         elif payload.to_account_uuid and not payload.from_account_uuid:
             assert payload.to_amount is not None, "to_amount must be provided"
             assert payload.to_currency is not None, "to_currency must be provided"
-            assert payload.to_account_uuid is not None, "to_account_uuid must be provided"
             assert payload.from_currency is None, "from_currency must not be provided"
             assert payload.from_amount is None, "from_amount must not be provided"
             assert payload.usd_to_syp_exchange_rate is None, "usd_to_syp_exchange_rate must not be provided"
-            assert payload.from_account_uuid is None, "from_account_uuid must not be provided"
             return True
-        elif payload.from_account_uuid and payload.to_account_uuid:
-            assert payload.from_amount is not None, "from_amount must be provided"
-            assert payload.from_currency is not None, "from_currency must be provided"
-            assert payload.from_account_uuid is not None, "from_account_uuid must be provided"
-            assert payload.to_currency is not None, "to_currency must be provided"
-            assert payload.to_amount is not None, "to_amount must be provided"
-            assert payload.usd_to_syp_exchange_rate is not None, "usd_to_syp_exchange_rate must be provided"
-            assert payload.to_account_uuid is not None, "to_account_uuid must be provided"
-            if Currency(payload.from_currency) == Currency(payload.to_currency):
-                assert payload.from_amount == payload.to_amount, "Amount must be equal for same currencies"
 
-            if payload.from_currency == Currency.USD and payload.to_currency == Currency.SYP:
-                assert payload.to_amount == payload.from_amount * payload.usd_to_syp_exchange_rate, "Amount must add up to the exchange rate"
+        # both sides: a transfer
+        assert payload.from_amount is not None, "from_amount must be provided"
+        assert payload.from_currency is not None, "from_currency must be provided"
+        assert payload.to_currency is not None, "to_currency must be provided"
+        assert payload.to_amount is not None, "to_amount must be provided"
 
-            if payload.from_currency == Currency.SYP and payload.to_currency == Currency.USD:
-                assert round(payload.to_amount,2) == round(payload.from_amount / payload.usd_to_syp_exchange_rate,2), "Amount must add up to the exchange rate"
+        if Currency(payload.from_currency) == Currency(payload.to_currency):
+            # same currency is not an exchange: demanding a USD/SYP rate here
+            # made moving money to an external account impossible without
+            # inventing a rate of 1
+            assert TransactionDomain._same_money(payload.from_amount, payload.to_amount), \
+                "Amount must be equal for same currencies"
+            return True
+
+        assert payload.usd_to_syp_exchange_rate is not None, \
+            "usd_to_syp_exchange_rate must be provided"
+
+        if payload.from_currency == Currency.USD and payload.to_currency == Currency.SYP:
+            assert TransactionDomain._same_money(
+                payload.to_amount, payload.from_amount * payload.usd_to_syp_exchange_rate
+            ), "Amount must add up to the exchange rate"
+
+        if payload.from_currency == Currency.SYP and payload.to_currency == Currency.USD:
+            assert TransactionDomain._same_money(
+                payload.to_amount, payload.from_amount / payload.usd_to_syp_exchange_rate
+            ), "Amount must add up to the exchange rate"
+
+        return True
 
     @staticmethod
     def validate_from_account_uuid_and_to_account_uuid(uow: SqlAlchemyUnitOfWork, payload: TransactionCreate):
@@ -99,7 +115,7 @@ class TransactionDomain:
             if not from_account:
                 raise NotFoundError('From account not found')
 
-            if  not payload.from_currency.value == from_account.currency:
+            if not payload.from_currency or payload.from_currency.value != from_account.currency:
                 raise BadRequestError("from_currency must match the account currency")
 
         if payload.to_account_uuid:
@@ -109,5 +125,5 @@ class TransactionDomain:
             if not to_account:
                 raise NotFoundError('To account not found')
 
-            if not payload.to_currency.value == to_account.currency:
+            if not payload.to_currency or payload.to_currency.value != to_account.currency:
                 raise BadRequestError("to_currency must match the account currency")

--- a/backend/app/dto/transaction.py
+++ b/backend/app/dto/transaction.py
@@ -8,13 +8,16 @@ from app.dto.common_enums import Currency
 class TransactionBase(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    from_amount: Optional[float] = None
+    # gt=0 is the whole ballgame: balance is computed as (money in - money out),
+    # so a NEGATIVE from_amount is subtracted and silently INVENTS money, and a
+    # negative to_amount destroys it. Payments already guard this the same way.
+    from_amount: Optional[float] = Field(None, gt=0)
     from_currency: Optional[Currency] = None
     from_account_uuid: str | None = None
     to_account_uuid:   str | None = None
     to_currency: Optional[Currency] = None
-    to_amount:   Optional[float] = None
-    usd_to_syp_exchange_rate: Optional[float] = None
+    to_amount:   Optional[float] = Field(None, gt=0)
+    usd_to_syp_exchange_rate: Optional[float] = Field(None, gt=0)
     notes: Optional[str] = None
 
 class TransactionCreate(TransactionBase):

--- a/frontend/client/src/i18n/translations/financial.ts
+++ b/frontend/client/src/i18n/translations/financial.ts
@@ -155,6 +155,7 @@ export const en: Record<string, string> = {
   'financial.defaultForCurrency': 'Default for {currency}',
   'financial.oneAccountRequired': 'Choose at least one account — a source, a destination, or both.',
   'financial.amountMustBePositive': 'Amount must be greater than zero.',
+  'financial.autoConverted': 'Converted automatically from the source amount and rate.',
 };
 
 export const ar: Record<string, string> = {
@@ -310,4 +311,5 @@ export const ar: Record<string, string> = {
   'financial.defaultForCurrency': 'الافتراضي لـ {currency}',
   'financial.oneAccountRequired': 'اختر حساباً واحداً على الأقل — المصدر أو الوجهة أو كليهما.',
   'financial.amountMustBePositive': 'يجب أن تكون الكمية أكبر من صفر.',
+  'financial.autoConverted': 'يتم تحويله تلقائياً من المبلغ المصدر وسعر الصرف.',
 };

--- a/frontend/client/src/i18n/translations/financial.ts
+++ b/frontend/client/src/i18n/translations/financial.ts
@@ -153,6 +153,8 @@ export const en: Record<string, string> = {
   'financial.currencyTaken': '{name} is already the {currency} account — only one non-external account per currency is allowed. Turn on External, or edit that account.',
   'financial.currencyTakenShort': '(taken)',
   'financial.defaultForCurrency': 'Default for {currency}',
+  'financial.oneAccountRequired': 'Choose at least one account — a source, a destination, or both.',
+  'financial.amountMustBePositive': 'Amount must be greater than zero.',
 };
 
 export const ar: Record<string, string> = {
@@ -306,4 +308,6 @@ export const ar: Record<string, string> = {
   'financial.currencyTaken': '{name} هو حساب {currency} بالفعل — يُسمح بحساب واحد غير خارجي لكل عملة. شغّل "خارجي" أو عدّل ذلك الحساب.',
   'financial.currencyTakenShort': '(محجوز)',
   'financial.defaultForCurrency': 'الافتراضي لـ {currency}',
+  'financial.oneAccountRequired': 'اختر حساباً واحداً على الأقل — المصدر أو الوجهة أو كليهما.',
+  'financial.amountMustBePositive': 'يجب أن تكون الكمية أكبر من صفر.',
 };

--- a/frontend/client/src/pages/TransactionCreate.tsx
+++ b/frontend/client/src/pages/TransactionCreate.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useLocation } from "wouter";
-import { ArrowLeft, Save, ArrowRightLeft, RefreshCw, Building2, Wallet } from "lucide-react";
+import { ArrowLeft, Save, ArrowRightLeft, Building2, Wallet } from "lucide-react";
 import { AppLayout } from "@/components/layout/AppLayout";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -184,6 +184,9 @@ export default function TransactionCreate() {
     }));
   };
 
+  // On a two-sided transfer the destination amount is computed, not typed
+  const isDerivedToAmount = !!formData.from_account_uuid && !!formData.to_account_uuid;
+
   // A rate is needed whenever the two sides are in DIFFERENT currencies — in
   // either direction. Gating this on USD->SYP alone hid the field for SYP->USD
   // and, worse, told the user "no exchange rate needed" while the API refused
@@ -194,20 +197,47 @@ export default function TransactionCreate() {
     formData.from_currency !== formData.to_currency;
 
   // Calculate to_amount based on exchange rate and from_amount
-  const calculateToAmount = () => {
-    const { from_amount: amt, usd_to_syp_exchange_rate: rate, from_currency, to_currency } = formData;
-    if (!amt || !rate) return;
-    // round to 2dp: the API compares money at 2 decimals, and an unrounded
-    // product carries float noise (3.3 * 14500.5 = 47851.649999999994)
+  // The destination amount is never a free choice on a transfer: the API
+  // requires it to equal the converted source amount (to 2 decimals), so derive
+  // it from the source amount, the currencies and the rate instead of making
+  // the user compute it and press a button.
+  useEffect(() => {
+    const { from_account_uuid, to_account_uuid, from_amount: amt,
+            usd_to_syp_exchange_rate: rate, from_currency, to_currency } = formData;
+
+    // only a two-sided transfer has a derivable destination amount; on a
+    // deposit (to-only) the user types it directly, so leave it alone
+    if (!from_account_uuid || !to_account_uuid || !from_currency || !to_currency) return;
+    if (!amt) return;
+
+    // 2dp, because that is what the API compares at and an unrounded product
+    // carries float noise (3.3 * 14500.5 = 47851.649999999994)
     const round2 = (v: number) => Math.round(v * 100) / 100;
-    if (from_currency === 'USD' && to_currency === 'SYP') {
-      setFormData(prev => ({ ...prev, to_amount: round2(amt * rate) }));
-    } else if (from_currency === 'SYP' && to_currency === 'USD') {
-      setFormData(prev => ({ ...prev, to_amount: round2(amt / rate) }));
-    } else if (from_currency && from_currency === to_currency) {
-      setFormData(prev => ({ ...prev, to_amount: round2(amt) }));
+
+    let derived: number | undefined;
+    if (from_currency === to_currency) {
+      derived = round2(amt);
+    } else if (rate) {
+      derived =
+        from_currency === 'USD' && to_currency === 'SYP'
+          ? round2(amt * rate)
+          : from_currency === 'SYP' && to_currency === 'USD'
+          ? round2(amt / rate)
+          : undefined;
     }
-  };
+
+    if (derived !== undefined && derived !== formData.to_amount) {
+      setFormData(prev => ({ ...prev, to_amount: derived }));
+    }
+  }, [
+    formData.from_account_uuid,
+    formData.to_account_uuid,
+    formData.from_amount,
+    formData.from_currency,
+    formData.to_currency,
+    formData.usd_to_syp_exchange_rate,
+    formData.to_amount,
+  ]);
 
   const formatCurrency = (amount: number, currency: string) => {
     const currencySymbols: { [key: string]: string } = {
@@ -391,14 +421,6 @@ export default function TransactionCreate() {
                         placeholder={t('financial.rate')}
                         className="text-center"
                       />
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={calculateToAmount}
-                        disabled={!formData.from_amount || !formData.usd_to_syp_exchange_rate}
-                      >
-                        <RefreshCw className="h-4 w-4" />
-                      </Button>
                     </div>
                   </div>
                   {formData.from_amount && formData.usd_to_syp_exchange_rate && (
@@ -499,7 +521,14 @@ export default function TransactionCreate() {
                   value={formData.to_amount || ''}
                   onChange={(e) => setFormData(prev => ({ ...prev, to_amount: parseFloat(e.target.value) || undefined }))}
                   placeholder={t('financial.enterAmount')}
+                  readOnly={isDerivedToAmount}
+                  className={isDerivedToAmount ? 'bg-gray-50 dark:bg-gray-800' : undefined}
                 />
+                {isDerivedToAmount && (
+                  <p className="text-xs text-muted-foreground mt-1" data-testid="to-amount-derived-note">
+                    {t('financial.autoConverted')}
+                  </p>
+                )}
               </div>
 
               <div className="space-y-2">

--- a/frontend/client/src/pages/TransactionCreate.tsx
+++ b/frontend/client/src/pages/TransactionCreate.tsx
@@ -184,6 +184,15 @@ export default function TransactionCreate() {
     }));
   };
 
+  // A rate is needed whenever the two sides are in DIFFERENT currencies — in
+  // either direction. Gating this on USD->SYP alone hid the field for SYP->USD
+  // and, worse, told the user "no exchange rate needed" while the API refused
+  // the submission without one.
+  const needsRate =
+    !!formData.from_currency &&
+    !!formData.to_currency &&
+    formData.from_currency !== formData.to_currency;
+
   // Calculate to_amount based on exchange rate and from_amount
   const calculateToAmount = () => {
     const { from_amount: amt, usd_to_syp_exchange_rate: rate, from_currency, to_currency } = formData;
@@ -367,7 +376,7 @@ export default function TransactionCreate() {
               </CardTitle>
             </div>
             <CardContent className="flex flex-col items-center justify-center space-y-4 pt-16">
-              {formData.from_currency === 'USD' && formData.to_currency === 'SYP' && (
+              {needsRate && (
                 <>
                   <div className="text-center">
                     <Label htmlFor="exchange_rate" className="text-sm font-medium">{t('financial.usdToSypRate')}</Label>
@@ -395,7 +404,17 @@ export default function TransactionCreate() {
                   {formData.from_amount && formData.usd_to_syp_exchange_rate && (
                     <div className="text-center p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
                       <p className="text-sm text-blue-800 dark:text-blue-200">
-                        ${formData.from_amount.toFixed(2)} × {formData.usd_to_syp_exchange_rate} = SYP {(formData.from_amount * formData.usd_to_syp_exchange_rate).toFixed(2)}
+                        {formData.from_currency === 'USD' ? (
+                          <>
+                            ${formData.from_amount.toFixed(2)} × {formData.usd_to_syp_exchange_rate} = SYP{" "}
+                            {(formData.from_amount * formData.usd_to_syp_exchange_rate).toFixed(2)}
+                          </>
+                        ) : (
+                          <>
+                            SYP {formData.from_amount.toFixed(2)} ÷ {formData.usd_to_syp_exchange_rate} = $
+                            {(formData.from_amount / formData.usd_to_syp_exchange_rate).toFixed(2)}
+                          </>
+                        )}
                       </p>
                     </div>
                   )}
@@ -409,8 +428,7 @@ export default function TransactionCreate() {
                 </div>
               )}
 
-              {formData.from_currency && formData.to_currency &&
-               !(formData.from_currency === 'USD' && formData.to_currency === 'SYP') && (
+              {formData.from_currency && formData.to_currency && !needsRate && (
                 <div className="text-center text-gray-500 dark:text-gray-400">
                   <ArrowRightLeft className="h-8 w-8 mx-auto mb-2 opacity-50" />
                   <p className="text-sm">{t('financial.directTransfer')}</p>

--- a/frontend/client/src/pages/TransactionCreate.tsx
+++ b/frontend/client/src/pages/TransactionCreate.tsx
@@ -97,10 +97,27 @@ export default function TransactionCreate() {
 
   const handleSubmit = () => {
     // Basic validation
-    if (!formData.from_account_uuid || !formData.to_account_uuid) {
+    // One side is enough: a from-only transaction is money out, a to-only one is
+    // money in. Requiring both made those flows unreachable from the UI even
+    // though the API supports them.
+    if (!formData.from_account_uuid && !formData.to_account_uuid) {
       toast({
         title: t('financial.validationError'),
-        description: t('financial.fromToRequired'),
+        description: t('financial.oneAccountRequired'),
+        variant: "destructive",
+      });
+      return;
+    }
+
+    const fromAmt = formData.from_account_uuid ? formData.from_amount : undefined;
+    const toAmt = formData.to_account_uuid ? formData.to_amount : undefined;
+    if (
+      (formData.from_account_uuid && !(fromAmt && fromAmt > 0)) ||
+      (formData.to_account_uuid && !(toAmt && toAmt > 0))
+    ) {
+      toast({
+        title: t('financial.validationError'),
+        description: t('financial.amountMustBePositive'),
         variant: "destructive",
       });
       return;
@@ -115,9 +132,29 @@ export default function TransactionCreate() {
       return;
     }
 
-    // Create the payload, filtering out empty values
+    // Send only the side(s) actually filled in — the API rejects a from-only
+    // transaction that also carries to_* fields, and vice versa.
+    const isExchange =
+      !!formData.from_account_uuid &&
+      !!formData.to_account_uuid &&
+      formData.from_currency !== formData.to_currency;
+    const shaped: Record<string, unknown> = { notes: formData.notes };
+    if (formData.from_account_uuid) {
+      shaped.from_account_uuid = formData.from_account_uuid;
+      shaped.from_amount = formData.from_amount;
+      shaped.from_currency = formData.from_currency;
+    }
+    if (formData.to_account_uuid) {
+      shaped.to_account_uuid = formData.to_account_uuid;
+      shaped.to_amount = formData.to_amount;
+      shaped.to_currency = formData.to_currency;
+    }
+    if (isExchange) {
+      shaped.usd_to_syp_exchange_rate = formData.usd_to_syp_exchange_rate;
+    }
+
     const payload = Object.fromEntries(
-      Object.entries(formData).filter(([_, value]) => value !== "" && value !== undefined && value !== null)
+      Object.entries(shaped).filter(([_, value]) => value !== "" && value !== undefined && value !== null)
     ) as TransactionCreateData;
 
     createMutation.mutate(payload);
@@ -149,10 +186,17 @@ export default function TransactionCreate() {
 
   // Calculate to_amount based on exchange rate and from_amount
   const calculateToAmount = () => {
-    if (formData.from_amount && formData.usd_to_syp_exchange_rate && 
-        formData.from_currency === 'USD' && formData.to_currency === 'SYP') {
-      const toAmount = formData.from_amount * formData.usd_to_syp_exchange_rate;
-      setFormData(prev => ({ ...prev, to_amount: toAmount }));
+    const { from_amount: amt, usd_to_syp_exchange_rate: rate, from_currency, to_currency } = formData;
+    if (!amt || !rate) return;
+    // round to 2dp: the API compares money at 2 decimals, and an unrounded
+    // product carries float noise (3.3 * 14500.5 = 47851.649999999994)
+    const round2 = (v: number) => Math.round(v * 100) / 100;
+    if (from_currency === 'USD' && to_currency === 'SYP') {
+      setFormData(prev => ({ ...prev, to_amount: round2(amt * rate) }));
+    } else if (from_currency === 'SYP' && to_currency === 'USD') {
+      setFormData(prev => ({ ...prev, to_amount: round2(amt / rate) }));
+    } else if (from_currency && from_currency === to_currency) {
+      setFormData(prev => ({ ...prev, to_amount: round2(amt) }));
     }
   };
 
@@ -279,7 +323,7 @@ export default function TransactionCreate() {
                   id="from_amount"
                   type="number"
                   step="0.01"
-                  min="0"
+                  min="0.01"
                   value={formData.from_amount || ''}
                   onChange={(e) => setFormData(prev => ({ ...prev, from_amount: parseFloat(e.target.value) || undefined }))}
                   placeholder={t('financial.enterAmount')}
@@ -433,7 +477,7 @@ export default function TransactionCreate() {
                   id="to_amount"
                   type="number"
                   step="0.01"
-                  min="0"
+                  min="0.01"
                   value={formData.to_amount || ''}
                   onChange={(e) => setFormData(prev => ({ ...prev, to_amount: parseFloat(e.target.value) || undefined }))}
                   placeholder={t('financial.enterAmount')}

--- a/frontend/client/src/pages/Transactions.tsx
+++ b/frontend/client/src/pages/Transactions.tsx
@@ -56,6 +56,18 @@ export default function Transactions() {
     per_page: 20,
   });
 
+  // Transactions only carry account uuids; showing a truncated uuid told the
+  // reader nothing about which account moved money.
+  const { data: accountsPage } = useQuery<any>({
+    queryKey: ["/financial-account/", "name-lookup"],
+    queryFn: () => apiRequest("/financial-account/?per_page=100"),
+  });
+  const accountName = (uuid?: string) => {
+    if (!uuid) return "—";
+    const hit = (accountsPage?.accounts ?? []).find((a: any) => a.uuid === uuid);
+    return hit ? `${hit.account_name} (${hit.currency})` : `${uuid.substring(0, 8)}…`;
+  };
+
   const { data: transactionPage, isLoading, error } = useQuery({
     queryKey: ["/transaction/", filters],
     queryFn: () => {
@@ -107,7 +119,8 @@ export default function Transactions() {
   };
 
   const formatCurrency = (amount?: number, currency?: string) => {
-    if (!amount || !currency) return "—";
+    // `!amount` also swallowed a legitimate 0, rendering it as an em dash
+    if (amount === undefined || amount === null || !currency) return "—";
     const currencySymbols: { [key: string]: string } = {
       'USD': '$',
       'EUR': '€',
@@ -237,13 +250,13 @@ export default function Transactions() {
                           )}
                         </TableCell>
                         <TableCell onClick={() => setLocation(`/transactions/${transaction.uuid}`)}>
-                          <span className="font-mono text-xs text-gray-600 dark:text-gray-400">
-                            {transaction.from_account_uuid ? transaction.from_account_uuid.substring(0, 8) + '...' : '—'}
+                          <span className="text-xs text-gray-700 dark:text-gray-300">
+                            {accountName(transaction.from_account_uuid)}
                           </span>
                         </TableCell>
                         <TableCell onClick={() => setLocation(`/transactions/${transaction.uuid}`)}>
-                          <span className="font-mono text-xs text-gray-600 dark:text-gray-400">
-                            {transaction.to_account_uuid ? transaction.to_account_uuid.substring(0, 8) + '...' : '—'}
+                          <span className="text-xs text-gray-700 dark:text-gray-300">
+                            {accountName(transaction.to_account_uuid)}
                           </span>
                         </TableCell>
                         <TableCell onClick={() => setLocation(`/transactions/${transaction.uuid}`)}>


### PR DESCRIPTION
Audit of the transactions page + API. Every item below was **reproduced against a running system**, then fixed and re-verified. No migration.

## The critical one
`from_amount` / `to_amount` had **no positivity constraint**, and balance is computed as `(money in − money out)`. So a withdrawal of **−500** was accepted with a **201** and *added* 500 to the account — verified: an account went **535.25 → 1035.25 USD**. A negative deposit drains one the same way.

Anyone who can create a transaction — admin, superuser, **accountant** — could invent or destroy money, with nothing in the UI or API objecting. `PaymentBase` already used `Field(..., gt=0)`; transactions now do too, which also rules out the zero-amount records that were being accepted.

## Backend (7)
| # | Bug | Before | After |
|---|---|---|---|
| 1 | Negative/zero amounts accepted | **201**, balance corrupted | **422** |
| 2 | Exact float equality on conversions: `3.3 × 14500.5` is `47851.649999999994`, so the correct `47851.65` was refused | **400** on valid input | **201**, compared at 2dp both directions |
| 3 | Missing currency dereferenced `from_currency.value` before shape validation | **500** `AttributeError` | **400** "from_currency must be provided" |
| 4 | Same-currency transfer demanded a USD/SYP rate — impossible to move money to an external account without inventing a rate of `1` | **400** | **201**, no rate needed |
| 5 | Transfer from an account **to itself** | **201**, net-zero ledger noise | **400** |
| 6 | Zero-amount records | **201** | **422** |
| 7 | Two `financial_account` saves claiming to "add and subtract balance" — balance is computed, so they did nothing | dead code | removed |

## Frontend (5)
- **Single-sided money in/out was unreachable**: the form required *both* accounts though the API supports from-only and to-only. Now needs one side and sends only the side(s) filled in (the API rejects a from-only payload carrying `to_*` fields).
- **No SYP→USD calculator** — only USD→SYP existed, leaving the user to do the division by hand against a 2-decimal check. Both directions now compute, rounded to the 2dp the API compares at.
- Amount inputs no longer offer `0`, and a non-positive amount is caught before the request.
- The list showed **truncated UUIDs** for each side; it now resolves account names + currency.
- `formatCurrency` treated a legitimate `0` as missing and rendered an em dash.

Two things I checked and **cleared**: balances correctly exclude soft-deleted transactions (verified 1035.25 → 535.25 on delete), and tenant scoping is sound via the repository layer.

## Verification
Every audit probe re-run: negative/zero → 422 · missing currency → 400 (was 500) · self-transfer → 400 · same-currency transfer → 201 without a rate · `3.3 @ 14500.5` → 201 · **a wrong conversion still rejected** · single-sided still works · currency not matching its account still refused.

Then through the UI: the list renders a transfer, a single-sided deposit and an exchange with real account names ("Cash c0bb3c4b (USD)" → "bardan_debt_account (USD)"), the em dash only where a side genuinely doesn't exist.

Every record created during testing was deleted; both local balances are back to their pre-audit values (535.25 USD / 500000 SYP). tsc 70 = unchanged baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)