### PR TITLE
Material detail: zero out an inventory lot; hide only truly empty lots

### DIFF
--- a/backend/app/entrypoint/routes/inventory/routes.py
+++ b/backend/app/entrypoint/routes/inventory/routes.py
@@ -195,6 +195,63 @@ def manual_add_inventory():
 
 
 
+@inventory_blueprint.route('/<string:uuid>/zero-out', methods=['POST'])
+@jwt_required()
+@scopes_required(PermissionScope.ADMIN.value,
+                 PermissionScope.SUPER_ADMIN.value,
+                 PermissionScope.ACCOUNTANT.value,
+                 PermissionScope.OPERATION_MANAGER.value,
+                 PermissionScope.OPERATOR.value)
+def zero_out_inventory(uuid: str):
+    """Write the lot's remaining quantity off to exactly zero.
+
+    The correcting quantity is computed HERE, from the lot's own events, rather
+    than taken from the caller: a page that loaded a minute ago may be showing a
+    stale figure, and trusting it would leave the lot slightly off — or worse,
+    push it the wrong side of zero. A negative lot is corrected upwards by the
+    same rule.
+
+    Recorded as a manual event with affect_original=False, so the lot keeps its
+    original received quantity for costing and only the current balance moves.
+    """
+    from app.dto.inventory_event import InventoryEventCreate, InventoryEventType
+    from app.domains.inventory_event.domain import InventoryEventDomain
+
+    current_user_uuid = get_jwt_identity()
+    notes = (request.json or {}).get('notes') if request.is_json else None
+
+    with SqlAlchemyUnitOfWork() as uow:
+        inventory = uow.inventory_repository.find_one(uuid=uuid, is_deleted=False)
+        if not inventory:
+            raise NotFoundError('Inventory not found')
+
+        remaining = inventory.current_quantity or 0
+        # 1e-9 rather than == 0: quantities are floats built by summing events
+        if abs(remaining) < 1e-9:
+            raise BadRequestError('This lot is already at zero')
+
+        event = InventoryEventCreate(
+            inventory_uuid=inventory.uuid,
+            event_type=InventoryEventType.MANUAL.value,
+            quantity=-remaining,
+            notes=notes or f'Zeroed out (was {remaining})',
+            affect_original=False,
+        )
+        add_logged_user_to_payload(uow=uow, user_uuid=current_user_uuid, payload=event)
+        event_read = InventoryEventDomain.create_inventory_event(uow=uow, payload=event)
+        uow.commit()
+
+        result = {
+            'inventory_uuid': inventory.uuid,
+            'lot_id': inventory.lot_id,
+            'previous_quantity': remaining,
+            'current_quantity': inventory.current_quantity,
+            'inventory_event': event_read.model_dump(mode='json'),
+        }
+    return jsonify(result), 201
+
+
+
 # ----------------------- WAREHOUSE INVENTORY ANALYTICS -----------------------
 # Stock is the running sum of SIGNED inventory events (purchases/returns are
 # positive, sales/process consumption negative) — exactly how

--- a/backend/app/entrypoint/routes/material/routes.py
+++ b/backend/app/entrypoint/routes/material/routes.py
@@ -163,8 +163,11 @@ def material_inventory_summary(uuid: str):
         lots = []
         for inv in uow.inventory_repository.find_all(material_uuid=uuid, is_deleted=False):
             qty = inv.current_quantity
-            if not qty or qty <= 0:
-                continue  # empty lots are noise — hidden by design
+            # Hide lots that are exactly empty — they are noise. NEGATIVE lots
+            # stay visible on purpose: they are a data problem, and hiding them
+            # would also hide the "zero this lot out" action that fixes them.
+            if not qty or abs(qty) < 1e-9:
+                continue
             dto = InventoryRead.from_orm(inv)
             InventoryDomain.enrich_cost_per_unit(uow=uow, inventory_dto=dto)
             currency = inv.currency or next(

--- a/frontend/client/src/components/materials/MaterialInventorySection.tsx
+++ b/frontend/client/src/components/materials/MaterialInventorySection.tsx
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ResponsiveContainer,
   LineChart,
@@ -9,9 +9,22 @@ import {
   CartesianGrid,
   Tooltip,
 } from "recharts";
+import { CircleSlash } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { toast } from "@/hooks/use-toast";
 
 interface SeriesEvent {
   t: string | null;
@@ -59,6 +72,34 @@ export function MaterialInventorySection({ materialUuid }: { materialUuid: strin
       return { t: toMs(e.t as string), total: Math.round(bal * 100) / 100 };
     });
   }, [summary]);
+
+  const queryClient = useQueryClient();
+  const [lotToZero, setLotToZero] = useState<InventoryLot | null>(null);
+
+  // The correcting quantity is worked out server-side from the lot's own
+  // events, so a stale page cannot overshoot; the client only names the lot.
+  const zeroOut = useMutation({
+    mutationFn: (lotUuid: string) =>
+      apiRequest(`/inventory/${lotUuid}/zero-out`, { method: "POST", body: {} }),
+    onSuccess: (res: any) => {
+      queryClient.invalidateQueries({ queryKey: ["/material/"] });
+      queryClient.invalidateQueries({ queryKey: ["/inventory/"] });
+      queryClient.invalidateQueries({ queryKey: ["/inventory-event/"] });
+      toast({
+        title: t("materials.lotZeroed"),
+        description: `${res?.lot_id ?? ""} · ${res?.previous_quantity ?? ""} → 0`,
+      });
+      setLotToZero(null);
+    },
+    onError: (e: any) => {
+      toast({
+        title: t("materials.zeroOutFailed"),
+        description: e?.message,
+        variant: "destructive",
+      });
+      setLotToZero(null);
+    },
+  });
 
   // lots come pre-filtered from the API: only lots with remaining stock
   const lots: InventoryLot[] = summary?.lots || [];
@@ -153,7 +194,8 @@ export function MaterialInventorySection({ materialUuid }: { materialUuid: strin
                       <th className="py-2 pe-4 font-medium text-end">{t('materials.costPerUnit')}</th>
                       <th className="py-2 pe-4 font-medium text-end">{t('materials.stockValue')}</th>
                       <th className="py-2 pe-4 font-medium">{t('materials.received')}</th>
-                      <th className="py-2 font-medium">{t('materials.expires')}</th>
+                      <th className="py-2 pe-4 font-medium">{t('materials.expires')}</th>
+                      <th className="py-2 font-medium" />
                     </tr>
                   </thead>
                   <tbody>
@@ -161,7 +203,11 @@ export function MaterialInventorySection({ materialUuid }: { materialUuid: strin
                       <tr key={l.uuid} className="border-b last:border-0" data-testid={`row-lot-${l.uuid}`}>
                         <td className="py-2 pe-4 font-mono text-xs">{l.lot_id || l.uuid.slice(0, 8)}</td>
                         <td className="py-2 pe-4">{l.warehouse_name || "—"}</td>
-                        <td className="py-2 pe-4 text-end font-semibold tabular-nums">
+                        <td
+                          className={`py-2 pe-4 text-end font-semibold tabular-nums ${
+                            (l.current_quantity || 0) < 0 ? "text-red-600" : ""
+                          }`}
+                        >
                           {fmt(l.current_quantity || 0)}
                         </td>
                         <td className="py-2 pe-4 text-gray-500">{l.unit || "—"}</td>
@@ -174,12 +220,50 @@ export function MaterialInventorySection({ materialUuid }: { materialUuid: strin
                             : "—"}
                         </td>
                         <td className="py-2 pe-4 whitespace-nowrap">{fmtDate(l.created_at)}</td>
-                        <td className="py-2 whitespace-nowrap">{fmtDate(l.expiration_date)}</td>
+                        <td className="py-2 pe-4 whitespace-nowrap">{fmtDate(l.expiration_date)}</td>
+                        <td className="py-2 whitespace-nowrap">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-7 gap-1 text-xs"
+                            onClick={() => setLotToZero(l)}
+                            disabled={zeroOut.isPending}
+                            data-testid={`zero-out-${l.uuid}`}
+                          >
+                            <CircleSlash className="h-3.5 w-3.5" />
+                            {t('materials.zeroOut')}
+                          </Button>
+                        </td>
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
+
+              <AlertDialog open={!!lotToZero} onOpenChange={(o) => !o && setLotToZero(null)}>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>{t('materials.zeroOutConfirmTitle')}</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      {t('materials.zeroOutConfirmBody', {
+                        lot: lotToZero?.lot_id || lotToZero?.uuid.slice(0, 8) || '',
+                        qty: fmt(lotToZero?.current_quantity || 0),
+                        unit: lotToZero?.unit || '',
+                      })}
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+                    <AlertDialogAction
+                      onClick={() => lotToZero && zeroOut.mutate(lotToZero.uuid)}
+                      disabled={zeroOut.isPending}
+                      data-testid="confirm-zero-out"
+                    >
+                      {t('materials.zeroOut')}
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
 
               {/* weighted average cost of remaining stock */}
               <div className="mt-4 flex flex-wrap gap-x-8 gap-y-2 text-sm" data-testid="material-avg-cost">

--- a/frontend/client/src/i18n/translations/materials.ts
+++ b/frontend/client/src/i18n/translations/materials.ts
@@ -94,6 +94,11 @@ export const en: Record<string, string> = {
   'enum.product': 'Product',
   'enum.machinery_and_equipment': 'Machinery and Equipment',
   'enum.vehicle': 'Vehicle',
+  'materials.zeroOut': 'Zero out',
+  'materials.lotZeroed': 'Lot zeroed out',
+  'materials.zeroOutFailed': 'Could not zero out this lot',
+  'materials.zeroOutConfirmTitle': 'Zero out this lot?',
+  'materials.zeroOutConfirmBody': 'Lot {lot} holds {qty} {unit}. This writes an inventory event that brings it to exactly 0 — it does not delete the lot, and it can be undone by deleting that event.',
 };
 
 export const ar: Record<string, string> = {
@@ -188,4 +193,9 @@ export const ar: Record<string, string> = {
   'enum.product': 'منتج',
   'enum.machinery_and_equipment': 'آلات ومعدات',
   'enum.vehicle': 'مركبة',
+  'materials.zeroOut': 'تصفير',
+  'materials.lotZeroed': 'تم تصفير الدفعة',
+  'materials.zeroOutFailed': 'تعذر تصفير هذه الدفعة',
+  'materials.zeroOutConfirmTitle': 'تصفير هذه الدفعة؟',
+  'materials.zeroOutConfirmBody': 'الدفعة {lot} تحتوي {qty} {unit}. سيتم تسجيل حركة مخزون تجعلها 0 بالضبط — لا يتم حذف الدفعة، ويمكن التراجع بحذف تلك الحركة.',
 };


### PR DESCRIPTION
## What this adds
A per-lot **Zero out** button on the material detail page. It writes the lot's remaining quantity off to exactly zero — subtracting what's left, or **adding** when the lot has gone negative.

| Lot balance | Event written | Result |
|---|---|---|
| 40 kg | −40 | 0 |
| −5 kg | **+5** | 0 |
| 0 | none | **400** "This lot is already at zero" |

## Design choices worth knowing
- **The correcting quantity is computed server-side** from the lot's own events, not taken from the request. A page that loaded a minute ago may show a stale figure, and trusting it would leave the lot slightly off — or push it past zero to the wrong side. The client only names the lot.
- **Nothing is deleted.** It's a manual inventory event with `affect_original=False`, so the lot keeps the original received quantity that costing depends on, and only the current balance moves. The lot and its history stay, and the action is undone by deleting that one event — which the confirm dialog says out loud.
- "Already zero" uses a `1e-9` window rather than `== 0`, because these quantities are floats summed from events.

## The second half: which lots are shown
The summary hid every lot with `qty <= 0` — which also hid **negative** lots. Those are exactly the ones worth seeing (a negative balance is a data problem), and hiding them also hid the action that fixes them.

It now hides only lots that are **genuinely empty** (`|qty| < 1e-9`), and shows negative balances in red.

## Verification (local, API + browser)
- 40 kg lot → zeroed via a `−40` event, `affect_original=false`, and **disappeared from the table**.
- Lot pushed to −5 → **visible** (was hidden before), and zeroing it wrote **+5** to reach 0.
- Re-zeroing → **400** "This lot is already at zero".
- Through the UI: the confirm dialog names the lot and quantity ("Lot 2026-07-27-16:37:19 holds 33 kg…"), the toast reports "33 → 0", and the row disappears **without a reload** (the mutation invalidates `/material/`, `/inventory/` and `/inventory-event/`).

Test lots were removed by the uuids captured when they were created; flour is back to its original single 1963.6 kg lot. No migration. tsc 70 = unchanged baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)