### PR TITLE
Tell clients when their permissions change

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -79,6 +79,7 @@ def _load_request_identity():
         RESOURCE_SET,
         endpoint_allowed,
         effective_permissions,
+        perms_version,
     )
     try:
         verify_jwt_in_request(optional=True)
@@ -165,6 +166,12 @@ def _load_request_identity():
         g.user_scopes = set((user.permission_scope or "").split(","))
         # effective perms: explicit checklist or role preset (None = admin)
         g.user_acl = effective_permissions(user)
+        # Fingerprint of what governs this caller, emitted on every response by
+        # _emit_perms_version below. Computed here because this is the one place
+        # that has all four inputs already resolved and DB-fresh.
+        g.perms_version = perms_version(
+            g.user_scopes, g.user_acl, g.account_perms, g.account_verified
+        )
 
     if request.blueprint in RESOURCE_SET:
         # An unverified company gets no resource access at all. FIRST in this
@@ -210,12 +217,42 @@ def _load_request_identity():
     return None
 
 
+PERMS_VERSION_HEADER = "X-Perms-Version"
+
+
+def _emit_perms_version(response):
+    """Stamp the caller's permission fingerprint onto every authenticated response.
+
+    On EVERY response, not just /auth/me: the point is that a client discovers its
+    permissions moved while going about its ordinary business, without a poll and
+    without waiting to be restarted.
+
+    Silent for unauthenticated requests — _load_request_identity returns before
+    setting this when there are no claims, so `getattr` rather than attribute
+    access. An absent header simply means "nothing to compare", which is what an
+    older client already assumes.
+    """
+    from flask import g
+
+    version = getattr(g, "perms_version", None)
+    if version:
+        response.headers[PERMS_VERSION_HEADER] = version
+    return response
+
+
 def create_app(config_object=Config):
     app = Flask(__name__)
 
     # CORS(app, supports_credentials=True)
     # CORS FOR ANY ORIGIN
-    CORS(app)
+    #
+    # expose_headers is required, not cosmetic: a browser hides every response
+    # header from JS except a short safelist, so without naming it here the web
+    # client reads null from X-Perms-Version and never notices a change. The
+    # native app is unaffected either way — CORS is a browser rule — which is
+    # exactly the sort of asymmetry that would have looked like "works on mobile,
+    # broken on web" instead of a missing config line.
+    CORS(app, expose_headers=[PERMS_VERSION_HEADER])
 
     # load configs from .env
     app.config.from_object(Config)
@@ -239,6 +276,7 @@ def create_app(config_object=Config):
     jwt.init_app(app)
 
     app.before_request(_load_request_identity)
+    app.after_request(_emit_perms_version)
 
     # Register blueprints
     app.register_blueprint(customer_blueprint, url_prefix='/customer')

--- a/backend/app/entrypoint/routes/auth/routes.py
+++ b/backend/app/entrypoint/routes/auth/routes.py
@@ -301,6 +301,8 @@ def list_permissions():
 @auth_blueprint.route("/me", methods=["GET"])
 @jwt_required()
 def me():
+    from flask import g
+
     current_uuid = get_jwt_identity()
     with SqlAlchemyUnitOfWork() as uow:
         # self-lookup by verified JWT identity — unscoped so impersonation
@@ -334,6 +336,11 @@ def me():
             account = uow.account_repository.find_one(uuid=imp_account)
             dto["impersonating_account_uuid"] = imp_account
             dto["impersonating_company"] = account.company_name if account else None
+        # The baseline a client compares later responses against. Read from `g`
+        # rather than recomputed here so the body and the X-Perms-Version header
+        # can never disagree — computing it twice from two code paths is how a
+        # client ends up refreshing in a loop against a version it can never match.
+        dto["perms_version"] = getattr(g, "perms_version", None)
         return jsonify(dto), 200
 
 

--- a/backend/app/entrypoint/routes/common/permissions.py
+++ b/backend/app/entrypoint/routes/common/permissions.py
@@ -112,3 +112,42 @@ def endpoint_allowed(permissions: dict, blueprint: str, method: str) -> bool:
         return False
     allowed = (permissions.get("endpoints") or {}).get(blueprint) or []
     return action in allowed
+
+
+def perms_version(scopes, user_acl, account_perms, account_verified) -> str:
+    """A short fingerprint of everything that governs what a client may see.
+
+    The server revokes access on the caller's very next request, because the
+    chokepoint re-reads their row every time. The CLIENTS were the stale half:
+    both fetch /auth/me exactly once per provider mount, so a menu built from a
+    revoked grant survived until the app was force-quit — on a phone that is
+    never force-quit, until the 14-day refresh token died.
+
+    This is the signal that closes that gap. It rides on every response as a
+    header; a client holding a different value knows to re-read /auth/me. Cheaper
+    than polling and it needs no push channel.
+
+    DERIVED, not stored, so there is no column to forget to bump and no migration:
+    it is a hash of the actual governing values, so it moves when — and only when —
+    one of them does. That covers a role change, a per-user checklist edit, a
+    tenant feature-cap change, a verification flip, AND a role_presets.json edit
+    shipped by a deploy, none of which have to know this function exists.
+
+    hashlib rather than hash(): the builtin is salted per process, so under
+    gunicorn's several workers every worker would report a different version for
+    the same user and clients would refresh on every other request forever.
+    """
+    import hashlib
+
+    payload = json.dumps(
+        {
+            "scopes": sorted(s for s in (scopes or []) if s),
+            "acl": user_acl,
+            "account": account_perms,
+            "verified": bool(account_verified),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]

--- a/backend/tests/domains/test_perms_version.py
+++ b/backend/tests/domains/test_perms_version.py
@@ -1,0 +1,144 @@
+"""The fingerprint that tells a client its permissions moved.
+
+The server has always revoked access on the caller's next request — the chokepoint
+re-reads their row every time. The CLIENTS were the stale half: both fetch /auth/me
+once per provider mount, so a menu built from a since-revoked grant survived until
+the app was force-quit, which on a phone that is never force-quit meant until the
+14-day refresh token died.
+
+`perms_version` closes that. It rides on every response as a header, and a client
+holding a different value knows to re-read its profile. Two properties make or break
+it, and both are pinned here:
+
+  * IT MUST MOVE when any governing input moves. A version that misses a change is
+    worse than no version at all — the client now has positive confirmation that its
+    stale menu is current.
+  * IT MUST NOT MOVE otherwise, and in particular must be identical across
+    processes. Under gunicorn's several workers, a per-process value would have every
+    worker reporting a different version for the same user, and clients would refresh
+    on every other request forever.
+"""
+from app.entrypoint.routes.common.permissions import perms_version
+
+ACL = {"modules": ["customers", "trips"], "endpoints": {"customer": ["read"]}}
+CAP = {"modules": ["customers"], "endpoints": {"customer": ["read", "create"]}}
+
+
+def v(scopes=("sales",), acl=ACL, cap=None, verified=True):
+    return perms_version(set(scopes), acl, cap, verified)
+
+
+# --- it must not move -----------------------------------------------------
+
+
+def test_the_same_inputs_give_the_same_version():
+    assert v() == v()
+
+
+def test_the_version_is_identical_across_processes():
+    """The reason this is a literal and not a self-comparison.
+
+    Python's builtin hash() is salted per process, so `hash(payload)` would satisfy
+    every other test in this file and still break in production the moment gunicorn
+    ran more than one worker: two workers, two versions for one user, and a client
+    refreshing forever. Pinning the actual digest is what catches that swap — a
+    self-comparison inside one process cannot.
+    """
+    assert v() == "497dc95b4eb15822"
+
+
+def test_scope_order_does_not_matter():
+    """Scopes must be sorted, not taken in iteration order.
+
+    Passed as LISTS on purpose. Writing this with sets — the type the chokepoint
+    actually passes — makes it tautological: `{"sales","driver"}` and
+    `{"driver","sales"}` are one and the same object, so the assertion holds however
+    the function orders them and the test proves nothing. A list preserves the
+    difference and so actually exercises the sort.
+    """
+    assert perms_version(["sales", "driver"], ACL, None, True) == perms_version(
+        ["driver", "sales"], ACL, None, True
+    )
+
+
+def test_dict_key_order_does_not_matter():
+    """JSONB round-trips do not promise key order. Without sort_keys a client would
+    refresh because Postgres handed the same grants back in a different order."""
+    a = {"endpoints": {"customer": ["read"]}, "modules": ["customers", "trips"]}
+    b = {"modules": ["customers", "trips"], "endpoints": {"customer": ["read"]}}
+    assert v(acl=a) == v(acl=b)
+
+
+def test_the_version_is_short_enough_to_be_a_header():
+    assert len(v()) == 16
+    assert all(c in "0123456789abcdef" for c in v())
+
+
+# --- it must move ---------------------------------------------------------
+
+
+def test_a_role_change_moves_it():
+    assert v(scopes=("sales",)) != v(scopes=("accountant",))
+
+
+def test_a_revoked_module_moves_it():
+    """The case the whole mechanism exists for: an admin unticks a menu module and
+    the app has to stop offering that tile."""
+    fewer = {**ACL, "modules": ["trips"]}
+    assert v(acl=ACL) != v(acl=fewer)
+
+
+def test_a_revoked_endpoint_action_moves_it():
+    stripped = {**ACL, "endpoints": {"customer": []}}
+    assert v(acl=ACL) != v(acl=stripped)
+
+
+def test_a_tenant_feature_cap_change_moves_it():
+    """The platform owner narrowing what a whole company may use has to reach that
+    company's users, not just the owner's own console."""
+    assert v(cap=None) != v(cap=CAP)
+
+
+def test_a_verification_flip_moves_it():
+    """So a company that has just been approved stops being shown the notice without
+    having to force-quit the app."""
+    assert v(verified=True) != v(verified=False)
+
+
+def test_promotion_to_admin_moves_it():
+    """An admin carries no permissions object at all — None, not an empty one. That
+    must be a different fingerprint from having grants, and from having none."""
+    assert v(acl=None) != v(acl=ACL)
+    assert v(acl=None) != v(acl={"modules": [], "endpoints": {}})
+
+
+def test_a_preset_edit_shipped_by_a_deploy_moves_it():
+    """Nothing has to know this function exists for a role_presets.json change to
+    propagate: the chokepoint passes the RESOLVED acl, so an edited preset arrives
+    here as different grants and the version moves on its own."""
+    before = {"modules": ["customers"], "endpoints": {"customer": ["read"]}}
+    after = {"modules": ["customers"], "endpoints": {"customer": ["read", "update"]}}
+    assert v(acl=before) != v(acl=after)
+
+
+# --- shapes the chokepoint really passes ---------------------------------
+
+
+def test_an_empty_session_does_not_explode():
+    """Defensive: the chokepoint only calls this for an authenticated request, but a
+    fingerprint function that raises would turn a permission change into a 500."""
+    assert isinstance(perms_version(set(), None, None, False), str)
+    assert isinstance(perms_version(None, None, None, True), str)
+
+
+def test_the_empty_scope_string_is_ignored():
+    """`set("".split(","))` is `{""}` — which is exactly what the chokepoint produces
+    for a user with no role. It must not read as a distinct scope."""
+    assert perms_version({""}, ACL, None, True) == perms_version(set(), ACL, None, True)
+
+
+def test_truthy_and_boolean_verification_agree():
+    """g.account_verified is built with bool() in some branches and read straight from
+    the column in others. Both must fingerprint the same."""
+    assert perms_version({"sales"}, ACL, None, 1) == perms_version({"sales"}, ACL, None, True)
+    assert perms_version({"sales"}, ACL, None, 0) == perms_version({"sales"}, ACL, None, False)

--- a/expo_app/contexts/AuthContext.tsx
+++ b/expo_app/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
+import { AppState } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { API_BASE_URL, apiCall, setOnAuthFailure } from '@/utils/api';
+import { API_BASE_URL, apiCall, setOnAuthFailure, setOnPermsChanged } from '@/utils/api';
 
 interface AuthContextType {
   isAuthenticated: boolean;
@@ -28,8 +29,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setIsAuthenticated(false);
       setUser(null);
     });
+    // An admin changed this user's role, permissions or the company's feature cap.
+    // Re-read the profile so the menu stops offering what they can no longer use —
+    // previously this only happened on a cold start, which on a phone that is never
+    // force-quit could be weeks.
+    setOnPermsChanged(() => {
+      refreshProfile();
+    });
     checkAuthStatus();
-    return () => setOnAuthFailure(null);
+
+    // The header only arrives on a response, so it needs traffic — and a user
+    // sitting on the menu generates none. Resuming the app is the moment that
+    // matters in practice: the change was made while the phone was in a pocket,
+    // and this is when they look at it again.
+    const appStateSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') refreshProfile();
+    });
+
+    return () => {
+      setOnAuthFailure(null);
+      setOnPermsChanged(null);
+      appStateSub.remove();
+    };
   }, []);
 
   const clearAuthData = async () => {
@@ -73,6 +94,30 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setIsAuthenticated(false);
       setUser(null);
       return false;
+    }
+  };
+
+  /**
+   * Re-read the profile WITHOUT risking the session.
+   *
+   * fetchUserInfo signs the user out on any non-200, which is right at startup —
+   * a bad token must not leave a half-signed-in app — and wrong for an
+   * opportunistic refresh: resuming in a tunnel with no signal would log the user
+   * out over a network blip. This applies a newer profile when one arrives and
+   * otherwise changes nothing.
+   *
+   * A genuinely dead session still ends: apiCall's 401 path refreshes the token
+   * and, if that is rejected, fires onAuthFailure — the existing machinery.
+   */
+  const refreshProfile = async () => {
+    try {
+      const response = await apiCall('/auth/me');
+      if (response.status === 200 && response.data) {
+        await AsyncStorage.setItem('user_data', JSON.stringify(response.data));
+        setUser(response.data);
+      }
+    } catch (error) {
+      console.error('Profile refresh failed, session kept:', error);
     }
   };
 

--- a/expo_app/utils/api.ts
+++ b/expo_app/utils/api.ts
@@ -19,8 +19,48 @@ export const setOnAuthFailure = (handler: (() => void) | null) => {
   onAuthFailure = handler;
 };
 
+export const PERMS_VERSION_HEADER = 'X-Perms-Version';
+
+// Registered by AuthContext so a permission change re-reads /auth/me.
+let onPermsChanged: (() => void) | null = null;
+export const setOnPermsChanged = (handler: (() => void) | null) => {
+  onPermsChanged = handler;
+};
+
+// The fingerprint the cached `user` object is consistent with. Deliberately not
+// persisted: on a cold start AuthContext re-reads /auth/me anyway, so the first
+// response of the session seeds this and there is nothing to go stale.
+let knownPermsVersion: string | null = null;
+
+/**
+ * Notice, from any response, that this user's permissions are no longer what the
+ * cached profile says.
+ *
+ * The server revokes on the next request; the app was the stale half, holding a
+ * menu built at mount until it was force-quit. Every response carries the current
+ * fingerprint, so ordinary traffic is the discovery channel — no poll, no push.
+ *
+ * The new version is adopted BEFORE the handler runs, which is what stops a loop:
+ * the /auth/me call the handler makes returns this same version, so it reads as a
+ * match instead of triggering another refresh, forever.
+ */
+const notePermsVersion = (response: Response) => {
+  const version = response.headers.get(PERMS_VERSION_HEADER);
+  if (!version) return;
+  if (knownPermsVersion === null) {
+    knownPermsVersion = version;
+    return;
+  }
+  if (version === knownPermsVersion) return;
+  knownPermsVersion = version;
+  onPermsChanged?.();
+};
+
 const clearStoredAuth = async () => {
   await AsyncStorage.multiRemove(['access_token', 'refresh_token', 'user_email', 'user_data']);
+  // so the next user to sign in on this device is not compared against the
+  // previous one's fingerprint
+  knownPermsVersion = null;
 };
 
 // 'ok' = new access token stored; 'rejected' = refresh token invalid/expired
@@ -76,7 +116,12 @@ const doFetch = async (endpoint: string, options: RequestInit): Promise<Response
     headers['Authorization'] = `Bearer ${token}`;
   }
 
-  return fetch(`${API_BASE_URL}${endpoint}`, { ...options, headers });
+  const response = await fetch(`${API_BASE_URL}${endpoint}`, { ...options, headers });
+  // checked here rather than in apiCall so it covers the retried request too,
+  // and every caller regardless of status: a 403 is the response most likely to
+  // be the first sign that permissions moved.
+  notePermsVersion(response);
+  return response;
 };
 
 export const apiCall = async <T = any>(

--- a/frontend/client/src/contexts/AuthContext.tsx
+++ b/frontend/client/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { API_BASE_URL } from '../lib/config';
+import { notePermsVersion, resetPermsVersion, setOnPermsChanged } from '../lib/queryClient';
 
 interface User {
   uuid: string;
@@ -53,7 +54,56 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     // Check for existing session on mount
     checkAuthStatus();
+    // An admin changed this user's role, permissions or the company's feature cap.
+    // Re-read the profile so the sidebar stops offering what they can no longer
+    // use. This has to come from a response header rather than a react-query
+    // invalidation: the save happens in the ADMIN's browser session, which cannot
+    // reach into this one.
+    setOnPermsChanged(() => {
+      refreshProfile();
+    });
+
+    // The header needs traffic, and a left-open tab generates none. Coming back to
+    // the tab is the equivalent of resuming the app on a phone.
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') refreshProfile();
+    };
+    document.addEventListener('visibilitychange', onVisible);
+
+    return () => {
+      setOnPermsChanged(null);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, []);
+
+  /**
+   * Re-read the profile WITHOUT risking the session.
+   *
+   * checkAuthStatus drops the stored token on any failure, including a transient
+   * one — right for a mount-time check, wrong here: a flaky moment on tab focus
+   * would silently sign the user out on their next request. This applies a newer
+   * profile when one arrives and otherwise changes nothing.
+   */
+  const refreshProfile = async () => {
+    try {
+      const token = localStorage.getItem('auth_token');
+      if (!token) return;
+
+      const response = await fetch(`${API_BASE_URL}/auth/me`, {
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'ngrok-skip-browser-warning': 'true',
+        },
+        mode: 'cors',
+      });
+
+      notePermsVersion(response);
+      if (response.ok) setUser(await response.json());
+    } catch (error) {
+      console.error('Profile refresh failed, session kept:', error);
+    }
+  };
 
   const checkAuthStatus = async () => {
     try {
@@ -71,6 +121,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         },
         mode: 'cors',
       });
+
+      // seeds the baseline other responses are compared against — this call
+      // bypasses apiRequest, so without it nothing would establish it
+      notePermsVersion(response);
 
       if (response.ok) {
         const userData = await response.json();
@@ -201,6 +255,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const logout = () => {
     localStorage.removeItem('auth_token');
     setUser(null);
+    // so the next user on this browser is not compared against this one's
+    // fingerprint and refreshed for no reason
+    resetPermsVersion();
   };
 
   const scopes = (user?.permission_scope ?? '')

--- a/frontend/client/src/lib/queryClient.ts
+++ b/frontend/client/src/lib/queryClient.ts
@@ -1,6 +1,48 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 import { API_BASE_URL } from "./config";
 
+export const PERMS_VERSION_HEADER = "X-Perms-Version";
+
+// Registered by AuthContext so a permission change re-reads /auth/me.
+let onPermsChanged: (() => void) | null = null;
+export const setOnPermsChanged = (handler: (() => void) | null) => {
+  onPermsChanged = handler;
+};
+
+// The fingerprint the in-memory `user` object is consistent with.
+let knownPermsVersion: string | null = null;
+
+export const resetPermsVersion = () => {
+  knownPermsVersion = null;
+};
+
+/**
+ * Notice, from any response, that this user's permissions have changed.
+ *
+ * The sidebar is built from the profile fetched once at mount, so before this a
+ * revoked module stayed clickable for the whole life of the tab — and the save
+ * that revoked it happens in a DIFFERENT browser session, which no amount of
+ * react-query invalidation can reach.
+ *
+ * Requires the backend to name this header in `expose_headers`; a browser hides
+ * every non-safelisted response header from JS, so without that this reads null
+ * and silently does nothing.
+ *
+ * The new version is adopted BEFORE the handler runs, so the /auth/me request the
+ * handler makes is not itself a second trigger.
+ */
+export function notePermsVersion(res: Response) {
+  const version = res.headers.get(PERMS_VERSION_HEADER);
+  if (!version) return;
+  if (knownPermsVersion === null) {
+    knownPermsVersion = version;
+    return;
+  }
+  if (version === knownPermsVersion) return;
+  knownPermsVersion = version;
+  onPermsChanged?.();
+}
+
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     if (res.status === 401) {
@@ -35,7 +77,9 @@ export async function apiRequest(
   });
   
   console.log(`API Response: ${res.status} ${res.statusText}`);
-  
+
+  notePermsVersion(res);
+
   if (res.status === 401) {
     localStorage.removeItem('auth_token');
     window.location.reload();
@@ -68,6 +112,8 @@ export const getQueryFn: <T>(options: {
       headers,
       mode: 'cors',
     });
+
+    notePermsVersion(res);
 
     if (unauthorizedBehavior === "returnNull" && res.status === 401) {
       return null;


### PR DESCRIPTION
Closes the client half of permission revocation.

## The problem, measured

The server was never the stale part: the chokepoint re-reads the caller's row on every
request, so a revoked grant 403s immediately. The clients were. Both fetch `/auth/me`
exactly once per provider mount — no `AppState` listener, no focus refetch, no
interval, nothing on token refresh.

On a local stack, with a `sales_manager` session:

| step | result |
|---|---|
| revoke the `customers` module server-side | `/auth/me` reflects it at once |
| background the app, resume it | **tile still there** |
| cold start | tile gone |

And because `utils/api.ts` silently refreshes the access token and replays the
request, the session never tears itself down — so on a phone that is never force-quit
the ceiling was the 14-day refresh token.

## The mechanism

Every authenticated response carries `X-Perms-Version`, a 16-hex fingerprint of what
governs that caller. A client holding a different value re-reads its profile.

Derived, not stored — no column to forget to bump, no migration. It is a hash of the
actual governing values, so it moves when, and only when, one of them does: a role
change, a per-user checklist edit, a tenant feature-cap change, a verification flip,
or a `role_presets.json` edit shipped by a deploy. None of those have to know this
exists.

## Three things this had to get right

1. **`hashlib`, not `hash()`.** The builtin is salted per process, so under gunicorn's
   several workers each worker would report a different version for the same user and
   clients would refresh on every other request forever. Pinned by a literal digest in
   the tests — a self-comparison inside one process cannot catch that swap. Verified
   across three separate processes with `PYTHONHASHSEED=random`.
2. **`expose_headers` on CORS.** Browsers hide non-safelisted response headers from JS,
   so without naming it the web client reads `null` and silently does nothing. The
   native app is unaffected, which would have presented as "works on mobile, broken on
   web" rather than as a missing config line.
3. **Adopt the new version before notifying.** Otherwise the `/auth/me` the handler
   makes is itself the next trigger. Measured with a temporary request counter in the
   container: **2** requests on resume, converging, and **0** while idle.

## Resume, not just traffic

A response only arrives if there is traffic, and a user looking at the menu generates
none. So both clients also refresh on resume — `AppState` active on the app,
`visibilitychange` on the web — which is the case that actually matters, since the
change was made while the phone was in a pocket.

Those call a **non-destructive** refresh, not the existing one: `fetchUserInfo` and
`checkAuthStatus` both drop the session on any non-200, which is right at startup and
wrong here, where resuming in a tunnel would sign someone out over a network blip. A
genuinely dead session still ends through the existing 401 machinery.

## Verification

- After the change, the same background-and-resume that failed above **removes the
  tile** — no cold start.
- Version is stable across identical requests, moves on revoke, returns to its
  original value on restore, and is identical across processes.
- Header absent on unauthenticated responses, present on authenticated ones, and the
  `/auth/me` body matches the header exactly.
- 15 new tests in `backend/tests/domains/test_perms_version.py`, mutation-tested: 7
  seeded bugs, each caught. One of my own tests was tautological on the first pass
  (comparing two identical sets) and was rewritten to actually exercise the sort.
- Backend failure set byte-identical to a clean baseline — 227 before and after, none
  new, none fixed. `frontend tsc` 70, `expo tsc` 119, both unchanged.

## Scope

This does not touch the separate finding that `modules` is never enforced server-side:
revoking a module hides a tile while the endpoint stays open. This makes the menu
honest sooner; it does not make it a permission. That fix is making `modules` derived
from `endpoints`, which is the next piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)