### PR TITLE
Auto-populate the trip stop outcome as sale when the stop sold something

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -133,6 +133,24 @@ These are the rest, in rough order of how much they mislead someone:
 
 ---
 
+## Three roles cannot touch customer orders at all (found 2026-07-30)
+
+- **`driver`, `operator` and `operation_manager` have no `customer_order` grant whatsoever**, so both reading and creating orders 403 for them at the `before_request` chokepoint ([backend/app/__init__.py:156-171](backend/app/__init__.py#L156)) before the route body runs. Verified by evaluating the gate directly rather than by reading the presets:
+
+  ```
+  driver             GET=False POST=False grant=None
+  operator           GET=False POST=False grant=None
+  operation_manager  GET=False POST=False grant=None
+  sales              GET=True  POST=True  grant=['create','read','update']
+  accountant         GET=True  POST=False grant=['read']
+  ```
+
+  This looks like an oversight rather than a policy: `driver` already holds `invoice: [create,read,update]`, `customer_order_item: [create,read]` and `payment: [create,read,update]` — every *part* of an order except the order itself, and the parts cannot be created without the parent. The practical effect is that **a driver cannot complete a sale in the app**: `POST /customer-order/with-items-and-invoice/checkout` lives on the `customer_order` blueprint, so it maps to action `create` and is denied. The recent-orders panel on the stop screen is likewise always empty for them, and the new sale auto-populate is a permanent silent no-op — it degrades quietly (no crash, no toast, `hasRevenueOrderAtStop([])` is just false), which is why it is recorded here rather than treated as a bug in that feature.
+
+  Needs a product/security call, not a mechanical fix: grant `customer_order: [create, read]` to `driver` (and decide about the other two), or establish that trip users are always given `sales`. Until then the whole selling flow at a stop only works for admins and `sales`. **Small lift once decided** — one entry in `role_presets.json` plus a parity check that the preset still matches what the routes need.
+
+---
+
 ## From the trip-name change (2026-07-30)
 
 - **The web posts task results keyed by `field.label`, the app by `field.name`.** [WorkflowExecutionTaskDetail.tsx:307](frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx#L307) does `result[field.label] = data[field.name]` and reads existing values back the same way at :233, while [expo start.tsx](expo_app/app/distribution/start.tsx) keys strictly by `f.name`. Since every operator schema is `extra="forbid"`, a form descriptor whose label differs from its name breaks **the web only**, tenant-wide, while the app keeps working — which is what a label of `"trip name"` did to this change before review caught it. `app/dto/task.py:99-117` also enriches options by `f.label`. Two clients disagreeing about the wire key is the actual defect; the label==name convention is a workaround that everyone has to remember. Fix is to make the web post by `name` like the app, which needs a migration of every stored `result` whose keys are labels. **Medium lift, and worth doing before the next form field is added.**

--- a/backend/tests/domains/test_trip_stop_sale_outcome.py
+++ b/backend/tests/domains/test_trip_stop_sale_outcome.py
@@ -1,0 +1,249 @@
+"""A stop where goods were sold should say "sale" without being asked twice.
+
+Both clients auto-populate the trip stop's `outcome` select to the sale option
+when a revenue-bearing order was created at that stop. Neither client can be
+tested here — the web has no test runner and the app's jest has no suites — so
+what this file pins is the BACKEND side of the contract they both depend on:
+
+  1. which money field means "value of goods sold", and why the two obvious
+     alternatives are each wrong on the case the other handles, and
+  2. that the sale option is findable by its machine key, since the clients must
+     resolve the option string out of the stop's own frozen option list rather
+     than hardcoding a value.
+
+Break either and the feature degrades silently: no error anywhere, just a stop
+that stays blank after a sale, or an outcome string no chart groups correctly.
+
+The client-side twins are frontend/client/src/lib/tripStopOutcome.ts and
+expo_app/utils/tripStopOutcome.ts.
+"""
+import pytest
+
+from models.common import MONEY_TOLERANCE, CustomerOrder, Invoice
+from app.domains.task_execution.workflow_operators.create_trip_operator import (
+    TripStopOutcome,
+)
+
+# The Python branches of the hybrids — the class attributes are SQL expressions.
+# Lifting them verbatim is the point: a paraphrase of the predicate would pass
+# these tests while the shipped one failed.
+_order_total_adjusted = CustomerOrder.__dict__["total_adjusted_amount"].fget
+_order_net_due = CustomerOrder.__dict__["net_amount_due"].fget
+_order_net_paid = CustomerOrder.__dict__["net_amount_paid"].fget
+_invoice_total_adjusted = Invoice.__dict__["total_adjusted_amount"].fget
+
+
+class _Invoice:
+    """Just enough of an invoice for the order-level sums."""
+
+    def __init__(self, total_adjusted, net_due, net_paid, is_deleted=False):
+        self.total_adjusted_amount = total_adjusted
+        self.net_amount_due = net_due
+        self.net_amount_paid = net_paid
+        self.is_deleted = is_deleted
+
+
+class _Order:
+    def __init__(self, *invoices):
+        self.invoices = list(invoices)
+
+
+def sold_for(total, collected):
+    """An order of `total` with `collected` already taken in."""
+    return _Order(_Invoice(total, total - collected, collected))
+
+
+# --- which field means "revenue" ------------------------------------------
+#
+# This is the whole reason the feature needed care. A driver who sells for cash
+# collects on the spot, and the app's create-order screen marks that order paid
+# immediately, so the amount still owed is zero on the most ordinary sale there
+# is. Checked against live data before writing this: of ten real stop-linked
+# orders, `net_amount_due > 0` missed three genuine sales — every one of them
+# paid in full at the stop.
+
+
+@pytest.mark.parametrize("collected", [0.0, 40.0, 100.0])
+def test_revenue_is_the_same_whether_or_not_the_money_came_in(collected):
+    """Unpaid, part-paid and paid-in-full are all equally a sale."""
+    order = sold_for(100.0, collected)
+    assert _order_total_adjusted(order) == 100.0
+
+
+def test_amount_due_would_miss_a_sale_paid_on_the_spot():
+    """The trap, stated as a test so nobody 'simplifies' the predicate into it."""
+    cash_sale = sold_for(100.0, 100.0)
+    assert _order_total_adjusted(cash_sale) > MONEY_TOLERANCE, "it IS a sale"
+    assert _order_net_due(cash_sale) == 0.0, (
+        "and amount-due says otherwise — this is why the predicate cannot use it"
+    )
+
+
+def test_amount_paid_would_miss_a_sale_on_credit():
+    """The mirror-image trap: no single payment-derived field works."""
+    credit_sale = sold_for(100.0, 0.0)
+    assert _order_total_adjusted(credit_sale) > MONEY_TOLERANCE
+    assert _order_net_paid(credit_sale) == 0.0
+
+
+def test_a_free_sample_run_is_not_a_sale():
+    """Zero-priced goods handed over: real visit, no revenue."""
+    assert _order_total_adjusted(sold_for(0.0, 0.0)) == 0.0
+
+
+def test_an_order_credited_back_to_nothing_is_not_a_sale():
+    """total_adjusted_amount is items + debit notes - credit notes."""
+    returned = _Order(_Invoice(0.0, 0.0, 0.0))
+    assert _order_total_adjusted(returned) == 0.0
+
+
+def test_a_voided_invoice_leaves_no_revenue_on_a_live_order():
+    """Deleted invoices drop out of every one of the three sums."""
+    order = _Order(_Invoice(100.0, 100.0, 0.0, is_deleted=True))
+    assert _order_total_adjusted(order) == 0
+    assert _order_net_due(order) == 0
+
+
+def test_an_order_with_no_invoice_at_all_has_no_revenue():
+    """Reachable: POST /customer-order/ creates an order without one."""
+    assert _order_total_adjusted(_Order()) == 0
+
+
+# --- why the threshold is a tolerance, not zero ----------------------------
+
+
+class _InvoiceItem:
+    def __init__(self, total_price, debits=(), credits=(), is_deleted=False):
+        self.total_price = total_price
+        self.is_deleted = is_deleted
+        self.debit_note_items = [_Note(a) for a in debits]
+        self.credit_note_items = [_Note(a) for a in credits]
+
+
+class _Note:
+    def __init__(self, amount, is_deleted=False):
+        self.amount = amount
+        self.is_deleted = is_deleted
+
+
+class _InvoiceWithItems:
+    """Enough of an invoice to exercise its own total_adjusted_amount."""
+
+    def __init__(self, *items):
+        self.invoice_items = list(items)
+
+    @property
+    def total_amount(self):
+        return sum(i.total_price for i in self.invoice_items if not i.is_deleted)
+
+
+def test_invoice_revenue_can_go_negative_which_is_why_zero_is_not_the_bar():
+    """A live credit note against a VOIDED invoice line reads negative.
+
+    `total_amount` skips deleted items; the debit/credit legs of
+    total_adjusted_amount iterate `self.invoice_items` without that filter (see
+    models/common.py:477-490), so the credit outlives the line it was raised
+    against. The SQL branch of the same property DOES filter, so the identical
+    order answers 0 there — meaning a `!= 0` test would both call this a sale
+    and disagree with itself depending on how the value was read.
+    """
+    invoice = _InvoiceWithItems(_InvoiceItem(50.0, credits=(50.0,), is_deleted=True))
+    assert _invoice_total_adjusted(invoice) == -50.0
+    assert _invoice_total_adjusted(invoice) != 0, (
+        "the premise: a '!= 0' predicate would report revenue here"
+    )
+    assert not (_invoice_total_adjusted(invoice) > MONEY_TOLERANCE), (
+        "the tolerance comparison the clients use rejects it"
+    )
+
+
+def test_float_dust_is_not_revenue():
+    """The same half-cent bar the invoice/payment code uses."""
+    assert not (0.001 > MONEY_TOLERANCE)
+    assert 0.01 > MONEY_TOLERANCE
+
+
+# --- the sale option must be findable by its machine key -------------------
+#
+# Each stop's option list is a SNAPSHOT frozen into task_inputs.fields when its
+# trip was created, so the exact strings differ by vintage — the local database
+# holds a bare "sale" on a stop from 2026-06-30 and "sale - تم البيع" on every
+# stop since. The clients therefore match on the family key rather than the whole
+# value, exactly as every downstream reader does (`ilike 'sale%'` in the backend
+# analytics, `startsWith('sale')` in both trip-analytics widgets).
+
+
+def family(option: str) -> str:
+    """The clients' rule, restated: everything before the Arabic half."""
+    return option.split(" - ")[0].strip()
+
+
+def test_the_sale_outcomes_family_key_is_exactly_sale():
+    assert family(TripStopOutcome.SALE.value) == "sale", (
+        "both clients find the sale option by this key; renaming the member "
+        "without keeping the key makes the auto-populate silently do nothing"
+    )
+
+
+def test_only_one_outcome_answers_to_that_key():
+    """Otherwise `find` picks whichever happens to come first."""
+    matches = [o.value for o in TripStopOutcome if family(o.value) == "sale"]
+    assert matches == [TripStopOutcome.SALE.value]
+
+
+def test_no_other_outcome_is_mistaken_for_a_sale():
+    """`no_sale` used to be a member and rows still carry it; the family key
+    keeps it distinct, where a substring test would not."""
+    for outcome in TripStopOutcome:
+        if outcome is TripStopOutcome.SALE:
+            continue
+        assert family(outcome.value) != "sale", outcome.value
+
+
+def test_every_outcome_splits_on_the_separator_the_clients_use():
+    """If a member is ever added without ' - <arabic>', the split still yields a
+    usable key — but the charts group by the Arabic half, so it would show up
+    untranslated. Assert the shape instead of discovering it in a chart."""
+    for outcome in TripStopOutcome:
+        assert " - " in outcome.value, outcome.value
+        key, arabic = outcome.value.split(" - ", 1)
+        assert key.strip() and arabic.strip(), outcome.value
+
+
+# --- the field descriptor the clients read ---------------------------------
+
+
+def outcome_descriptor():
+    """The outcome field as create_trip_operator builds it for a new stop."""
+    from app.dto.task import FieldType, TaskInputField
+
+    return TaskInputField(
+        name="outcome -  النتيجة",
+        label="outcome",
+        type=FieldType.SELECT,
+        required=True,
+        options=[o.value for o in TripStopOutcome],
+    )
+
+
+def test_the_clients_locate_the_field_by_label_not_name():
+    """`label` is the stable half. `name` carries the Arabic and has drifted —
+    older stops hold a bare "outcome", current ones "outcome -  النتيجة" with two
+    spaces — so a client keying off `name` finds nothing on one vintage or the
+    other. It still has to WRITE under `name`, which is the form-state key."""
+    field = outcome_descriptor()
+    assert field.label == "outcome"
+    assert field.name != field.label, (
+        "if these ever converge, drop the two-key dance in both clients"
+    )
+
+
+def test_the_sale_option_is_present_and_resolvable_on_a_new_stop():
+    field = outcome_descriptor()
+    found = next((o for o in (field.options or []) if family(o) == "sale"), None)
+    assert found == TripStopOutcome.SALE.value
+
+
+def test_the_outcome_is_required_so_auto_populating_only_saves_a_tap():
+    """It cannot mask a missing value — the driver still sees and confirms it."""
+    assert outcome_descriptor().required is True

--- a/expo_app/app/distribution/stop/[taskExecutionUuid].tsx
+++ b/expo_app/app/distribution/stop/[taskExecutionUuid].tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -17,6 +17,7 @@ import { NativeHeader } from '@/components/layout/NativeHeader';
 import { apiCall } from '@/utils/api';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { formatMonthDayTime } from '@/utils/date';
+import { findSaleOption, hasRevenueOrderAtStop } from '@/utils/tripStopOutcome';
 
 interface Field {
   name: string;
@@ -54,6 +55,7 @@ export default function StopDetailScreen() {
   const [exeStatus, setExeStatus] = useState<string | null>(null);
   const [balance, setBalance] = useState<Record<string, number> | null>(null);
   const [recentOrders, setRecentOrders] = useState<any[]>([]);
+  const [stopHasSale, setStopHasSale] = useState(false);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -93,6 +95,11 @@ export default function StopDetailScreen() {
       setBalance(custRes.data?.balance_per_currency || {});
 
       const all: any[] = ordersRes.data?.orders || ordersRes.data?.customer_orders || [];
+      // Computed from the FULL list, never from the sliced recentOrders below:
+      // that slice is sorted unpaid/unfulfilled first and cut to five, and an
+      // order just created here is paid AND fulfilled, so it sorts last and gets
+      // cut away — for exactly the customers who order most often.
+      setStopHasSale(hasRevenueOrderAtStop(all, tripStopUuid));
       const attention = (o: any) => o.is_paid === false || o.is_fulfilled === false;
       setRecentOrders(
         [...all].sort((a, b) => {
@@ -109,6 +116,50 @@ export default function StopDetailScreen() {
   }, [taskUuid, customerUuid, refreshKey]);
 
   const setValue = (name: string, v: any) => setValues((p) => ({ ...p, [name]: v }));
+
+  // A stop where a revenue-bearing order was written up is a sale, so say so.
+  //
+  // This has to be its OWN effect. Putting it in the fetch effect's setValues
+  // initializer above would be dead code on the main flow: that initializer is
+  // skipped whenever `prev` is already populated, which it always is by the time
+  // the driver comes back from creating an order — so the outcome would stay on
+  // "Select…" after a sale, yet fill in correctly if they instead backed out to
+  // the trip list and re-entered. Broken one way and working the other reads as
+  // random flakiness, which is worse than not having the feature.
+  const completed = exeStatus === 'completed';
+  const outcomeField = fields.find((f) => f.type === 'select' && f.label === 'outcome');
+  const saleOption = findSaleOption(outcomeField?.options);
+  const lastAutoOutcome = useRef<string | null>(null);
+  useEffect(() => {
+    if (!outcomeField || !saleOption || !stopHasSale) return;
+    // A completed stop is a record; its fields are read-only and showing a value
+    // that differs from what was submitted would contradict the record.
+    if (completed) return;
+    // Key by the field's `name`, which for this field is NOT its label: the
+    // descriptor is name "outcome -  النتيجة" (two spaces after the dash — and
+    // stops created before that vintage carry a bare "outcome"), label "outcome".
+    // The dropdown reads values[f.name], so the label would write a phantom key
+    // and leave Complete blocked on a required field that looks filled in.
+    const key = outcomeField.name;
+    // Functional update because the fetch effect may have just replaced `values`
+    // in the same commit; the updater stays pure, so the ref write sits outside.
+    // Recording the suggestion unconditionally is safe: it is only ever compared
+    // against what is in the field, so a value the driver chose still fails the
+    // untouched test and survives.
+    setValues((prev) => {
+      const current = prev[key];
+      const untouched = !current || current === lastAutoOutcome.current;
+      if (!untouched || current === saleOption) return prev;
+      return { ...prev, [key]: saleOption };
+    });
+    lastAutoOutcome.current = saleOption;
+    // Deliberately NOT watching the outcome value itself. A driver who overrides
+    // the suggestion keeps their choice — a stop can carry an order and still
+    // honestly end in `interested:insufficient_funds` — and this screen re-runs
+    // its fetch on every focus and every pull-to-refresh, so re-suggesting on
+    // each pass would overwrite them repeatedly with no visible cause. Nothing
+    // here ever CLEARS the field either.
+  }, [outcomeField?.name, saleOption, stopHasSale, completed]);
   const toggleChecklist = (name: string, opt: string) =>
     setValues((p) => {
       const cur: string[] = p[name] || [];
@@ -143,8 +194,6 @@ export default function StopDetailScreen() {
       setSubmitting(false);
     }
   };
-
-  const completed = exeStatus === 'completed';
 
   const renderField = (f: Field) => {
     if (f.type === 'select') {

--- a/expo_app/utils/tripStopOutcome.ts
+++ b/expo_app/utils/tripStopOutcome.ts
@@ -1,0 +1,96 @@
+/**
+ * Deciding whether a trip stop's outcome should read as a sale.
+ *
+ * Twin of frontend/client/src/lib/tripStopOutcome.ts. The two clients render the
+ * same stop form, so they must reach the same verdict — otherwise the same visit
+ * is recorded differently depending on whether the driver used the app or the
+ * web, and the trip's own sale count disagrees with the customer's history.
+ * Keep the two in step; the contract they both rely on is pinned by
+ * backend/tests/domains/test_trip_stop_sale_outcome.py.
+ */
+
+/** Half a cent — mirrors MONEY_TOLERANCE in backend/models/common.py. */
+export const MONEY_TOLERANCE = 0.005;
+
+/**
+ * The machine key of an outcome option: everything before the Arabic half.
+ *
+ * Outcome options are composite strings — "sale - تم البيع",
+ * "not_interested:price_too_high - غير مهتم: السعر مرتفع جدًا" — and the WHOLE
+ * string is what lands in trip_stop.outcome, so it is data rather than a label
+ * (see TripStopOutcome's docstring in create_trip_operator.py). Everything
+ * downstream keys off this prefix: `ilike 'sale%'` in the backend analytics,
+ * `startsWith('sale')` in TripAnalyticsCard.tsx and TripAnalytics.tsx.
+ */
+export const outcomeFamily = (option: string): string => option.split(' - ')[0].trim();
+
+/**
+ * Find the sale option among the ones THIS stop actually offers.
+ *
+ * Never hardcode the full value. Each stop's option list is a snapshot frozen
+ * into task_inputs when its trip was created, so the strings differ by vintage:
+ * the local database holds both a bare "sale" (a stop from 2026-06-30) and
+ * "sale - تم البيع" (every stop since). Matching on the family key finds either.
+ * Returns null when the snapshot has no sale option at all, which must leave the
+ * field alone rather than invent a value the stop cannot store.
+ */
+export const findSaleOption = (options?: string[] | null): string | null =>
+  options?.find((o) => typeof o === 'string' && outcomeFamily(o) === 'sale') ?? null;
+
+/** The subset of an order row this decision needs. */
+export interface RevenueOrderRow {
+  trip_stop_uuid?: string | null;
+  total_adjusted_amount?: number | null;
+  is_deleted?: boolean;
+  /** Null when every invoice on the order has been voided. */
+  currency?: string | null;
+}
+
+/**
+ * Did a revenue-bearing order get created at THIS stop?
+ *
+ * Two things here are load-bearing.
+ *
+ * `total_adjusted_amount` — invoiced items plus debit notes minus credit notes —
+ * is the only field on an order that means "value of goods sold". Both obvious
+ * alternatives are wrong in opposite directions, and each fails on the case the
+ * other handles: `net_amount_due` collapses to 0 the moment payment is recorded,
+ * and the app's create-order screen marks a cash sale paid immediately, so using
+ * it would mean the most ordinary sale there is never triggers this;
+ * `net_amount_paid` is 0 for anything sold on credit. Checked against live data:
+ * of ten real stop-linked orders, `net_amount_due > 0` missed three genuine
+ * sales, all of them paid in full at the stop.
+ *
+ * The comparison is against MONEY_TOLERANCE rather than 0 because the value can
+ * arrive slightly negative. The ORM property this is serialized from sums debit
+ * and credit notes over `self.invoice_items` WITHOUT skipping deleted items,
+ * while the `total_amount` it adds them to DOES skip them — so an order whose
+ * invoice lines were voided while a credit note stayed live reports a negative
+ * total. A `!== 0` test would call that a sale.
+ *
+ * The trip_stop_uuid match is what makes this "at this stop": the orders
+ * endpoint is scoped to the CUSTOMER, so without it every repeat buyer's stop
+ * would flip to sale on the strength of a purchase from a previous visit.
+ *
+ * Pass the FULL fetched list, not the rendered recent-orders slice: that slice
+ * is sorted unpaid/unfulfilled first and cut to five, and an order the driver
+ * just created is paid AND fulfilled, so it sorts last and can be cut away
+ * exactly for the customers who order most.
+ */
+export const hasRevenueOrderAtStop = (
+  orders: RevenueOrderRow[] | null | undefined,
+  tripStopUuid: string | null | undefined,
+): boolean => {
+  if (!tripStopUuid || !orders?.length) return false;
+  return orders.some(
+    (o) =>
+      o?.trip_stop_uuid === tripStopUuid &&
+      !o.is_deleted &&
+      // No live invoice means no money to attribute, which is a different thing
+      // from "invoiced at zero". Mirrors _money_by_currency in
+      // backend/app/entrypoint/routes/trip_stop/routes.py, which skips these
+      // before touching the amount.
+      !!o.currency &&
+      Number(o.total_adjusted_amount ?? 0) > MONEY_TOLERANCE,
+  );
+};

--- a/frontend/client/src/lib/tripStopOutcome.ts
+++ b/frontend/client/src/lib/tripStopOutcome.ts
@@ -1,0 +1,88 @@
+/**
+ * Deciding whether a trip stop's outcome should read as a sale.
+ *
+ * Shared shape with expo_app/utils/tripStopOutcome.ts — the two clients render
+ * the same stop form and must reach the same verdict, or the same visit gets
+ * recorded differently depending on which screen the driver used.
+ */
+
+/** Half a cent — mirrors MONEY_TOLERANCE in backend/models/common.py. */
+export const MONEY_TOLERANCE = 0.005;
+
+/**
+ * The machine key of an outcome option: everything before the Arabic half.
+ *
+ * Outcome options are composite strings — "sale - تم البيع",
+ * "not_interested:price_too_high - غير مهتم: السعر مرتفع جدًا" — and the WHOLE
+ * string is what lands in trip_stop.outcome, so it is data rather than a label
+ * (see TripStopOutcome's docstring in create_trip_operator.py). Everything
+ * downstream keys off this prefix: `ilike 'sale%'` in the backend analytics,
+ * `startsWith('sale')` in TripAnalytics.tsx and TripAnalyticsCard.tsx.
+ */
+export const outcomeFamily = (option: string): string => option.split(' - ')[0].trim();
+
+/**
+ * Find the sale option among the ones THIS stop actually offers.
+ *
+ * Never hardcode the full value. Each stop's option list is a snapshot frozen
+ * into task_inputs when its trip was created, so the strings differ by vintage:
+ * the local database holds both a bare "sale" (a stop from 2026-06-30) and
+ * "sale - تم البيع" (every stop since). Matching on the family key finds either.
+ * Returns null when the snapshot has no sale option at all, which must leave
+ * the field alone rather than invent a value the stop cannot store.
+ */
+export const findSaleOption = (options?: string[] | null): string | null =>
+  options?.find((o) => typeof o === 'string' && outcomeFamily(o) === 'sale') ?? null;
+
+/** The subset of an order row this decision needs. */
+export interface RevenueOrderRow {
+  trip_stop_uuid?: string | null;
+  total_adjusted_amount?: number | null;
+  is_deleted?: boolean;
+  /** Null when every invoice on the order has been voided. */
+  currency?: string | null;
+}
+
+/**
+ * Did a revenue-bearing order get created at THIS stop?
+ *
+ * Two things here are load-bearing.
+ *
+ * `total_adjusted_amount` — invoiced items plus debit notes minus credit notes —
+ * is the only field on an order that means "value of goods sold". Both obvious
+ * alternatives are wrong in opposite directions, and each fails on the case the
+ * other handles: `net_amount_due` collapses to 0 the moment payment is recorded,
+ * so a driver who sells for cash and collects on the spot — the most ordinary
+ * sale there is — would never trigger this; `net_amount_paid` is 0 for anything
+ * sold on credit. Checked against live data: of ten real stop-linked orders,
+ * `net_amount_due > 0` missed three genuine sales, all of them paid in full at
+ * the stop.
+ *
+ * The comparison is against MONEY_TOLERANCE rather than 0 because the value can
+ * arrive slightly negative. The ORM property this is serialized from sums debit
+ * and credit notes over `self.invoice_items` WITHOUT skipping deleted items,
+ * while the `total_amount` it adds them to DOES skip them — so an order whose
+ * invoice lines were voided while a credit note stayed live reports a negative
+ * total. A `!== 0` test would call that a sale.
+ *
+ * The trip_stop_uuid match is what makes this "at this stop": the orders
+ * endpoint is scoped to the CUSTOMER, so without it every repeat buyer's stop
+ * would flip to sale on the strength of a purchase from a previous visit.
+ */
+export const hasRevenueOrderAtStop = (
+  orders: RevenueOrderRow[] | null | undefined,
+  tripStopUuid: string | null | undefined,
+): boolean => {
+  if (!tripStopUuid || !orders?.length) return false;
+  return orders.some(
+    (o) =>
+      o?.trip_stop_uuid === tripStopUuid &&
+      !o.is_deleted &&
+      // No live invoice means no money to attribute, which is a different thing
+      // from "invoiced at zero". Mirrors _money_by_currency in
+      // backend/app/entrypoint/routes/trip_stop/routes.py, which skips these
+      // before touching the amount.
+      !!o.currency &&
+      Number(o.total_adjusted_amount ?? 0) > MONEY_TOLERANCE,
+  );
+};

--- a/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionTaskDetail.tsx
@@ -51,6 +51,7 @@ import { AddStopDialog } from "@/components/trips/AddStopDialog";
 import { CreateTripExpenseDialog } from "@/components/expenses/CreateTripExpenseDialog";
 import { CustomerRecentOrders } from "@/components/customer-orders/CustomerRecentOrders";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { findSaleOption, hasRevenueOrderAtStop } from "@/lib/tripStopOutcome";
 import { useToast } from "@/hooks/use-toast";
 import type { WorkflowExecution } from "@/types/workflowExecution";
 import type { TaskExecution, TaskExecutionPage, TaskExecutionComplete } from "@/types/taskExecution";
@@ -191,6 +192,18 @@ export default function WorkflowExecutionTaskDetail() {
         }
         case 'email':
           fieldSchema = z.string().email();
+          break;
+        case 'select':
+          // A required select has to actually hold something. Marking one
+          // `required` used to be decorative: the default value is '' and bare
+          // z.string() accepts it, so the form submitted and the backend took it
+          // (`outcome: str` accepts ""). The result is a stop whose outcome is
+          // the empty string — falsy in both clients, so it renders as "no
+          // outcome yet", never matches `ilike 'sale%'`, and drops silently out
+          // of every sale count. Two rows in the local database are already in
+          // that state. The outcome select is the only required select in the
+          // system, so this bites exactly there.
+          fieldSchema = field.required ? z.string().min(1) : z.string();
           break;
         case 'checklist':
           fieldSchema = z.array(z.string());
@@ -795,6 +808,56 @@ export default function WorkflowExecutionTaskDetail() {
     }
   };
   const orderContext = getTripStopOrderContext();
+
+  // A stop where a revenue-bearing order was written up is a sale, so say so.
+  //
+  // Shares its query key with the CustomerRecentOrders panel rendered below, so
+  // this is the same cache entry and the same single request — and it refetches
+  // on the ["/customer-order/"] invalidation CreateOrderDialog fires on success,
+  // which is how the suggestion appears the moment an order is created without
+  // anything having to poll.
+  const { data: stopOrdersPage } = useQuery<any>({
+    queryKey: ["/customer-order/", "recent", orderContext?.customerUuid],
+    queryFn: async () => apiRequest(`/customer-order/?customer_uuid=${orderContext?.customerUuid}&per_page=50`),
+    enabled: !!orderContext?.customerUuid,
+  });
+  const outcomeField = taskInputFields.find((f: any) => f?.type === 'select' && f?.label === 'outcome');
+  const saleOption = findSaleOption(outcomeField?.options);
+  const stopHasSale = hasRevenueOrderAtStop(
+    stopOrdersPage?.orders || stopOrdersPage?.customer_orders,
+    orderContext?.tripStopUuid,
+  );
+  // Remembers the suggestion this effect made, keyed by task execution, so
+  // switching between stops cannot make one stop's suggestion look like the
+  // other's deliberate choice.
+  const lastAutoOutcome = useRef<{ exeUuid?: string; value: string } | null>(null);
+  useEffect(() => {
+    if (!outcomeField || !saleOption || !stopHasSale) return;
+    // A completed stop is a record, not a draft. The web still allows editing one
+    // (the submit button reads "update"), so without this an admin opening a past
+    // visit just to read it would have its outcome silently rewritten to sale.
+    if (selectedTaskExecution?.status === 'completed') return;
+    // The react-hook-form key is the field's `name`, which for this field is NOT
+    // its label: the descriptor is name "outcome -  النتيجة" (two spaces after the
+    // dash — and stops created before that vintage carry a bare "outcome"), label
+    // "outcome". Read it off the field rather than writing either one down.
+    const key = outcomeField.name;
+    const current = form.getValues(key as any);
+    const ours = lastAutoOutcome.current;
+    const untouched =
+      !current ||
+      (!!ours && ours.exeUuid === selectedTaskExecution?.uuid && current === ours.value);
+    if (!untouched) return;
+    if (current !== saleOption) {
+      form.setValue(key as any, saleOption as any, { shouldDirty: false });
+    }
+    lastAutoOutcome.current = { exeUuid: selectedTaskExecution?.uuid, value: saleOption };
+    // Deliberately NOT watching the outcome value itself — same reason as the trip
+    // name above. A driver who overrides the suggestion keeps their choice: a stop
+    // can carry an order and still honestly end in `interested:insufficient_funds`.
+    // And nothing here ever CLEARS the field — a later zero-revenue order must not
+    // wipe an outcome somebody already recorded.
+  }, [outcomeField?.name, saleOption, stopHasSale, selectedTaskExecution?.uuid, selectedTaskExecution?.status]);
 
   // manual-stops mode: when checked on the start_trip form, hide the routing
   // inputs. service_areas intentionally stays visible: manual trips also carry


### PR DESCRIPTION
On the trip stop page, the required **Outcome** select now pre-selects the sale option when an order with **non-zero total revenue** exists for that stop. Web and app.

## The bit that needed care: which number is "revenue"

`net_amount_due` is the obvious candidate and it is wrong in the worst possible way. A driver selling for cash collects on the spot, and both create-order screens mark that order paid immediately — so the amount still owed is **zero on the most ordinary sale there is**. Checked against live data before writing the predicate:

| order | total_adjusted_amount | net_amount_due | by total | by due |
|---|---|---|---|---|
| 4d367909 | 10000.00 | 0.00 | SALE | ❌ no |
| 727a1a32 | 1.00 | 0.00 | SALE | ❌ no |
| fa68a264 | 100.00 | 0.00 | SALE | ❌ no |
| 264df6ec | 10000.00 | 9950.00 | SALE | SALE |

Three of ten real stop-linked orders. And it would have failed *asymmetrically* — credit sales filling in fine while cash sales never did — which reads as flakiness rather than a bug. `net_amount_paid` is the mirror error (zero for anything sold on credit). Only `total_adjusted_amount` means "value of goods sold", and it is unchanged across unpaid, part-paid and paid-in-full.

The bar is `MONEY_TOLERANCE`, not zero, because the value can arrive **negative**: the ORM property sums debit/credit notes over `self.invoice_items` without skipping deleted ones, while the `total_amount` it adds them to *does* skip them. An order whose lines were voided under a live credit note reports a negative total, and `!== 0` would call that a sale.

## Two more things the predicate needs

- **`trip_stop_uuid` must match.** The orders endpoint is scoped to the *customer*. Without this, every repeat buyer's stop flips to sale on the strength of a previous visit.
- **A live invoice** (`currency` non-null), mirroring `_money_by_currency` in the trip_stop routes, which skips those before touching an amount.

## No hardcoded option string

There isn't one to hardcode. Each stop freezes its own option list into `task_inputs` at trip creation, so the strings differ by vintage — the local DB holds a bare `"sale"` on a stop from 2026-06-30 alongside `"sale - تم البيع"` on every stop since. Both clients resolve the option out of *that stop's* list by family key, the same prefix `ilike 'sale%'` and `startsWith('sale')` already match on.

They also write under the field's **`name`**, not its `label`: the descriptor is name `"outcome -  النتيجة"` (**two** spaces), label `"outcome"`. Form state is keyed by name, so the label would have written a phantom key and left Complete blocked on a required field that looked filled in.

## Client-specific traps

The app's half is its **own effect**, not part of the fetch effect's `setValues` initializer — that initializer is skipped whenever the form already has values, which it always does by the time the driver returns from creating an order. It would have been dead code on the main flow while working if they backed out to the trip list instead.

The signal is computed from the **full** fetched list, not the rendered recent-orders slice: that slice is cut to five with unpaid first, and a just-created order is paid *and* fulfilled, so it sorts last and gets cut — for exactly the customers who order most.

Neither client overwrites an outcome the driver chose, and neither ever clears the field. A stop can carry an order and still honestly end in `interested:insufficient_funds`.

## Also fixed in the same field

A `required` select accepted `""`. The default is `''` and bare `z.string()` takes it, so a stop could be completed with no outcome at all — falsy in both clients, never matching `ilike 'sale%'`, silently absent from every sale count. **Two rows in the local DB are already like that.** The outcome select is the only required select in the system, so the fix lands exactly there.

## Verification

Live on both clients, both branches:
- revenue stop fills in with the exact option string — checked on **both** option vintages, reading the value out of the DOM rather than the rendered label (`nativeValue: "sale"` and `"sale - تم البيع"`)
- a stop whose only order is \$0, while the same customer has eight revenue orders at **other** stops, stays empty
- app screenshots confirm the same on iOS

Tests pin the backend half of the contract (the web has no test runner; the app's jest has no suites): the revenue field across paid/unpaid/part-paid, the negative-total case that justifies the tolerance, and that the sale option stays findable by family key. Confirmed they bite — renaming the enum key fails three of them.

Baselines held: frontend tsc 70, expo tsc 119, backend domain suite 5 pre-existing failures (all `test_transaction_domain`).

## Worth knowing separately

A **`driver`** has no `customer_order` grant at all, so `GET /customer-order/` 403s for them and this suggestion never appears — and the same gap blocks `POST`, meaning a driver cannot create an order at a stop today either. Not caused by this PR; it degrades quietly here (no crash, no toast). Flagged for a decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)