### PR TITLE
Cluster the customer map: at most 100 pins, counts in the pin, splitting on zoom

### DIFF
--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -133,6 +133,18 @@ These are the rest, in rough order of how much they mislead someone:
 
 ---
 
+## CI runs no tests at all (found 2026-07-30)
+
+- **No workflow in `.github/workflows/` invokes pytest.** `grep -rn pytest .github/workflows/` returns nothing: the pipelines build and push images and deploy, and that is all. So the backend suite is advisory — nothing stops a red suite from reaching production.
+
+  The consequence is already visible. The full suite on clean `origin/main` is **227 failed, 197 passed**, essentially all of it `tests/entrypoint/` (22 of the failures are customer routes). `tests/domains/` is comparatively healthy at 5 failures, all in `test_transaction_domain`, which is why work that only ran the domains subset never noticed. A suite that large and that broken cannot be used to answer "did I break something" — the only usable technique right now is to diff the failure SET against a clean `origin/main` worktree, which is what this branch did.
+
+  Two separable pieces of work, and the order matters. Adding a CI step first would simply paint the pipeline red forever, so: (1) triage `tests/entrypoint/` — decide per file whether it is repairable or should be deleted, since a test nobody can run is worse than no test; then (2) add a pytest step to the dev-build workflow and make it blocking. **Medium lift for the triage, small for the CI step.** Worth doing before the suite grows any further — every new test file added now inherits a harness nobody is checking.
+
+  Note the domains subset IS worth gating on immediately even before the triage: it is 5 known failures away from green and covers the money and trip logic.
+
+---
+
 ## Three roles cannot touch customer orders at all (found 2026-07-30)
 
 - **`driver`, `operator` and `operation_manager` have no `customer_order` grant whatsoever**, so both reading and creating orders 403 for them at the `before_request` chokepoint ([backend/app/__init__.py:156-171](backend/app/__init__.py#L156)) before the route body runs. Verified by evaluating the gate directly rather than by reading the presets:

--- a/DEFERRED.md
+++ b/DEFERRED.md
@@ -133,6 +133,23 @@ These are the rest, in rough order of how much they mislead someone:
 
 ---
 
+## The customer spatial index does not know about tenants (found 2026-07-30)
+
+- **`idx_customer_coordinates` is GiST on `coordinates` alone, so `account_uuid` is applied as a post-filter.** Correctness is unaffected — verified against real cross-tenant data, the map returns 236 of the 238 coord-bearing customers because 2 belong to another account — but the work done is proportional to *every* tenant's density in the viewport, not the caller's. `EXPLAIN ANALYZE` on the map-cluster query:
+
+  ```
+  Index Scan using idx_customer_coordinates on customer  (rows=233)
+    Index Cond: (coordinates @ <viewport envelope>)
+    Filter: (NOT is_deleted AND account_uuid = '<uuid>' AND ST_Within(...))
+    Rows Removed by Filter: 4
+  ```
+
+  Today's dilution is 4 rows, so this is a scaling note rather than a problem. It matters because of what this business actually is: the tenants are Syrian distributors and their customers are largely the same few square kilometres of Damascus, so tenants' geography *overlaps heavily*. Ten tenants in one city means each one's viewport scan walks roughly ten times the points it needs. It cannot be measured locally — one account holds 236 of 238 customers.
+
+  The fix is a composite `GiST (account_uuid, coordinates)`, which needs the `btree_gist` extension: available here (1.5) but **not installed**, so it is a migration that adds an extension plus an index, and installing an extension on the managed prod database is worth checking before promising it. Do not swap the existing index out — keep both until the plan is confirmed to use the composite. **Small lift, but gate it on a real measurement** (the honest trigger is a second tenant with real Damascus customer volume, at which point `Rows Removed by Filter` on that plan tells you directly).
+
+---
+
 ## CI runs no tests at all (found 2026-07-30)
 
 - **No workflow in `.github/workflows/` invokes pytest.** `grep -rn pytest .github/workflows/` returns nothing: the pipelines build and push images and deploy, and that is all. So the backend suite is advisory — nothing stops a red suite from reaching production.

--- a/backend/app/dto/customer.py
+++ b/backend/app/dto/customer.py
@@ -138,3 +138,76 @@ class CustomerPage(BaseModel):
     page: int = Field(..., description="Current page number")
     per_page: int = Field(..., description="Number of items per page")
     pages: int = Field(..., description="Total number of pages")
+
+# --------------------------- MAP CLUSTERS ---------------------------
+#
+# The map needs positions and counts, not customers. Serving it from the normal
+# list endpoint is what made the app fall over: that route forces per_page to
+# 10000 whenever `within_polygon` is set, and every row is a full CustomerRead
+# whose `balance_per_currency` walks each order -> invoice -> items/payments/
+# notes. Measured on local data: 574 bytes and 1.4 ms per customer, so 10k
+# customers is ~5.7 MB and ~14 s for a single pan — and local order histories are
+# sparse, so that is a floor. A phone parsing that repeatedly, once per pan, is
+# the crash.
+#
+# So this is a separate, deliberately thin response: at most MAX_MAP_POINTS rows,
+# each a position plus how many customers it stands for. Tapping a single pin
+# fetches that one customer in full, which is the only place the expensive DTO is
+# still needed.
+
+# The cap the grid is sized to hit. See the route for the arithmetic that makes
+# it a hard guarantee rather than a hope.
+MAX_MAP_POINTS = 100
+
+
+class CustomerMapClusterParams(BaseModel):
+    """Which viewport to summarise, and the filters to summarise it under."""
+    model_config = ConfigDict(extra="forbid")
+
+    # WKT polygon of the visible region. Required: a map request without a
+    # viewport is a request for everything, which is the bug this replaces.
+    within_polygon: str
+    # kept name-for-name with CustomerListParams so the same filter UI can drive
+    # either endpoint without a translation layer
+    category: Optional[CustomerCategory] = None
+    company_name: Optional[str] = None
+    full_name: Optional[str] = None
+
+
+class CustomerMapCluster(BaseModel):
+    """One pin: either a single customer or a group standing in for several."""
+    model_config = ConfigDict(extra="forbid")
+
+    latitude: float
+    longitude: float
+    # How many customers this pin represents. 1 means it is a real customer and
+    # `customer_uuid`/`company_name` are populated; more than 1 means a cluster
+    # and the position is the centroid of its members.
+    count: int
+    customer_uuid: Optional[str] = None
+    company_name: Optional[str] = None
+    # The real bounding box of this pin's members, which the client needs for two
+    # distinct jobs. It is the zoom target when a cluster is tapped, and — more
+    # importantly — a zero-span box is the exact signal that the members share a
+    # coordinate and NO amount of zooming will ever separate them. Without it a
+    # client can only guess, and tapping such a cluster strands the user zooming
+    # forever on a pin that never splits. Four customers in the local database
+    # share one point, so this is a real case, not a hypothetical.
+    min_latitude: float
+    max_latitude: float
+    min_longitude: float
+    max_longitude: float
+
+
+class CustomerMapClusterPage(BaseModel):
+    """Every customer in the viewport is accounted for, even when clustered."""
+    model_config = ConfigDict(extra="forbid")
+
+    clusters: List[CustomerMapCluster]
+    # Sum of every cluster's count — what the map can honestly claim to be
+    # showing. Not a page total: nothing is truncated, only grouped.
+    total_count: int
+    # Grid cell size in degrees, so a client can tell how coarse the grouping is
+    # (and so this is debuggable from a response body alone).
+    cell_size_degrees: float
+    max_points: int = MAX_MAP_POINTS

--- a/backend/app/entrypoint/routes/customer/routes.py
+++ b/backend/app/entrypoint/routes/customer/routes.py
@@ -1,9 +1,10 @@
+import math
 from datetime import datetime, timedelta
 from flask import  request, jsonify
 from flask_jwt_extended import get_jwt_identity, jwt_required
 from geoalchemy2 import WKTElement
 from pydantic import  ValidationError
-from sqlalchemy import func
+from sqlalchemy import func, select
 
 from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 from app.entrypoint.routes.customer import customer_blueprint
@@ -13,6 +14,12 @@ from app.utils.geom_utils import lat_lon_to_wkt
 from models.common import Customer as CustomerModel
 
 from app.dto.customer import CustomerUpdate, CustomerReadList,CustomerListParams, CustomerPage
+from app.dto.customer import (
+    MAX_MAP_POINTS,
+    CustomerMapCluster,
+    CustomerMapClusterPage,
+    CustomerMapClusterParams,
+)
 from app.entrypoint.routes.common.errors import BadRequestError
 from app.entrypoint.routes.common.errors import NotFoundError
 
@@ -542,4 +549,166 @@ def analytics_sold_customers():
             "per_page": per_page,
             "pages": ceil(total / per_page) if total else 0,
         }
+    return jsonify(result), 200
+
+
+# Target whole cells across the viewport's longer axis. 9 leaves room for the two
+# partial cells at the edges and still fits inside MAX_MAP_POINTS (10 x 10).
+MAP_CELLS_PER_AXIS = 9
+
+
+def grid_cell_degrees(span_degrees: float, cells_per_axis: int = MAP_CELLS_PER_AXIS) -> float:
+    """Side length, in degrees, of the grid cell used to group map pins.
+
+    Two properties matter, and both come from the arithmetic rather than from a
+    LIMIT that would silently drop customers off the map.
+
+    BOUNDED OUTPUT. `k = floor(log2(360 / target))` gives `2**k <= 360 / target`,
+    hence `cell = 360 / 2**k >= target = span / cells_per_axis`. So a viewport
+    spans at most `cells_per_axis` whole cells per axis, plus at most one more
+    where the edges fall mid-cell: at most 10 x 10 = 100 non-empty cells for the
+    default 9. That is the "max 100 points" guarantee, and it holds for every
+    viewport rather than on average.
+
+    STABLE UNDER PANNING. The size is quantised to a power-of-two fraction of 360
+    and the grid is anchored at (-180, -90) — a global origin, not the corner of
+    whatever the user happens to be looking at. Panning therefore slides the
+    viewport across a fixed grid and pins stay put; only zooming changes the
+    grouping, which is what makes zooming in feel like clusters splitting rather
+    than everything rearranging itself.
+    """
+    if span_degrees <= 0:
+        # a degenerate viewport (zero span) still has to answer something
+        span_degrees = 1e-6
+    target = span_degrees / max(1, cells_per_axis)
+    k = math.floor(math.log2(360.0 / target))
+    # floor at 3 (45-degree cells) because a coarser grid than that cannot bound
+    # a whole-world view any better, and cap at 30 (~4 cm) because past that the
+    # grid is finer than any coordinate is accurate and doubles for nothing
+    k = max(3, min(30, k))
+    return 360.0 / (2 ** k)
+
+
+@customer_blueprint.route('/map-clusters', methods=['GET'])
+@jwt_required()
+@scopes_required(PermissionScope.ADMIN.value,
+                 PermissionScope.SUPER_ADMIN.value,
+                 PermissionScope.SALES.value,
+                 PermissionScope.DRIVER.value,
+                 PermissionScope.ACCOUNTANT.value)
+def customer_map_clusters():
+    """Summarise the customers in a viewport as at most 100 map pins.
+
+    The map used to render this from `GET /customer/?within_polygon=...`, which
+    forces per_page to 10000 and serialises a full CustomerRead per row — the
+    reason the app died on any account with real customer volume. Here the
+    response size is fixed by the grid, so it does not grow with the number of
+    customers: a viewport holding 50 customers and one holding 50,000 both come
+    back as at most 100 rows.
+
+    A pin with count == 1 carries its customer's uuid so the app can open the
+    existing detail popup; the expensive full DTO is fetched for that one
+    customer on tap, which is the only place it is actually needed.
+    """
+    params = CustomerMapClusterParams(**request.args)
+
+    try:
+        poly = WKTElement(params.within_polygon, srid=CustomerModel.coordinates.type.srid)
+    except (ValidationError, ValueError) as e:
+        raise BadRequestError(f"Invalid polygon: {e}")
+
+    with SqlAlchemyUnitOfWork() as uow:
+        # Ask PostGIS for the viewport's extent rather than parsing WKT here, so
+        # the polygon is validated by the same code that will filter on it. An
+        # unparseable polygon raises here instead of silently matching nothing.
+        try:
+            xmin, ymin, xmax, ymax = uow.session.execute(
+                select(
+                    func.ST_XMin(poly), func.ST_YMin(poly),
+                    func.ST_XMax(poly), func.ST_YMax(poly),
+                )
+            ).one()
+        except Exception as e:
+            raise BadRequestError(f"Invalid polygon: {e}")
+
+        cell = grid_cell_degrees(max(float(xmax) - float(xmin), float(ymax) - float(ymin)))
+
+        filters = [
+            CustomerModel.is_deleted == False,
+            CustomerModel.coordinates.is_not(None),
+            CustomerModel.coordinates.ST_Within(poly),  # type: ignore[attr-defined]
+        ]
+        # This is a raw session query, so it is OUTSIDE the repository layer that
+        # normally injects the tenant filter (AbstractRepository._scope_filters).
+        # Without this line the map would show every account's customers. None
+        # means the platform owner, who is deliberately unscoped — same condition
+        # the repositories use.
+        if uow.account_uuid is not None:
+            filters.append(CustomerModel.account_uuid == uow.account_uuid)
+
+        if params.category:
+            filters.append(CustomerModel.category == params.category.value)
+        if params.company_name:
+            filters.append(CustomerModel.company_name.ilike(f"%{params.company_name}%"))
+        if params.full_name:
+            filters.append(CustomerModel.full_name.ilike(f"%{params.full_name}%"))
+
+        # Integer cell indices via floor, NOT ST_SnapToGrid. SnapToGrid rounds to
+        # the nearest node, which puts cell boundaries at odd half-multiples of
+        # the size — so consecutive levels of the ladder are not nested and
+        # zooming in makes clusters merge and re-split incoherently instead of
+        # each one dividing. floor nests exactly, because
+        # floor(u) == floor(floor(2u) / 2) for every u.
+        grid_x = func.floor((func.ST_X(CustomerModel.coordinates) + 180.0) / cell)
+        grid_y = func.floor((func.ST_Y(CustomerModel.coordinates) + 90.0) / cell)
+        # The pin sits on the centroid of its members, not on the cell's centre,
+        # so a cluster appears over the customers it stands for instead of on an
+        # arbitrary grid intersection.
+        centroid = func.ST_Centroid(func.ST_Collect(CustomerModel.coordinates))
+
+        rows = (
+            uow.session.query(
+                func.count().label("n"),
+                func.ST_Y(centroid).label("lat"),
+                func.ST_X(centroid).label("lng"),
+                # only meaningful for a single-member cell, which is the only
+                # case that reads them; min() over one row is that row
+                func.min(CustomerModel.uuid).label("uuid"),
+                func.min(CustomerModel.company_name).label("company_name"),
+                func.min(func.ST_Y(CustomerModel.coordinates)).label("min_lat"),
+                func.max(func.ST_Y(CustomerModel.coordinates)).label("max_lat"),
+                func.min(func.ST_X(CustomerModel.coordinates)).label("min_lng"),
+                func.max(func.ST_X(CustomerModel.coordinates)).label("max_lng"),
+            )
+            .filter(*filters)
+            .group_by(grid_x, grid_y)
+            .order_by(func.count().desc())
+            .limit(MAX_MAP_POINTS)
+            .all()
+        )
+
+        clusters = [
+            CustomerMapCluster(
+                latitude=float(r.lat),
+                longitude=float(r.lng),
+                count=int(r.n),
+                customer_uuid=r.uuid if int(r.n) == 1 else None,
+                company_name=r.company_name if int(r.n) == 1 else None,
+                min_latitude=float(r.min_lat),
+                max_latitude=float(r.max_lat),
+                min_longitude=float(r.min_lng),
+                max_longitude=float(r.max_lng),
+            )
+            for r in rows
+            # a NULL centroid would mean an empty collection, which grouping
+            # cannot produce — but a bad row must not become a pin at (0, 0)
+            if r.lat is not None and r.lng is not None
+        ]
+
+        result = CustomerMapClusterPage(
+            clusters=clusters,
+            total_count=sum(c.count for c in clusters),
+            cell_size_degrees=cell,
+        ).model_dump(mode='json')
+
     return jsonify(result), 200

--- a/backend/tests/domains/test_customer_map_grid.py
+++ b/backend/tests/domains/test_customer_map_grid.py
@@ -1,0 +1,142 @@
+"""The customer map shows at most 100 pins, and zooming in splits them.
+
+The map used to render from `GET /customer/?within_polygon=...`, which forces
+per_page to 10000 and serialises a full CustomerRead per row — including
+balance_per_currency, which walks every order, invoice, payment and note.
+Measured on local data at 574 bytes and 1.4 ms per customer, so an account with
+10,000 customers meant roughly 5.7 MB and 14 s for a single pan, on a phone,
+repeatedly. That is what crashed the app.
+
+The replacement groups customers onto a grid and returns one pin per occupied
+cell. Everything that makes that safe is arithmetic in `grid_cell_degrees`, so it
+is worth pinning here rather than discovering on a device:
+
+  * the output is BOUNDED — a viewport can never touch more than 100 cells, so
+    the payload does not grow with the number of customers, and nothing has to be
+    silently dropped to keep it small;
+  * the levels are NESTED — zooming in splits each cluster instead of reshuffling
+    every pin, which is what makes "zoom in to see more" true rather than merely
+    plausible;
+  * the grid is GLOBAL — panning slides the viewport over a fixed lattice, so
+    pins stay put when the user is only moving sideways.
+"""
+import math
+
+import pytest
+
+from app.dto.customer import MAX_MAP_POINTS
+from app.entrypoint.routes.customer.routes import (
+    MAP_CELLS_PER_AXIS,
+    grid_cell_degrees,
+)
+
+# Every zoom a user can reach, from the whole planet to a single building.
+SPANS = [360, 180, 90, 45, 10, 3, 1, 0.6, 0.3, 0.15, 0.03, 0.008, 0.001, 0.0001]
+
+
+def cells_touched(span, cell):
+    """Cells a segment of `span` crosses on a lattice of pitch `cell`.
+
+    Worst case over alignment: the segment starts just inside one cell, so both
+    end cells are partial.
+    """
+    return math.floor(span / cell) + 2
+
+
+@pytest.mark.parametrize("span", SPANS)
+def test_no_viewport_can_exceed_the_pin_budget(span):
+    """The reason the payload cannot blow up again.
+
+    This is the whole guarantee, and it is a property of the arithmetic rather
+    than of a LIMIT: `k = floor(log2(360 / target))` gives `2**k <= 360 / target`,
+    so `cell >= target = span / cells_per_axis` and a viewport spans at most
+    `cells_per_axis` whole cells per axis.
+    """
+    cell = grid_cell_degrees(span)
+    per_axis = cells_touched(span, cell)
+    assert per_axis ** 2 <= MAX_MAP_POINTS, (
+        f"span {span} deg gives {per_axis} cells per axis "
+        f"= {per_axis ** 2} pins, over the {MAX_MAP_POINTS} budget"
+    )
+
+
+@pytest.mark.parametrize("span", SPANS)
+def test_the_cell_is_never_finer_than_the_target(span):
+    """The inequality the bound rests on, asserted directly."""
+    assert grid_cell_degrees(span) >= span / MAP_CELLS_PER_AXIS
+
+
+def test_a_degenerate_viewport_still_answers():
+    """A zero-span region is reachable — a map laid out before it has measured
+    itself reports one. It must not divide by zero or loop."""
+    assert grid_cell_degrees(0) > 0
+    assert grid_cell_degrees(-1) > 0
+
+
+# --- nesting: why zooming in SPLITS clusters -------------------------------
+#
+# Cell sizes come off a power-of-two ladder so that each level's cells divide
+# exactly into the next. Without that, zooming in makes clusters merge and
+# re-split incoherently rather than each one dividing — measured on the real
+# database while building this: with ST_SnapToGrid (which rounds to the NEAREST
+# node, putting boundaries at odd half-multiples of the cell) 7 of 17 fine cells
+# straddled two coarse cells. With floor-based indices, 0 of 19 did.
+
+
+@pytest.mark.parametrize("span", SPANS)
+def test_every_cell_size_is_a_power_of_two_fraction_of_360(span):
+    ratio = 360.0 / grid_cell_degrees(span)
+    assert ratio == pytest.approx(round(ratio)), "not an integer divisor of 360"
+    assert round(ratio) & (round(ratio) - 1) == 0, f"{round(ratio)} is not a power of two"
+
+
+@pytest.mark.parametrize("span", SPANS)
+def test_zooming_in_never_coarsens_the_grid(span):
+    """Halving the viewport must keep the cell the same or halve it, never grow
+    it — a coarser grid on zoom-in would MERGE clusters as the user zoomed in."""
+    cell = grid_cell_degrees(span)
+    finer = grid_cell_degrees(span / 2)
+    assert finer <= cell
+    assert cell / finer in (1.0, 2.0), f"jumped by a factor of {cell / finer}"
+
+
+def test_consecutive_levels_nest_exactly():
+    """The property the split depends on: `floor(u) == floor(floor(2u) / 2)`.
+
+    Two customers in the same fine cell are therefore always in the same coarse
+    cell, so a coarse pin's members are exactly the union of the fine pins it
+    contains. Checked across the ladder at offsets that straddle boundaries,
+    which is where a round-to-nearest scheme fails.
+    """
+    for k in range(3, 20):
+        coarse = 360.0 / (2 ** k)
+        fine = coarse / 2
+        for i in range(400):
+            # deliberately includes exact boundaries and either side of them
+            x = -180.0 + i * fine * 0.5
+            assert math.floor((x + 180.0) / coarse) == math.floor(
+                math.floor((x + 180.0) / fine) / 2
+            ), f"level {k} does not nest at x={x}"
+
+
+def test_the_ladder_is_anchored_globally_not_to_the_viewport():
+    """Panning must not re-cluster.
+
+    Cell size depends only on the SPAN, never on where the viewport sits, and the
+    route anchors indices at (-180, -90). So two viewports of equal size at
+    different places share one lattice, and a pin does not move when the user
+    pans past it.
+    """
+    span = 0.15
+    assert grid_cell_degrees(span) == grid_cell_degrees(span)
+    # same span, wildly different locations -> same cell size
+    for _ in range(3):
+        assert grid_cell_degrees(0.15) == grid_cell_degrees(0.15)
+
+
+def test_the_budget_is_not_quietly_larger_than_advertised():
+    """MAX_MAP_POINTS is what the user asked for; the grid must be sized to it,
+    so that the route's LIMIT is a safety net and never the thing doing the
+    bounding. If it ever bites, pins would silently vanish from the map."""
+    assert MAX_MAP_POINTS == 100
+    assert (MAP_CELLS_PER_AXIS + 1) ** 2 <= MAX_MAP_POINTS

--- a/expo_app/components/MapView.tsx
+++ b/expo_app/components/MapView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, StyleSheet, ActivityIndicator, Dimensions, TouchableOpacity, Platform } from 'react-native';
+import { View, StyleSheet, ActivityIndicator, Dimensions, ScrollView, TouchableOpacity, Platform } from 'react-native';
 import MapView, { Marker, Region, PROVIDER_GOOGLE } from 'react-native-maps';
 import { ThemedText } from '@/components/ThemedText';
 import { apiCall } from '@/utils/api';
@@ -29,29 +29,72 @@ interface CustomerPage {
   pages: number;
 }
 
+/** One map pin: a single customer, or a group standing in for several. */
+interface MapCluster {
+  latitude: number;
+  longitude: number;
+  count: number;
+  /** Populated only when count === 1. */
+  customer_uuid: string | null;
+  company_name: string | null;
+  /** True extent of the members — the zoom target, and the co-location signal. */
+  min_latitude: number;
+  max_latitude: number;
+  min_longitude: number;
+  max_longitude: number;
+}
+
+interface MapClusterPage {
+  clusters: MapCluster[];
+  total_count: number;
+  cell_size_degrees: number;
+  max_points: number;
+}
+
+/**
+ * Never let a zoom target collapse to a point.
+ *
+ * fitToCoordinates / animateToRegion on a degenerate extent slams the map to
+ * maximum zoom, which looks like the app breaking. Clusters of customers on one
+ * street are routinely near-coincident, so this is the common case rather than a
+ * corner one.
+ */
+const MIN_ZOOM_SPAN = 0.002;
+
+/**
+ * The shape the popup renders before the customer's detail has arrived.
+ *
+ * Only company_name is real; the rest is empty so each line of the card simply
+ * does not draw until the fetch fills it in. Balance is an empty object, which the
+ * card's own total already treats as nothing owed.
+ */
+const PLACEHOLDER_CUSTOMER: Customer = {
+  uuid: '',
+  email_address: null,
+  company_name: '',
+  full_name: '',
+  phone_number: '',
+  full_address: '',
+  business_cards: null,
+  notes: null,
+  // Empty rather than any real category: the card would otherwise state a
+  // category it is only guessing at for the moment before the fetch lands, and
+  // the blocks below are guarded on this being non-empty.
+  category: '' as Customer['category'],
+  coordinates: null,
+  created_at: '',
+  is_deleted: false,
+  balance_per_currency: {},
+};
+
+/** Beyond three digits the number stops fitting the pin. */
+const formatClusterCount = (n: number): string => (n > 999 ? '999+' : String(n));
+
 interface MapViewComponentProps {
   onCustomerPress: (customer: Customer) => void;
   searchTerm?: string;
   categoryFilter?: string;
 }
-
-const parseCoordinates = (coordinatesString: string | null): { lat: number; lng: number } | null => {
-  if (!coordinatesString) return null;
-
-  try {
-    const coords = coordinatesString.split(',');
-    if (coords.length === 2) {
-      const lat = parseFloat(coords[0].trim());
-      const lng = parseFloat(coords[1].trim());
-      if (!isNaN(lat) && !isNaN(lng)) {
-        return { lat, lng };
-      }
-    }
-  } catch (error) {
-    console.error('Error parsing coordinates:', error);
-  }
-  return null;
-};
 
 const regionToWKT = (region: Region): string => {
   const { latitude, longitude, latitudeDelta, longitudeDelta } = region;
@@ -71,11 +114,17 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
   searchTerm = '',
   categoryFilter = 'all',
 }) => {
-  const [customers, setCustomers] = useState<Customer[]>([]);
+  const [clusters, setClusters] = useState<MapCluster[]>([]);
+  // How many customers the pins stand for, which is not the number of pins.
+  const [customerTotal, setCustomerTotal] = useState(0);
   const [loading, setLoading] = useState(false);
   const [currentBounds, setCurrentBounds] = useState<string | null>(null);
   const [isMapReady, setIsMapReady] = useState(false);
   const [selectedCustomer, setSelectedCustomer] = useState<Customer | null>(null);
+  // Members of a pin that cannot be split by zooming, shown as a chooser.
+  const [coincident, setCoincident] = useState<Customer[] | null>(null);
+  // See the marker below: true only for the moment after a pin set changes.
+  const [tracksViewChanges, setTracksViewChanges] = useState(true);
   const [popupPosition, setPopupPosition] = useState<{ x: number; y: number } | null>(null);
   const [locatingUser, setLocatingUser] = useState(false);
   const mapRef = useRef<MapView>(null);
@@ -90,7 +139,21 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
     longitudeDelta: 0.1,
   };
 
-  const fetchCustomersInBounds = async (wkt: string) => {
+  /**
+   * Ask the server to summarise the viewport, rather than to enumerate it.
+   *
+   * This used to call `GET /customer/?within_polygon=...&per_page=50`, and the
+   * per_page was a fiction: that route overrides it to 10000 whenever a polygon
+   * is present, then serialises a full customer per row — including
+   * balance_per_currency, which walks every order, invoice, payment and note.
+   * Measured at 574 bytes and 1.4 ms per customer, so an account with 10,000
+   * customers meant roughly 5.7 MB and 14 s of work for every single pan, on a
+   * phone, repeatedly. That is what was killing the app.
+   *
+   * `/customer/map-clusters` answers with at most 100 rows whatever the viewport
+   * holds, so the payload no longer scales with the number of customers.
+   */
+  const fetchClustersInBounds = async (wkt: string) => {
     if (isLoadingRef.current) {
       console.log('Already loading, skipping request');
       return;
@@ -100,10 +163,7 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
       isLoadingRef.current = true;
       setLoading(true);
 
-      const params = new URLSearchParams({
-        within_polygon: wkt,
-        per_page: '50',
-      });
+      const params = new URLSearchParams({ within_polygon: wkt });
 
       if (searchTerm) {
         params.append('full_name', searchTerm);
@@ -113,23 +173,24 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
         params.append('category', categoryFilter);
       }
 
-      console.log('Fetching customers within bounds:', wkt);
-      const response = await apiCall<CustomerPage>(`/customer/?${params.toString()}`);
+      const response = await apiCall<MapClusterPage>(`/customer/map-clusters?${params.toString()}`);
 
       if (response.status === 200 && response.data) {
-        const customersWithCoords = response.data.customers.filter(customer =>
-          parseCoordinates(customer.coordinates) !== null
+        setClusters(response.data.clusters || []);
+        setCustomerTotal(response.data.total_count || 0);
+        console.log(
+          `Map: ${response.data.clusters?.length ?? 0} pins covering ` +
+          `${response.data.total_count} customers (cell ${response.data.cell_size_degrees}deg)`
         );
-        setCustomers(customersWithCoords);
-        console.log(`Loaded ${customersWithCoords.length} customers in map bounds`);
       } else {
-        console.error('Failed to load customers:', response);
+        console.error('Failed to load map clusters:', response);
         if (response.status !== 401) {
-          setCustomers([]);
+          setClusters([]);
+          setCustomerTotal(0);
         }
       }
     } catch (error) {
-      console.error('Error fetching customers in bounds:', error);
+      console.error('Error fetching map clusters:', error);
     } finally {
       setLoading(false);
       isLoadingRef.current = false;
@@ -140,16 +201,18 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
         pendingRegionRef.current = null;
         const wkt = regionToWKT(pendingRegion);
         setCurrentBounds(wkt);
-        fetchCustomersInBounds(wkt);
+        fetchClustersInBounds(wkt);
       }
     }
   };
 
   const handleRegionChange = (region: Region) => {
-    if (!isMapReady) return;
-
-    // Always store the latest region for processing
+    // Record the region BEFORE the readiness check. onRegionChangeComplete can
+    // fire before onMapReady, and dropping that first region on the floor is why
+    // the map used to open empty and only populate once the user happened to pan
+    // — nothing else ever triggered a fetch.
     pendingRegionRef.current = region;
+    if (!isMapReady) return;
 
     if (debounceTimerRef.current) {
       clearTimeout(debounceTimerRef.current);
@@ -162,7 +225,7 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
         if (wkt !== currentBounds) {
           pendingRegionRef.current = null; // Clear pending since we're processing it now
           setCurrentBounds(wkt);
-          fetchCustomersInBounds(wkt);
+          fetchClustersInBounds(wkt);
         } else {
           pendingRegionRef.current = null; // Clear pending if bounds haven't changed
         }
@@ -171,10 +234,133 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
     }, 1000);
   };
 
+  /**
+   * Open a single customer, or break a cluster open.
+   *
+   * A cluster normally zooms to the extent of its own members, which the exactly
+   * nested grid guarantees will split it into smaller pins. The exception is a
+   * cluster whose members share a coordinate — several shops at one address, or
+   * records saved from the same spot. Those have a zero-span extent and no amount
+   * of zooming will ever separate them, so zooming would strand the user tapping
+   * a pin that never changes. Four customers in the local database sit on one
+   * point, so this is ordinary rather than theoretical: those are listed instead.
+   */
+  const handlePinPress = async (cluster: MapCluster) => {
+    if (cluster.count === 1 && cluster.customer_uuid) {
+      await openCustomerPopup(
+        cluster.customer_uuid,
+        cluster.latitude,
+        cluster.longitude,
+        cluster.company_name,
+      );
+      return;
+    }
+
+    const latSpan = cluster.max_latitude - cluster.min_latitude;
+    const lngSpan = cluster.max_longitude - cluster.min_longitude;
+
+    if (latSpan <= 0 && lngSpan <= 0) {
+      await showCoincidentCustomers(cluster);
+      return;
+    }
+
+    // Pad the extent so the outermost members are not sitting on the screen edge,
+    // and floor it so a tight cluster does not throw the map to maximum zoom.
+    mapRef.current?.animateToRegion(
+      {
+        latitude: (cluster.min_latitude + cluster.max_latitude) / 2,
+        longitude: (cluster.min_longitude + cluster.max_longitude) / 2,
+        latitudeDelta: Math.max(latSpan * 1.4, MIN_ZOOM_SPAN),
+        longitudeDelta: Math.max(lngSpan * 1.4, MIN_ZOOM_SPAN),
+      },
+      500,
+    );
+  };
+
+  /**
+   * The popup needs the full customer — address, category, balance — which the
+   * cluster payload deliberately does not carry. Fetching one customer on tap is
+   * what lets the map itself stay cheap.
+   */
+  const openCustomerPopup = async (
+    uuid: string,
+    lat: number,
+    lng: number,
+    knownName?: string | null,
+  ) => {
+    const placePopup = () => {
+      const screen = Dimensions.get('window');
+      mapRef.current
+        ?.pointForCoordinate({ latitude: lat, longitude: lng })
+        .then((point) => setPopupPosition({ x: point.x, y: point.y }))
+        .catch(() => setPopupPosition({ x: screen.width / 2, y: screen.height / 2 }));
+    };
+
+    // Open on the name the pin already carries, so the tap feels instant, and let
+    // the address, category and balance arrive a moment later. Waiting for the
+    // round trip before showing anything made the most frequent gesture on the
+    // screen feel like it had missed.
+    if (knownName) {
+      setSelectedCustomer({ ...PLACEHOLDER_CUSTOMER, uuid, company_name: knownName });
+      placePopup();
+    }
+
+    try {
+      const response = await apiCall<Customer>(`/customer/${uuid}`);
+      if (response.status === 200 && response.data) {
+        setSelectedCustomer(response.data);
+        if (!knownName) placePopup();
+      } else {
+        console.error('Failed to load customer for popup:', response);
+        // nothing to enrich and nothing shown yet — do not leave a blank card
+        if (!knownName) setSelectedCustomer(null);
+      }
+    } catch (error) {
+      console.error('Error loading customer for popup:', error);
+      if (!knownName) setSelectedCustomer(null);
+    }
+  };
+
+  /**
+   * List customers that share one coordinate, so a pin that cannot split is
+   * still openable. Scoped to a hair's breadth around the point rather than to
+   * the grid cell, so this really is the co-located set and not the neighbours.
+   */
+  const showCoincidentCustomers = async (cluster: MapCluster) => {
+    const e = 0.00002; // ~2 m
+    const { latitude: lat, longitude: lng } = cluster;
+    const wkt =
+      `POLYGON((${lng - e} ${lat - e}, ${lng - e} ${lat + e}, ` +
+      `${lng + e} ${lat + e}, ${lng + e} ${lat - e}, ${lng - e} ${lat - e}))`;
+    const params = new URLSearchParams({ within_polygon: wkt });
+    if (searchTerm) params.append('full_name', searchTerm);
+    if (categoryFilter && categoryFilter !== 'all') params.append('category', categoryFilter);
+
+    try {
+      const response = await apiCall<CustomerPage>(`/customer/?${params.toString()}`);
+      const found = response.data?.customers ?? [];
+      if (response.status === 200 && found.length) {
+        setCoincident(found);
+      } else {
+        console.error('Could not load co-located customers:', response);
+      }
+    } catch (error) {
+      console.error('Error loading co-located customers:', error);
+    }
+  };
+
   const handleMapReady = () => {
     console.log('✅ Map is ready - Platform:', Platform.OS);
     console.log('✅ Map provider:', Platform.OS === 'android' ? 'PROVIDER_GOOGLE' : 'Apple Maps');
     setIsMapReady(true);
+    // Load whatever is on screen now. Falls back to the initial region when the
+    // map settled without reporting one, so opening the map always shows pins
+    // instead of an empty city.
+    const region = pendingRegionRef.current ?? defaultRegion;
+    pendingRegionRef.current = null;
+    const wkt = regionToWKT(region);
+    setCurrentBounds(wkt);
+    fetchClustersInBounds(wkt);
   };
 
   const handleLocateMe = async () => {
@@ -216,9 +402,16 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
       }
-      fetchCustomersInBounds(currentBounds);
+      fetchClustersInBounds(currentBounds);
     }
   }, [searchTerm, categoryFilter]);
+
+  // Give a newly-rendered pin set one window to rasterise itself, then freeze it.
+  useEffect(() => {
+    setTracksViewChanges(true);
+    const timer = setTimeout(() => setTracksViewChanges(false), 600);
+    return () => clearTimeout(timer);
+  }, [clusters]);
 
   useEffect(() => {
     return () => {
@@ -250,49 +443,65 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
         loadingEnabled={true}
         moveOnMarkerPress={false}
       >
-        {customers.map((customer) => {
-          try {
-            const coords = parseCoordinates(customer.coordinates);
-            if (!coords) return null;
-
-            return (
-              <Marker
-                key={customer.uuid}
-                coordinate={{
-                  latitude: coords.lat,
-                  longitude: coords.lng,
-                }}
-                title={customer.company_name}
-                description={customer.full_address}
-                onPress={(event) => {
-                  if (mapRef.current) {
-                    mapRef.current.pointForCoordinate({
-                      latitude: coords.lat,
-                      longitude: coords.lng,
-                    }).then((point) => {
-                      setSelectedCustomer(customer);
-                      setPopupPosition({ x: point.x, y: point.y });
-                    }).catch(() => {
-                      const screenData = Dimensions.get('window');
-                      setSelectedCustomer(customer);
-                      setPopupPosition({ x: screenData.width / 2, y: screenData.height / 2 });
-                    });
-                  }
-                }}
-              >
+        {clusters.map((cluster) => {
+          const isSingle = cluster.count === 1;
+          return (
+            <Marker
+              // The count is part of the key on purpose. tracksViewChanges is off
+              // below, which freezes each marker's bitmap after its first frame,
+              // and Apple Maps does not reliably redraw a custom marker view in
+              // place either (TripMap.tsx works around the same thing). Without
+              // the count in the key, a pin that regrouped from 12 to 30 members
+              // would keep displaying 12.
+              key={`${cluster.latitude.toFixed(6)},${cluster.longitude.toFixed(6)}:${cluster.count}`}
+              coordinate={{ latitude: cluster.latitude, longitude: cluster.longitude }}
+              // Track, then stop. Left at its default (true) every custom-child
+              // marker joins a 40 ms re-rasterization loop on the Android UI
+              // thread — a buildDrawingCache plus a bitmap upload each, for every
+              // marker, forever — which at up to 100 pins is what turns a slow
+              // map into an out-of-memory crash. But pinned to false from mount,
+              // a marker can be rasterised before its child has laid out and then
+              // never redrawn, leaving a pin with no number in it. So it tracks
+              // just long enough to capture a frame and is then frozen.
+              tracksViewChanges={tracksViewChanges}
+              // A native callout would fight the custom popup below, so only the
+              // single-customer pins get one — matching the previous behaviour.
+              title={isSingle ? cluster.company_name ?? undefined : undefined}
+              onPress={() => handlePinPress(cluster)}
+            >
+              {isSingle ? (
                 <View style={[styles.circleMarker, { backgroundColor: '#ff4757' }]} />
-              </Marker>
-            );
-          } catch (error) {
-            console.error('Error rendering marker for customer:', customer.uuid, error);
-            return null;
-          }
+              ) : (
+                <View style={[styles.circleMarker, styles.clusterMarker]}>
+                  <ThemedText
+                    style={[
+                      styles.clusterCount,
+                      cluster.count > 99 && styles.clusterCountSmall,
+                    ]}
+                    // the pin is deliberately close to the plain marker's size,
+                    // so the number must not be allowed to wrap or ellipsise
+                    numberOfLines={1}
+                    allowFontScaling={false}
+                  >
+                    {formatClusterCount(cluster.count)}
+                  </ThemedText>
+                </View>
+              )}
+            </Marker>
+          );
         })}
       </MapView>
 
       <View style={styles.mapOverlay}>
         <ThemedText style={styles.mapOverlayText}>
-          {loading ? 'Loading...' : `${customers.length} customer${customers.length !== 1 ? 's' : ''} on map`}
+          {loading
+            ? 'Loading...'
+            : clusters.length === customerTotal
+              // every pin is one customer, so there is nothing to explain
+              ? `${customerTotal} customer${customerTotal !== 1 ? 's' : ''} on map`
+              // say both numbers: "14 pins" alone hides customers, and "161
+              // customers" alone makes the pin count look like a bug
+              : `${customerTotal} customers in ${clusters.length} groups — zoom in to split`}
         </ThemedText>
       </View>
 
@@ -306,6 +515,40 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
           {locatingUser ? '📍...' : '📍 Locate Me'}
         </ThemedText>
       </TouchableOpacity>
+
+      {/* A pin whose members share a coordinate cannot be split by zooming, so it
+          opens as a list instead of moving the map. */}
+      {coincident && (
+        <View style={styles.coincidentSheet}>
+          <View style={styles.coincidentHeader}>
+            <ThemedText style={styles.coincidentTitle}>
+              {coincident.length} customers at this location
+            </ThemedText>
+            <TouchableOpacity onPress={() => setCoincident(null)} style={styles.popupCloseButton}>
+              <ThemedText style={styles.popupCloseText}>×</ThemedText>
+            </TouchableOpacity>
+          </View>
+          <ScrollView>
+            {coincident.map((c) => (
+              <TouchableOpacity
+                key={c.uuid}
+                style={styles.coincidentRow}
+                onPress={() => {
+                  setCoincident(null);
+                  onCustomerPress(c);
+                }}
+              >
+                <ThemedText style={styles.coincidentName}>{c.company_name || c.full_name}</ThemedText>
+                {!!c.full_address && (
+                  <ThemedText style={styles.coincidentAddress} numberOfLines={1}>
+                    {c.full_address}
+                  </ThemedText>
+                )}
+              </TouchableOpacity>
+            ))}
+          </ScrollView>
+        </View>
+      )}
 
       {selectedCustomer && popupPosition && (
         <View
@@ -329,13 +572,19 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
 
           <View style={styles.infoPopupContent}>
             <ThemedText style={styles.infoPopupTitle}>{selectedCustomer.company_name}</ThemedText>
-            <ThemedText style={styles.infoPopupSubtitle}>{selectedCustomer.full_name}</ThemedText>
-            <View style={styles.infoPopupCategory}>
-              <ThemedText style={styles.infoPopupCategoryText}>
-                {selectedCustomer.category.charAt(0).toUpperCase() + selectedCustomer.category.slice(1)}
-              </ThemedText>
-            </View>
-            <ThemedText style={styles.infoPopupAddress}>{selectedCustomer.full_address}</ThemedText>
+            {!!selectedCustomer.full_name && (
+              <ThemedText style={styles.infoPopupSubtitle}>{selectedCustomer.full_name}</ThemedText>
+            )}
+            {!!selectedCustomer.category && (
+              <View style={styles.infoPopupCategory}>
+                <ThemedText style={styles.infoPopupCategoryText}>
+                  {selectedCustomer.category.charAt(0).toUpperCase() + selectedCustomer.category.slice(1)}
+                </ThemedText>
+              </View>
+            )}
+            {!!selectedCustomer.full_address && (
+              <ThemedText style={styles.infoPopupAddress}>{selectedCustomer.full_address}</ThemedText>
+            )}
             {(() => {
               const totalBalance = Object.values(selectedCustomer.balance_per_currency).reduce((sum, amount) => sum + amount, 0);
               return totalBalance !== 0 ? (
@@ -349,7 +598,10 @@ export const MapViewComponent: React.FC<MapViewComponentProps> = ({
             })()}
 
             <TouchableOpacity
-              style={styles.visitButton}
+              style={[styles.visitButton, !selectedCustomer.uuid && styles.visitButtonDisabled]}
+              // disabled until the real record has arrived: the placeholder has no
+              // uuid, and handing that to the caller would navigate nowhere
+              disabled={!selectedCustomer.uuid}
               onPress={() => {
                 onCustomerPress(selectedCustomer);
                 setSelectedCustomer(null);
@@ -426,6 +678,75 @@ const styles = StyleSheet.create({
     borderColor: '#ffffff',
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  // Same pin, with room for a number. Kept to 32 dp on purpose: react-native-maps
+  // 1.20.1 never writes the marker's size fields, so Android falls back to a
+  // 100 x 100 DEVICE pixel bitmap — at density 3 anything past ~33 dp is clipped.
+  clusterMarker: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#e8352e',
+  },
+  clusterCount: {
+    color: '#ffffff',
+    fontSize: 12,
+    lineHeight: 14,
+    fontWeight: '700',
+    textAlign: 'center',
+    includeFontPadding: false,
+  },
+  clusterCountSmall: {
+    fontSize: 9,
+    lineHeight: 11,
+  },
+  coincidentSheet: {
+    position: 'absolute',
+    left: 16,
+    right: 16,
+    bottom: 90,
+    maxHeight: '55%',
+    backgroundColor: '#ffffff',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+    paddingVertical: 8,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    elevation: 8,
+    zIndex: 1001,
+  },
+  coincidentHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 14,
+    paddingBottom: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#e5e7eb',
+  },
+  coincidentTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#1f2937',
+  },
+  coincidentRow: {
+    paddingHorizontal: 14,
+    paddingVertical: 11,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: 'rgba(0,0,0,0.06)',
+  },
+  coincidentName: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#1f2937',
+  },
+  coincidentAddress: {
+    fontSize: 12,
+    color: '#6b7280',
+    marginTop: 2,
   },
   infoPopup: {
     position: 'absolute',
@@ -505,6 +826,9 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 16,
     alignItems: 'center',
+  },
+  visitButtonDisabled: {
+    opacity: 0.5,
   },
   visitButtonText: {
     color: 'white',


### PR DESCRIPTION
The customer map in the app now shows at most 100 pins. Where several customers fall close together they become one pin with the count inside it, and zooming in splits those into more pins until they resolve into individual customers.

## The crash was the payload, not the pins

Your description was right and the code disagreed with it, which is what made this worth digging into. The map already fetched by viewport with `per_page: 50` — but that 50 was a fiction. `GET /customer/` **overrides `per_page` to 10000** whenever `within_polygon` is set ([routes.py:143-164](karma/backend/app/entrypoint/routes/customer/routes.py#L143), twice, commented *"make per page a very high number to avoid pagination"*). Every row is then a full `CustomerRead` including `balance_per_currency`, which walks each order → invoice → items/payments/credit and debit notes.

Measured on local data — 574 bytes and 1.4 ms per customer:

| customers in view | payload | time |
|---|---|---|
| 238 (local, measured) | 137 KB | 0.33 s |
| 1,000 | 0.6 MB | 1.4 s |
| 5,000 | 2.9 MB | 6.9 s |
| 10,000 | **5.7 MB** | **13.8 s** |

Every pan. On a phone. Local order histories are sparse, so those are a floor. On the same viewport the new endpoint is **75× smaller** (161,990 → 2,156 bytes) and, unlike the old path, stays flat as customers grow.

## The 100 is arithmetic, not a LIMIT

A `LIMIT` would silently drop pins off the map. Instead the cell size is the largest power-of-two fraction of 360 that is still ≥ `span/9`, so a viewport spans at most 9 whole cells per axis plus two partial edges — at most 100 occupied cells, for **every** viewport. Verified across every reachable zoom, worst case 81:

| viewport | pins | customers shown | biggest cluster | singles |
|---|---|---|---|---|
| whole world | 1 | 236 | 236 | 0 |
| country | 2 | 233 | 231 | 0 |
| 0.6° | 7 | 233 | 153 | 0 |
| 0.3° | 14 | 229 | — | 1 |
| 0.03° | 4 | 4 | 1 | **all 4** |

The route keeps a `LIMIT` anyway so the guarantee is *enforced* rather than merely derived — if it ever bites, that's a bug, not a cap.

## Three things I got wrong first

**The grid must use floor-based cell indices, not `ST_SnapToGrid`** — which is what I wrote initially. SnapToGrid rounds to the *nearest* node, putting boundaries at odd half-multiples of the cell, so consecutive zoom levels don't nest and zooming in makes clusters merge and re-split instead of each dividing. Measured on the real database: SnapToGrid had **7 of 17** fine cells straddling two coarse cells; floor had **0 of 19**. `floor` nests exactly because `floor(u) == floor(floor(2u)/2)`.

**The lattice is anchored globally at (-180,-90)**, never at the viewport's own corner — otherwise the grid shifts on every pan and pins jump while the user is only moving sideways.

**Each pin carries the true bounding box of its members.** That's the zoom target when a cluster is tapped, and a zero-span box is the *exact* signal that the members share a coordinate and no zooming will ever separate them. Four customers in the local DB sit on one point, so without this, tapping such a pin would strand you zooming forever on something that never splits. Those open as a list instead.

## Client details that matter

The marker **tracks view changes just long enough to capture a frame, then freezes**. Left at the default, every custom-child marker joins a 40 ms re-rasterization loop on the Android UI thread — at 100 pins that's its own OOM path, so raising the pin count without this would have made the crash *worse*. Pinned to `false` from mount, a marker can rasterise before its child lays out and show a pin with no number in it. The count is part of the marker key for the same reason.

Also fixed because it was in the way: **the map opened empty** and only populated once you happened to pan. `onRegionChangeComplete` can fire before `onMapReady` and the handler dropped that first region, with nothing else to trigger a fetch.

Tapping a single pin opens the popup immediately from the name the pin already carries, filling in address/category/balance when the fetch lands. The placeholder asserts only the name — category is empty and the card's category, subtitle and address blocks are guarded on being non-empty, so it never states a category it's guessing at, and *Visit Customer* is disabled until the real record arrives.

## `GET /customer/` is deliberately untouched

Seven call sites pass `within_polygon`, including the web's Customers, Vendors and Warehouses map pages, plus every app build already in the field. Honouring `per_page` there would silently drop them to 50 markers with no visible signal. **The backend must deploy before any app build that calls the new route** — an app hitting a missing route gets a 404 and renders an empty map.

## Verification

On the simulator: 88 customers as 14 grouped pins with counts, resolving to 4 pins of which 3 are individual customers at 5× tighter zoom. Screenshots in the thread.

60 new tests pin the bound, the power-of-two ladder and the nesting property; loosening the grid fails 10 of them. Tenant scoping verified against real cross-tenant data — the query is a raw `session.query` outside the repository layer, and it returns 236 of the 238 coord-bearing customers because 2 belong to another account. Unauthenticated requests get 401.

expo tsc 119 and frontend tsc 70, both at baseline. Backend failure set **byte-identical** to `origin/main` (227 failures, none new, 60 more passes).

## Worth knowing

**CI runs no tests at all** — `grep -rn pytest .github/workflows/` returns nothing. Clean `origin/main` is 227 failed / 197 passed, almost all `tests/entrypoint/`. Written up in [DEFERRED.md](karma/DEFERRED.md) with the ordering (triage before gating, but the domains subset is 5 failures from green and worth gating now).

The web's customer map has the same unbounded fetch and was left alone, since you asked about the app and desktop browsers tolerate 5 MB far better than phones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)