### PR TITLE
Stop the app rendering English text in a right-to-left layout

### DIFF
--- a/expo_app/contexts/LanguageContext.tsx
+++ b/expo_app/contexts/LanguageContext.tsx
@@ -22,22 +22,52 @@ interface LanguageContextType {
 
 const LanguageContext = createContext<LanguageContextType | undefined>(undefined);
 
+/**
+ * Keep the native layout direction in step with the language — Arabic is
+ * right-to-left. I18nManager's flag is persisted natively, so it survives
+ * reinstalls and login changes and can easily disagree with the language we
+ * resolved (an admin edits the profile on the web, a previous session left the
+ * flag set, …). Call this from EVERY path that adopts a language, not just the
+ * in-app switcher, or the app renders English text in a mirrored layout.
+ *
+ * React Native only applies a direction change on the next app start, so we
+ * reload — but only when the direction actually changed, otherwise the app
+ * would reload-loop on every launch.
+ */
+function syncLayoutDirection(l: Lang) {
+  const wantRTL = l === 'ar';
+  if (I18nManager.isRTL === wantRTL) return;
+  I18nManager.allowRTL(wantRTL);
+  I18nManager.forceRTL(wantRTL);
+  try {
+    DevSettings.reload();
+  } catch {
+    // release build without dev menu — direction applies on next launch
+  }
+}
+
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
   const [lang, setLangState] = useState<Lang>('en');
 
   // the signed-in user's PROFILE language is the source of truth: adopt it
   // whenever it changes (e.g. login, or an admin changed it on the web).
-  // AsyncStorage is only a pre-auth cache for the very first paint.
+  // AsyncStorage is only a pre-auth cache for the very first paint. Whichever
+  // language wins, reconcile the native layout direction with it — the flag
+  // persists across launches and reinstalls, so it may well contradict us.
   useEffect(() => {
     (async () => {
+      let resolved: Lang = 'en';
       if (user?.language === 'ar' || user?.language === 'en') {
-        setLangState(user.language);
-        await AsyncStorage.setItem(STORAGE_KEY, user.language);
+        resolved = user.language;
+        await AsyncStorage.setItem(STORAGE_KEY, resolved);
       } else {
         const stored = await AsyncStorage.getItem(STORAGE_KEY);
-        if (stored === 'en' || stored === 'ar') setLangState(stored);
+        if (stored === 'en' || stored === 'ar') resolved = stored;
       }
+      setLangState(resolved);
+      // after the cache write above, so a reload can't drop the language
+      syncLayoutDirection(resolved);
     })();
   }, [user?.language]);
 
@@ -69,20 +99,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
     // persist the preference on the user profile; best-effort
     apiCall('/auth/me', { method: 'PUT', body: JSON.stringify({ language: l }) }).catch(() => {});
 
-    // Arabic is a right-to-left language: flip the layout direction. React
-    // Native only applies the flip on the next app start, so reload when the
-    // direction actually changes (DevSettings.reload works in dev clients and
-    // release builds pick it up on next launch).
-    const wantRTL = l === 'ar';
-    if (I18nManager.isRTL !== wantRTL) {
-      I18nManager.allowRTL(wantRTL);
-      I18nManager.forceRTL(wantRTL);
-      try {
-        DevSettings.reload();
-      } catch {
-        // release build without dev menu — direction applies on next launch
-      }
-    }
+    syncLayoutDirection(l);
   }, []);
 
   return (


### PR DESCRIPTION
## The bug

The UI layout direction could end up mirrored against the language, so the app rendered English text in a right-to-left layout — back arrow on the right, rows reversed. Arabic-speaking drivers are the app's main users, so this sits on the path they use most.

This is pre-existing and not from #62.

## Cause

`I18nManager`'s flag persists natively (on iOS, `RCTI18nUtil_forceRTL` in the app's `NSUserDefaults`), but we only ever flipped it inside `setLang`. The signed-in user's profile language is the source of truth and is adopted in a `useEffect` on `user?.language` that called `setLangState` only — so any path that changed the effective language without going through the in-app switcher left direction and text disagreeing, and nothing reconciled the two at boot:

- an admin changes a user's language on the web
- the app installs or logs in on a device whose native flag was set by a previous session

## Fix

Pull the direction flip into a single `syncLayoutDirection()` helper and call it from **every** path that adopts a language — the profile-adoption effect and the AsyncStorage fallback, not just `setLang` — so `I18nManager.isRTL` always matches `lang === 'ar'`.

The effect now resolves one `lang` value across both branches, including the default `'en'`, so a device whose flag was left set by a previous session is corrected even with no profile and nothing stored.

Both existing guards are kept:

- **reload only when the direction actually changed** (`if (I18nManager.isRTL === wantRTL) return`), otherwise the app reload-loops on every launch
- **`try`/`catch` around `DevSettings.reload`** for release builds without a dev menu, where direction applies on next launch instead

One ordering detail: the helper runs *after* the awaited `AsyncStorage.setItem`, so a reload can't interrupt the cache write.

## Verification

Reproduced and fixed on a booted iOS simulator (iPhone 17 Pro, iOS 26.5), which was already sitting in the bug state — `forceRTL = true` with both the stored and profile language `en`:

| | stored lang | `forceRTL` | render |
|---|---|---|---|
| before | `en` | `true` | English, mirrored ✗ |
| after | `en` | → `false` | English, LTR ✓ |
| after | `ar` | → `true` | Arabic, RTL ✓ |

- The "after" run landed on the login screen, so it was specifically the **AsyncStorage fallback path** that reconciled direction — the path that previously did not touch it at all.
- Checked for reload loops: sampled the screen every 10s for 90s on a relaunch with the flag already matching. Stable, no reload.
- Setting the stored language to `ar` flips it the other way, and restoring `en` self-corrects back to LTR.

`tsc` is clean for this file; the 8 remaining errors are pre-existing in unrelated `customers*` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)