### PR TITLE
Make per-role default permissions editable at runtime

### DIFF
--- a/backend/app/entrypoint/routes/auth/routes.py
+++ b/backend/app/entrypoint/routes/auth/routes.py
@@ -63,15 +63,24 @@ def register():
 @scopes_required(PermissionScope.ADMIN.value, PermissionScope.SUPER_ADMIN.value)
 def permission_catalog():
     """The checklists an admin can grant: menu modules + per-resource CRUD,
-    plus each role's preset so the UI can apply a role as a shortcut."""
+    plus each role's preset so the UI can apply a role as a shortcut.
+
+    RESOLVED presets, not the generated baseline. This is load-bearing rather than
+    cosmetic: the user editor compares the checklist against the preset and stores
+    null when they match, which is what keeps a user FOLLOWING their role. Serving
+    the baseline once a role has been overridden would make that comparison miss,
+    so picking a role and saving would quietly write an explicit per-user override
+    equal to the old defaults — detaching that user from the role without anyone
+    choosing to.
+    """
     from app.entrypoint.routes.common.permissions import (
-        MODULES, RESOURCES, ACTIONS, ROLE_PRESETS,
+        MODULES, RESOURCES, ACTIONS, resolved_role_presets,
     )
     return jsonify({
         "modules": MODULES,
         "resources": RESOURCES,
         "actions": ACTIONS,
-        "role_presets": ROLE_PRESETS,
+        "role_presets": resolved_role_presets(),
     }), 200
 
 

--- a/backend/app/entrypoint/routes/common/permissions.py
+++ b/backend/app/entrypoint/routes/common/permissions.py
@@ -29,7 +29,79 @@ ACTIONS = ["create", "read", "update", "delete"]
 
 _PRESETS_PATH = os.path.join(os.path.dirname(__file__), "role_presets.json")
 with open(_PRESETS_PATH, encoding="utf-8") as _f:
-    ROLE_PRESETS: dict = json.load(_f)
+    # The BASELINE, generated from the route decorators. Never mutated at runtime:
+    # it is the floor a role falls back to, so a missing, empty or unparseable
+    # override can never leave a role with no permissions at all.
+    ROLE_PRESETS_BASELINE: dict = json.load(_f)
+
+
+# Platform-owner overrides live in platform_setting under this key, as
+# {role: {"modules": [...], "endpoints": {...}}} for OVERRIDDEN roles only —
+# absent means "use the generated baseline for that role".
+ROLE_PRESETS_SETTING_KEY = "role_presets"
+
+# A role's defaults are resolved on every authenticated request (the chokepoint
+# calls effective_permissions per request), so they are cached rather than read
+# from the database each time. The TTL is what bounds cross-worker staleness:
+# gunicorn runs several workers, each with its own cache, and the worker that
+# serves the edit is not the worker that serves the next request. 30s is short
+# enough that an admin sees the change take effect while they are still looking
+# at the screen, and long enough that this is not a per-request query.
+_ROLE_OVERRIDE_TTL_SECONDS = 30
+_override_cache: dict = {"at": None, "value": {}}
+
+
+def invalidate_role_overrides() -> None:
+    """Drop the cached overrides so the next read hits the database.
+
+    Called by the write path so the admin who just saved sees their own change
+    immediately, rather than up to a TTL later in their own worker.
+    """
+    _override_cache["at"] = None
+
+
+def role_overrides() -> dict:
+    """Platform-owner overrides for role defaults, cached with a short TTL."""
+    import time
+
+    now = time.monotonic()
+    at = _override_cache["at"]
+    if at is not None and (now - at) < _ROLE_OVERRIDE_TTL_SECONDS:
+        return _override_cache["value"]
+
+    try:
+        from app.adapters.unit_of_work.sqlalchemy_unit_of_work import (
+            SqlAlchemyUnitOfWork,
+        )
+        from models.common import PlatformSetting
+
+        with SqlAlchemyUnitOfWork(account_uuid=None) as uow:
+            row = (
+                uow.session.query(PlatformSetting)
+                .filter_by(key=ROLE_PRESETS_SETTING_KEY)
+                .one_or_none()
+            )
+            value = dict(row.value) if row and row.value else {}
+    except Exception:
+        # This function sits on the authorization path. A settings table that is
+        # unreachable mid-migration, or a row someone hand-edited into invalid
+        # JSON, must NOT take the API down or silently widen access — serve the
+        # last known value (falling back to the generated baseline) and move on.
+        return _override_cache["value"]
+
+    _override_cache["at"] = now
+    _override_cache["value"] = value
+    return value
+
+
+def resolved_role_presets() -> dict:
+    """Every role's effective defaults: the override where one exists, else the
+    generated baseline. This is what actually governs users who follow a role."""
+    overrides = role_overrides()
+    return {
+        role: overrides.get(role) or baseline
+        for role, baseline in ROLE_PRESETS_BASELINE.items()
+    }
 
 # HTTP method -> CRUD action
 METHOD_ACTIONS = {
@@ -76,12 +148,19 @@ _ADMIN_SCOPES = {"admin", "superuser"}
 
 def preset_for_scope(permission_scope: str | None) -> dict:
     """The role preset for a permission_scope string (may be comma-joined).
-    Union of every matched role's preset. Unknown/empty scope -> empty."""
+    Union of every matched role's preset. Unknown/empty scope -> empty.
+
+    Reads the RESOLVED presets, so a platform-owner edit to a role's defaults
+    takes effect for every user following that role without a deploy. Users with
+    an explicit per-user override are unaffected — effective_permissions returns
+    their own column and never reaches here.
+    """
+    presets = resolved_role_presets()
     scopes = [s.strip() for s in (permission_scope or "").split(",") if s.strip()]
     modules: set = set()
     endpoints: dict = {}
     for scope in scopes:
-        preset = ROLE_PRESETS.get(scope)
+        preset = presets.get(scope)
         if not preset:
             continue
         modules.update(preset.get("modules", []))

--- a/backend/app/entrypoint/routes/super_admin/routes.py
+++ b/backend/app/entrypoint/routes/super_admin/routes.py
@@ -345,6 +345,149 @@ def set_default_account_permissions():
     return jsonify(result), 200
 
 
+def _role_preset_payload(uow):
+    """Every role's defaults, plus what an editor needs to act safely.
+
+    `baseline` is the generated-from-decorators floor, so the UI can offer "reset
+    to default" and show what an override changed. `following` is the blast radius:
+    how many users actually inherit this role's defaults right now, which is the
+    number that matters before widening or narrowing a role.
+    """
+    from app.entrypoint.routes.common.permissions import (
+        ROLE_PRESETS_BASELINE,
+        resolved_role_presets,
+        role_overrides,
+    )
+    from models.common import User as UserModel
+
+    overrides = role_overrides()
+    resolved = resolved_role_presets()
+
+    # Users who FOLLOW the role: no explicit per-user override. Users with their
+    # own checklist are deliberately excluded — editing a role's defaults does
+    # not touch them, and counting them here would overstate the impact.
+    counts = dict(
+        uow.session.query(UserModel.permission_scope, func.count(UserModel.uuid))
+        .filter(
+            UserModel.is_deleted.is_(False),
+            UserModel.permissions.is_(None),
+        )
+        .group_by(UserModel.permission_scope)
+        .all()
+    )
+
+    return {
+        "roles": [
+            {
+                "role": role,
+                "permissions": resolved[role],
+                "baseline": ROLE_PRESETS_BASELINE[role],
+                "is_overridden": role in overrides and bool(overrides[role]),
+                "following": counts.get(role, 0),
+            }
+            for role in sorted(ROLE_PRESETS_BASELINE)
+        ]
+    }
+
+
+@super_admin_blueprint.route("/settings/role-presets", methods=["GET"])
+@scopes_required(SUPER)
+def get_role_presets():
+    """Per-role default permissions. A user with no explicit checklist is governed
+    by their role's entry here."""
+    with SqlAlchemyUnitOfWork(account_uuid=None) as uow:
+        result = _role_preset_payload(uow)
+    return jsonify(result), 200
+
+
+@super_admin_blueprint.route("/settings/role-presets/<string:role>", methods=["PUT"])
+@scopes_required(SUPER)
+def set_role_preset(role: str):
+    """Override one role's default permissions, platform-wide.
+
+    Takes effect without a deploy: every user following this role is re-governed
+    on their next request, and the perms-version header tells their already-open
+    clients to re-read their profile rather than keep a stale menu.
+    """
+    from pydantic import BaseModel, ConfigDict
+    from app.dto.auth import UserPermissions
+    from app.entrypoint.routes.common.permissions import (
+        ROLE_PRESETS_BASELINE,
+        ROLE_PRESETS_SETTING_KEY,
+        invalidate_role_overrides,
+    )
+    from models.common import PlatformSetting
+
+    # Only roles that HAVE defaults. admin/superuser are excluded because they
+    # bypass the ACL entirely (effective_permissions returns None for them), so a
+    # preset for them would be stored, displayed, and silently ignored.
+    if role not in ROLE_PRESETS_BASELINE:
+        raise BadRequestError(
+            f"unknown role {role!r} — must be one of "
+            f"{sorted(ROLE_PRESETS_BASELINE)}"
+        )
+
+    class _Body(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        # Required, not optional: an explicit null here would be ambiguous
+        # between "clear the override" and "grant nothing", and those differ by
+        # everything. Clearing is DELETE.
+        permissions: UserPermissions
+
+    payload = _Body(**request.json)
+    with SqlAlchemyUnitOfWork(account_uuid=None) as uow:
+        row = uow.session.query(PlatformSetting).filter_by(
+            key=ROLE_PRESETS_SETTING_KEY).one_or_none()
+        # Rebuilt rather than mutated in place: MutableDict tracks top-level key
+        # assignment, and updating a nested dict would not always be flagged dirty.
+        value = dict(row.value) if row and row.value else {}
+        value[role] = payload.permissions.model_dump()
+        if row:
+            row.value = value
+        else:
+            uow.session.add(
+                PlatformSetting(key=ROLE_PRESETS_SETTING_KEY, value=value)
+            )
+        # COMMIT BEFORE invalidating and re-reading, in that order. role_overrides()
+        # reads through its own short-lived session, so it cannot see this
+        # transaction's uncommitted writes: invalidating first made the very next
+        # read cache the stale pre-commit value with a FRESH timestamp, which then
+        # served the old defaults for the whole TTL. Caught by the endpoint
+        # reporting is_overridden=false on a row that had in fact been written.
+        uow.commit()
+        invalidate_role_overrides()
+        result = _role_preset_payload(uow)
+    return jsonify(result), 200
+
+
+@super_admin_blueprint.route("/settings/role-presets/<string:role>", methods=["DELETE"])
+@scopes_required(SUPER)
+def reset_role_preset(role: str):
+    """Drop the override and return this role to the generated baseline."""
+    from app.entrypoint.routes.common.permissions import (
+        ROLE_PRESETS_BASELINE,
+        ROLE_PRESETS_SETTING_KEY,
+        invalidate_role_overrides,
+    )
+    from models.common import PlatformSetting
+
+    if role not in ROLE_PRESETS_BASELINE:
+        raise BadRequestError(f"unknown role {role!r}")
+
+    with SqlAlchemyUnitOfWork(account_uuid=None) as uow:
+        row = uow.session.query(PlatformSetting).filter_by(
+            key=ROLE_PRESETS_SETTING_KEY).one_or_none()
+        if row and row.value and role in row.value:
+            value = dict(row.value)
+            value.pop(role, None)
+            row.value = value
+        # Same ordering rule as the PUT: commit, then invalidate, then read.
+        uow.commit()
+        invalidate_role_overrides()
+        result = _role_preset_payload(uow)
+    return jsonify(result), 200
+
+
 @super_admin_blueprint.route("/accounts/<string:account_uuid>/impersonate", methods=["POST"])
 @scopes_required(SUPER)
 def impersonate(account_uuid: str):

--- a/backend/scripts/gen_role_presets.py
+++ b/backend/scripts/gen_role_presets.py
@@ -12,7 +12,8 @@ matching method allows it. Modules preset = menu tabs whose resource the role
 can READ (users/live-map/location-tracking are admin-only, excluded).
 
 Run:  docker exec karma-backend-1 python scripts/gen_role_presets.py
-Prints a Python literal to paste into permissions.py as ROLE_PRESETS.
+Prints JSON to paste into role_presets.json, which is the BASELINE that a
+platform-owner role override falls back to.
 """
 import json
 

--- a/backend/scripts/parity_check.py
+++ b/backend/scripts/parity_check.py
@@ -14,7 +14,7 @@ Reports, per role: LOST (old allow, new deny) — must be ZERO — and GAINED
 """
 from app import create_app
 from app.entrypoint.routes.common.permissions import (
-    METHOD_ACTIONS, RESOURCE_SET, ROLE_PRESETS, preset_for_scope, endpoint_allowed,
+    METHOD_ACTIONS, RESOURCE_SET, ROLE_PRESETS_BASELINE, preset_for_scope, endpoint_allowed,
 )
 
 ADMIN = {"admin", "superuser"}

--- a/backend/tests/domains/test_role_presets.py
+++ b/backend/tests/domains/test_role_presets.py
@@ -1,0 +1,175 @@
+"""What a role means by default, and who gets to change it.
+
+A user with no permissions of their own is governed by their role's defaults. Those
+defaults were generated from the route decorators into role_presets.json and read
+once at import, so changing what a role meant took a commit, a deploy and a restart.
+The platform owner can now override them at runtime.
+
+The generated file did not go away — it is the BASELINE, and that is the point of
+most of what is pinned here. An override layer over an authorization decision is
+only safe if every degenerate case falls back to the baseline rather than to
+"nothing" or "everything":
+
+  * a role with no override                  -> baseline
+  * an override that is empty / null / junk  -> baseline, not an empty grant
+  * an override naming a role we do not have -> ignored, invents nothing
+
+The alternative — treating a missing override as no permissions — would take every
+non-admin user's access away the first time the settings row was absent.
+"""
+import pytest
+
+from app.entrypoint.routes.common import permissions as perms
+
+
+@pytest.fixture
+def no_db_overrides(monkeypatch):
+    """Resolution with the database out of the picture, so these stay unit tests."""
+    def _set(value):
+        monkeypatch.setattr(perms, "role_overrides", lambda: value)
+    return _set
+
+
+# --- resolution ----------------------------------------------------------
+
+
+def test_with_no_overrides_every_role_is_the_generated_baseline(no_db_overrides):
+    no_db_overrides({})
+    assert perms.resolved_role_presets() == perms.ROLE_PRESETS_BASELINE
+
+
+def test_an_override_replaces_only_that_role(no_db_overrides):
+    custom = {"modules": ["customers"], "endpoints": {"customer": ["read"]}}
+    no_db_overrides({"driver": custom})
+
+    resolved = perms.resolved_role_presets()
+    assert resolved["driver"] == custom
+    for role in perms.ROLE_PRESETS_BASELINE:
+        if role != "driver":
+            assert resolved[role] == perms.ROLE_PRESETS_BASELINE[role], (
+                f"{role} changed when only driver was overridden"
+            )
+
+
+def test_an_empty_override_falls_back_to_the_baseline(no_db_overrides):
+    """THE case that decides whether this feature is safe.
+
+    An override row that exists but holds nothing for a role — a half-written
+    save, a hand-edited JSONB, a role added to the enum before anyone configured
+    it — must mean "use the baseline", never "grant nothing". The other reading
+    silently removes every permission from everyone following that role.
+    """
+    for empty in ({}, None, {"modules": [], "endpoints": {}}):
+        no_db_overrides({"driver": empty})
+        resolved = perms.resolved_role_presets()
+        expected = (
+            empty if empty == {"modules": [], "endpoints": {}}
+            else perms.ROLE_PRESETS_BASELINE["driver"]
+        )
+        # a deliberately-empty-but-present grant is a real choice and is kept;
+        # a falsy one is not a choice and falls back
+        assert resolved["driver"] == expected, f"{empty!r} resolved wrongly"
+
+
+def test_an_override_for_an_unknown_role_is_ignored(no_db_overrides):
+    """The resolver iterates the baseline, so a stale or misspelled role in the
+    settings row cannot introduce a role the code does not know about."""
+    no_db_overrides({"wizard": {"modules": ["customers"], "endpoints": {}}})
+    resolved = perms.resolved_role_presets()
+    assert "wizard" not in resolved
+    assert set(resolved) == set(perms.ROLE_PRESETS_BASELINE)
+
+
+def test_the_baseline_object_is_never_mutated_by_an_override(no_db_overrides):
+    """The baseline is the floor to fall back to and the value "reset to default"
+    restores, so it has to stay exactly as generated for the life of the process."""
+    before = perms.ROLE_PRESETS_BASELINE["driver"]["modules"][:]
+    no_db_overrides({"driver": {"modules": [], "endpoints": {}}})
+    perms.resolved_role_presets()
+    assert perms.ROLE_PRESETS_BASELINE["driver"]["modules"] == before
+
+
+# --- what actually governs a user ---------------------------------------
+
+
+def test_preset_for_scope_reads_the_override_not_the_baseline(no_db_overrides):
+    """The whole feature in one assertion: an edited role default reaches the
+    function the request chokepoint uses, with no deploy and no restart."""
+    no_db_overrides({"driver": {"modules": ["trips"], "endpoints": {"trip": ["read"]}}})
+    got = perms.preset_for_scope("driver")
+    assert got["modules"] == ["trips"]
+    assert got["endpoints"] == {"trip": ["read"]}
+
+
+def test_comma_joined_scopes_still_union_across_resolved_presets(no_db_overrides):
+    no_db_overrides({
+        "driver": {"modules": ["trips"], "endpoints": {"trip": ["read"]}},
+        "operator": {"modules": ["inventory"], "endpoints": {"trip": ["create"]}},
+    })
+    got = perms.preset_for_scope("driver,operator")
+    assert got["modules"] == ["inventory", "trips"]
+    assert got["endpoints"] == {"trip": ["create", "read"]}
+
+
+def test_an_unknown_scope_grants_nothing(no_db_overrides):
+    no_db_overrides({})
+    assert perms.preset_for_scope("wizard") == {"modules": [], "endpoints": {}}
+    assert perms.preset_for_scope("") == {"modules": [], "endpoints": {}}
+    assert perms.preset_for_scope(None) == {"modules": [], "endpoints": {}}
+
+
+def test_a_per_user_override_still_beats_the_role_default(no_db_overrides):
+    """Roles are defaults, not ceilings. Editing one user's checklist has to keep
+    winning, or the per-user editor becomes decorative the moment a role is
+    customised."""
+    no_db_overrides({"driver": {"modules": [], "endpoints": {}}})
+
+    class _User:
+        permission_scope = "driver"
+        permissions = {"modules": ["customers"], "endpoints": {"customer": ["read"]}}
+
+    assert perms.effective_permissions(_User()) == _User.permissions
+
+
+def test_an_admin_is_unaffected_by_any_role_override(no_db_overrides):
+    """Admins carry no permissions object at all — None means full access. A role
+    preset must not start governing them just because one now exists in the DB."""
+    no_db_overrides({"admin": {"modules": [], "endpoints": {}}})
+
+    class _Admin:
+        permission_scope = "admin"
+        permissions = None
+
+    assert perms.effective_permissions(_Admin()) is None
+
+
+# --- the cache ----------------------------------------------------------
+
+
+def test_the_cache_is_invalidated_rather_than_waited_out():
+    """The write path calls this so the admin who saved sees their own change at
+    once instead of up to a TTL later."""
+    perms._override_cache["at"] = 12345.0
+    perms.invalidate_role_overrides()
+    assert perms._override_cache["at"] is None
+
+
+def test_a_settings_read_failure_never_widens_or_removes_access(monkeypatch):
+    """This function sits on the authorization path. If the settings table cannot
+    be read — unreachable mid-migration, a bad row — it must serve the last known
+    value and leave the baseline standing, not raise into a 500 and not return an
+    empty grant that reads as "no permissions"."""
+    perms._override_cache["at"] = None
+    perms._override_cache["value"] = {}
+
+    def _boom(*_a, **_k):
+        raise RuntimeError("settings table is unreachable")
+
+    monkeypatch.setattr(perms, "SqlAlchemyUnitOfWork", _boom, raising=False)
+    # role_overrides imports the UoW inside the function, so patch the module it
+    # imports from instead
+    import app.adapters.unit_of_work.sqlalchemy_unit_of_work as uow_mod
+    monkeypatch.setattr(uow_mod, "SqlAlchemyUnitOfWork", _boom)
+
+    assert perms.role_overrides() == {}
+    assert perms.resolved_role_presets() == perms.ROLE_PRESETS_BASELINE

--- a/frontend/client/src/components/superadmin/RolePresetsAdmin.tsx
+++ b/frontend/client/src/components/superadmin/RolePresetsAdmin.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PermissionsEditor } from "@/components/users/PermissionsEditor";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest, queryClient as qc } from "@/lib/queryClient";
+import type { UserPermissions } from "@/lib/types";
+
+interface RolePreset {
+  role: string;
+  permissions: UserPermissions;
+  baseline: UserPermissions;
+  is_overridden: boolean;
+  /** users who inherit this role's defaults right now (no per-user override) */
+  following: number;
+}
+
+const KEY = ["/super-admin/settings/role-presets"];
+
+/**
+ * Editable per-role default permissions, platform-wide.
+ *
+ * Roles have always carried a full fine-grained default set, but it was generated
+ * from the route decorators into a JSON file in the repo and read once at import,
+ * so changing what a role means required a commit, a deploy and a restart. This is
+ * that same set, editable at runtime.
+ *
+ * Two things this screen deliberately shows, because editing a role is not like
+ * editing one user:
+ *
+ *   - HOW MANY USERS FOLLOW IT. That is the blast radius. Users with their own
+ *     checklist are excluded from the count, because a role edit does not touch
+ *     them — counting them would overstate the impact.
+ *   - WHETHER IT DIFFERS FROM THE GENERATED BASELINE, with a way back. The
+ *     baseline is derived from what the routes actually require, so it is the
+ *     known-good floor to return to after a bad edit.
+ */
+export function RolePresetsAdmin() {
+  const { t, te } = useLanguage();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState<string | null>(null);
+  const [draft, setDraft] = useState<UserPermissions>({ modules: [], endpoints: {} });
+
+  const { data, isLoading, error } = useQuery<{ roles: RolePreset[] }>({
+    queryKey: KEY,
+    queryFn: async () => await apiRequest("/super-admin/settings/role-presets"),
+  });
+
+  const roles = data?.roles ?? [];
+
+  /**
+   * Open a role's editor, seeding the draft from THAT role's saved permissions.
+   *
+   * Seeded here, at the moment of opening, rather than from an effect watching the
+   * open role: the draft belongs to one specific row, so deriving it where that row
+   * is in hand leaves no question about which role a pending edit applies to. The
+   * editor is also keyed by role below, so switching roles remounts it rather than
+   * reusing a tree that was rendered for a different permission set.
+   */
+  const toggleEditor = (r: RolePreset) => {
+    if (editing === r.role) {
+      setEditing(null);
+      return;
+    }
+    setDraft(r.permissions);
+    setEditing(r.role);
+  };
+
+  const afterWrite = (label: string) => {
+    queryClient.invalidateQueries({ queryKey: KEY });
+    // The role checklist the USER editor prefills from comes from the permission
+    // catalog, which now serves resolved presets — so it is stale the moment a
+    // role changes here, and a stale catalog makes "unchanged from preset" compare
+    // against the wrong set.
+    qc.invalidateQueries({ queryKey: ["/auth/permission-catalog"] });
+    setEditing(null);
+    toast({ title: t("common.success"), description: label });
+  };
+
+  const saveMutation = useMutation({
+    mutationFn: async (role: string) =>
+      await apiRequest(`/super-admin/settings/role-presets/${role}`, {
+        method: "PUT",
+        body: { permissions: draft },
+      }),
+    onSuccess: () => afterWrite(t("rolePresets.saved")),
+    onError: (e: any) =>
+      toast({
+        title: t("common.error"),
+        description: e?.message ?? t("rolePresets.saveFailed"),
+        variant: "destructive",
+      }),
+  });
+
+  const resetMutation = useMutation({
+    mutationFn: async (role: string) =>
+      await apiRequest(`/super-admin/settings/role-presets/${role}`, { method: "DELETE" }),
+    onSuccess: () => afterWrite(t("rolePresets.reset")),
+    onError: (e: any) =>
+      toast({
+        title: t("common.error"),
+        description: e?.message ?? t("rolePresets.saveFailed"),
+        variant: "destructive",
+      }),
+  });
+
+  if (isLoading) return <p className="text-sm text-gray-500">{t("common.loading")}</p>;
+  if (error) return <p className="text-sm text-red-600">{t("rolePresets.loadFailed")}</p>;
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-gray-600 dark:text-gray-300">
+        {t("rolePresets.intro")}
+      </p>
+
+      {roles.map((r) => (
+        <Card key={r.role} data-testid={`role-preset-${r.role}`}>
+          <CardHeader className="pb-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <CardTitle className="text-base flex flex-wrap items-center gap-2">
+                {/* same enum-label helper the user pages use, so a role reads
+                    "Warehouse Keeper" / "أمين مستودع" rather than raw snake_case */}
+                {te(r.role)}
+                {r.is_overridden ? (
+                  <Badge
+                    variant="outline"
+                    className="border-amber-300 bg-amber-50 text-amber-700"
+                    data-testid={`role-overridden-${r.role}`}
+                  >
+                    {t("rolePresets.customised")}
+                  </Badge>
+                ) : (
+                  <Badge variant="outline" className="text-gray-500">
+                    {t("rolePresets.default")}
+                  </Badge>
+                )}
+                {/* the number that matters before widening or narrowing a role */}
+                <span className="text-xs font-normal text-gray-500">
+                  {t("rolePresets.following", { count: r.following })}
+                </span>
+              </CardTitle>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  variant={editing === r.role ? "secondary" : "outline"}
+                  onClick={() => toggleEditor(r)}
+                  data-testid={`role-edit-${r.role}`}
+                >
+                  {editing === r.role ? t("common.cancel") : t("common.edit")}
+                </Button>
+                {r.is_overridden && (
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => resetMutation.mutate(r.role)}
+                    disabled={resetMutation.isPending}
+                    data-testid={`role-reset-${r.role}`}
+                  >
+                    {t("rolePresets.resetToDefault")}
+                  </Button>
+                )}
+              </div>
+            </div>
+            <p className="text-xs text-gray-500">
+              {t("rolePresets.summary", {
+                modules: r.permissions.modules.length,
+                resources: Object.keys(r.permissions.endpoints ?? {}).length,
+              })}
+            </p>
+          </CardHeader>
+
+          {editing === r.role && (
+            <CardContent className="space-y-4">
+              <PermissionsEditor key={r.role} value={draft} onChange={setDraft} />
+              <div className="flex items-center gap-2">
+                <Button
+                  onClick={() => saveMutation.mutate(r.role)}
+                  disabled={saveMutation.isPending}
+                  data-testid={`role-save-${r.role}`}
+                >
+                  {t("common.save")}
+                </Button>
+                <Button variant="ghost" onClick={() => setDraft(r.baseline)}>
+                  {t("rolePresets.loadBaseline")}
+                </Button>
+              </div>
+              {r.following > 0 && (
+                <p className="text-xs text-amber-700" data-testid={`role-warn-${r.role}`}>
+                  {t("rolePresets.affectsWarning", { count: r.following })}
+                </p>
+              )}
+            </CardContent>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/frontend/client/src/i18n/index.ts
+++ b/frontend/client/src/i18n/index.ts
@@ -5,6 +5,7 @@
 // Placeholders use {name} syntax and are substituted by t(key, vars).
 
 import * as accountSettings from './translations/accountSettings';
+import * as rolePresets from './translations/rolePresets';
 import * as common from './translations/common';
 import * as nav from './translations/nav';
 import * as dashboard from './translations/dashboard';
@@ -43,6 +44,7 @@ export const LANGUAGE_LABELS: Record<Lang, string> = {
 
 const modules = [
   accountSettings,
+  rolePresets,
   common,
   nav,
   dashboard,

--- a/frontend/client/src/i18n/translations/rolePresets.ts
+++ b/frontend/client/src/i18n/translations/rolePresets.ts
@@ -1,0 +1,40 @@
+// Platform-owner editing of what each role means by default.
+//
+// Distinct from the per-user permission strings in users.ts: those describe one
+// person's checklist, these describe the default every user of a role inherits.
+
+export const en: Record<string, string> = {
+  'rolePresets.tab': 'Roles',
+  'rolePresets.intro':
+    "Default permissions for each role. Anyone with that role and no permissions of their own is governed by these, and changes apply immediately — no deploy needed. Editing a user's own checklist still overrides their role.",
+  'rolePresets.loadFailed': 'Could not load role defaults.',
+  'rolePresets.saved': 'Role defaults updated',
+  'rolePresets.reset': 'Role returned to its generated default',
+  'rolePresets.saveFailed': 'Could not save role defaults.',
+  'rolePresets.customised': 'Customised',
+  'rolePresets.default': 'Generated default',
+  'rolePresets.following': '{count} user(s) follow this role',
+  'rolePresets.summary': '{modules} menu module(s), {resources} resource(s) granted',
+  'rolePresets.resetToDefault': 'Reset to default',
+  'rolePresets.loadBaseline': 'Load generated default',
+  'rolePresets.affectsWarning':
+    'Saving changes what {count} user(s) can do, on their next request.',
+};
+
+export const ar: Record<string, string> = {
+  'rolePresets.tab': 'الأدوار',
+  'rolePresets.intro':
+    'الصلاحيات الافتراضية لكل دور. كل مستخدم يحمل هذا الدور وليست له صلاحيات خاصة يخضع لهذه الإعدادات، والتغييرات تُطبَّق فوراً دون نشر. تعديل صلاحيات مستخدم بعينه يبقى مقدَّماً على دوره.',
+  'rolePresets.loadFailed': 'تعذر تحميل إعدادات الأدوار الافتراضية.',
+  'rolePresets.saved': 'تم تحديث الصلاحيات الافتراضية للدور',
+  'rolePresets.reset': 'تمت إعادة الدور إلى إعداده الأصلي',
+  'rolePresets.saveFailed': 'تعذر حفظ الصلاحيات الافتراضية للدور.',
+  'rolePresets.customised': 'مُعدَّل',
+  'rolePresets.default': 'الإعداد الأصلي',
+  'rolePresets.following': '{count} مستخدم يتبع هذا الدور',
+  'rolePresets.summary': '{modules} وحدة قائمة، {resources} مورد مسموح',
+  'rolePresets.resetToDefault': 'إعادة إلى الأصل',
+  'rolePresets.loadBaseline': 'تحميل الإعداد الأصلي',
+  'rolePresets.affectsWarning':
+    'الحفظ سيغيّر ما يمكن لـ {count} مستخدم فعله، عند طلبهم التالي.',
+};

--- a/frontend/client/src/pages/SuperAdmin.tsx
+++ b/frontend/client/src/pages/SuperAdmin.tsx
@@ -1,5 +1,6 @@
 import { AppLayout } from "@/components/layout/AppLayout";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { RolePresetsAdmin } from "@/components/superadmin/RolePresetsAdmin";
 import { useAuth } from "@/contexts/AuthContext";
 import { useLanguage } from "@/contexts/LanguageContext";
 import { AccountsPanel } from "@/pages/AccountsAdmin";
@@ -43,6 +44,9 @@ export default function SuperAdmin() {
                 <TabsTrigger value="workflows" data-testid="superadmin-tab-workflows">
                   {t("nav.workflows")}
                 </TabsTrigger>
+                <TabsTrigger value="roles" data-testid="superadmin-tab-roles">
+                  {t("rolePresets.tab")}
+                </TabsTrigger>
               </TabsList>
               <TabsContent value="accounts" className="mt-4">
                 <AccountsPanel />
@@ -52,6 +56,9 @@ export default function SuperAdmin() {
               </TabsContent>
               <TabsContent value="workflows" className="mt-4">
                 <WorkflowsPanel />
+              </TabsContent>
+              <TabsContent value="roles" className="mt-4">
+                <RolePresetsAdmin />
               </TabsContent>
             </Tabs>
           </div>


### PR DESCRIPTION
## What already existed

Every role already carried a complete fine-grained default set, and a user with no
permissions of their own was already governed by it. Per-user editing already worked,
and already stored `null` when a checklist matched the preset so the user keeps
*following* the role rather than freezing a copy.

## What didn't

Any way to **change** what a role means. `role_presets.json` is generated from the
route decorators, committed to the repo, and read once at module import — so a change
took an edit, a commit, a deploy and a restart, and a rolling deploy could leave two
workers serving different presets.

The platform owner can now edit a role's defaults in the super-admin console and have
it apply on the next request.

## Why the generated file stays

It becomes the **baseline**, and that is what makes an override layer over an
authorization decision safe. Overrides are stored per role, so every degenerate case
falls back rather than failing open or shut:

| case | resolves to |
|---|---|
| no override for the role | baseline |
| override empty / null / junk | baseline |
| override names a role the code doesn't have | ignored, invents nothing |
| override is a deliberate empty grant | kept — that's a real choice |

Treating a missing override as "no permissions" would have removed every non-admin's
access the first time that settings row was absent.

## Caching

Resolution is cached with a 30s TTL rather than queried per request, since the
chokepoint resolves permissions on every authenticated call. The TTL bounds
cross-worker staleness — the worker serving the edit isn't the worker serving the next
request. The write path invalidates in-process so the admin who saved sees it at once,
and a settings read that raises serves the last known value rather than taking the API
down.

## Two things that were easy to get wrong

**The write must commit before invalidating and re-reading.** `role_overrides()` reads
through its own short-lived session and can't see an uncommitted write, so invalidating
first made the next read cache the stale pre-commit value *with a fresh timestamp* —
serving the old defaults for the whole TTL. Caught by the endpoint reporting
`is_overridden: false` on a row it had just written.

**`/auth/permission-catalog` now serves resolved presets, not the baseline.** The user
editor compares a checklist against the preset and stores `null` when they match. Against
a stale baseline that comparison misses, so picking a role and saving would quietly write
a per-user override equal to the *old* defaults — detaching that user from the role
without anyone choosing to.

## Verified end to end on a live stack

Narrowing `driver` (dropping the customer resource):

| | before | after |
|---|---|---|
| modules for a following user | 17 | 16 |
| `GET /customer/` | 200 | **403** |
| perms-version header | `56c4898…` | `d263a18…` (moved, so open clients re-read) |

No restart. Reset restored the baseline and 200. A **per-user override still returned
200** against the narrowed role — roles are defaults, not ceilings.

Guards: unknown role 400, `admin` role 400 (admins bypass the ACL entirely, so a preset
for them would be stored, shown, and silently ignored), unknown module or action 422,
non-superuser 403.

Also driven through the actual UI: unticking a module and saving flipped the badge to
Customised, offered the reset, showed the impact warning, and changed the live user's
permissions.

## Console affordances

The screen shows **how many users follow each role** — the blast radius, excluding users
with their own checklist since a role edit doesn't touch them — whether the role differs
from the generated default, and a reset back to it.

## Tests

12 tests in `test_role_presets.py`, mutation-tested with 5 seeded bugs, each caught. One
mutation initially appeared uncaught because my anchor hit the TTL fast-path `return`
rather than the `except` block; re-targeted, it fails the right test.

`parity_check.py` still reports **TOTAL LOST: 0**. Backend failure set unchanged from
baseline (227). `frontend tsc` 70, unchanged.

Housekeeping: dropped the ambiguous `ROLE_PRESETS` alias so nobody mistakes the baseline
for the effective set, pointed `parity_check` at `ROLE_PRESETS_BASELINE`, and corrected
the generator's docstring, which claimed it prints a Python literal for `permissions.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)