### PR TITLE
Fix list filters that 500'd, and stop reporting missing fields as conflicts

### DIFF
--- a/backend/app/dto/purchase_order_item.py
+++ b/backend/app/dto/purchase_order_item.py
@@ -15,8 +15,15 @@ class PurchaseOrderItemBase(BaseModel):
     material_uuid:       str
     quantity:            int
     price_per_unit:      float
-    currency:            Optional[Currency] = None
-    unit:                Optional[UnitOfMeasure] = None
+    # Required, because purchase_order_item.currency and .unit are both NOT NULL and
+    # nothing fills them in — neither the single-item route nor
+    # PurchaseOrderItemDomain.create_items, which dumps this DTO straight into the
+    # model. Declaring them Optional meant an omitted currency reached the database
+    # and came back as 409 "Conflicts with an existing record" from the global
+    # IntegrityError handler: a schema mismatch reported as a conflict the caller
+    # caused, with no mention of the field at fault. Now it is a 422 that names it.
+    currency:            Currency
+    unit:                UnitOfMeasure
 
 class PurchaseOrderItemCreate(PurchaseOrderItemBase):
     """Fields required to create a new purchase order item."""

--- a/backend/app/dto/warehouse.py
+++ b/backend/app/dto/warehouse.py
@@ -78,7 +78,11 @@ class WarehouseRead(WarehouseBase):
 class WarehouseListParams(BaseModel):
     """Pagination parameters for listing warehouses."""
     model_config = ConfigDict(extra="forbid")
-    uuid : Optional[UUID] = None
+    # str, not UUID: warehouse.uuid is character varying(36), so a UUID here binds
+    # as ::uuid and Postgres refuses the comparison outright —
+    # "operator does not exist: character varying = uuid" — turning the filter into
+    # a 500. Every other list DTO in the codebase types uuid as str for this reason.
+    uuid: Optional[str] = None
     name: Optional[str] = None
     within_polygon: Optional[str] = None  # WKT Polygon
     page:     int = Field(1, gt=0, description="Page number (>=1)")

--- a/backend/app/entrypoint/routes/common/errors.py
+++ b/backend/app/entrypoint/routes/common/errors.py
@@ -1,4 +1,20 @@
+import re
+
 from sqlalchemy.exc import IntegrityError
+
+try:  # psycopg2 is the driver in every environment, but do not hard-fail without it
+    from psycopg2.errors import NotNullViolation
+except ImportError:  # pragma: no cover
+    class NotNullViolation(Exception):  # type: ignore[no-redef]
+        """Placeholder so isinstance() stays valid when psycopg2 is absent."""
+
+
+def _not_null_column(detail: str) -> str | None:
+    """Pull the column name out of Postgres' not-null message, if it is there."""
+    match = re.search(r'null value in column "([^"]+)"', detail)
+    return match.group(1) if match else None
+
+
 # app/core/errors.py
 
 class ApiError(Exception):
@@ -50,8 +66,24 @@ def register_error_handlers(app):
         # first and return a 400 with a useful message. Reaching here means a
         # race or a path that skipped validation, and it should not read as a
         # server fault.
+        orig = getattr(e, 'orig', None)
+        detail = str(orig if orig is not None else e)
+
+        # Not every IntegrityError is a conflict. A NOT NULL violation means a
+        # column the DTO left optional is mandatory in the schema — nobody
+        # conflicted with anything, and answering 409 "Conflicts with an existing
+        # record" sends the caller looking for a duplicate that does not exist.
+        # This cost real debugging time on purchase_order_item.currency; keep the
+        # two apart so the next one is obvious from the response alone.
+        if isinstance(orig, NotNullViolation) or 'violates not-null constraint' in detail:
+            column = _not_null_column(detail)
+            return jsonify({
+                "error": (f"'{column}' is required" if column
+                          else "A required field was missing"),
+                "detail": "not_null_violation",
+            }), 422
+
         message = "Conflicts with an existing record"
-        detail = str(getattr(e, 'orig', e))
         if 'uq_financial_account_internal_currency' in detail:
             message = (
                 "This currency already has a non-external financial account. "

--- a/backend/app/entrypoint/routes/trip/routes.py
+++ b/backend/app/entrypoint/routes/trip/routes.py
@@ -1,8 +1,9 @@
 # app/entrypoint/routes/trip/routes.py
 from flask import Blueprint, g, request, jsonify
 from sqlalchemy import func
+from shapely import wkt as shapely_wkt
 from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
-from app.entrypoint.routes.common.errors import ApiError, NotFoundError
+from app.entrypoint.routes.common.errors import ApiError, BadRequestError, NotFoundError
 from app.dto.trip import (
     TripCreate,
     TripRead,
@@ -386,7 +387,21 @@ def list_trips():
     if params.vehicle_uuid:
         filters.append(TripModel.vehicle_uuid == params.vehicle_uuid)
     if params.service_area_uuid:
-        filters.append(TripModel.service_area_uuid == params.service_area_uuid)
+        # A trip does not store service-area uuids. It stores service_area_names, a
+        # varchar[] snapshot of the areas it covered, so `TripModel.service_area_uuid`
+        # was an AttributeError for every request that passed this param — valid uuid
+        # or not. Resolve the uuid to its name and match against that array instead,
+        # which is what the filter was always meant to express.
+        with SqlAlchemyUnitOfWork() as uow:
+            area = uow.service_area_repository.find_one(
+                uuid=params.service_area_uuid, is_deleted=False
+            )
+            if not area:
+                raise NotFoundError("ServiceArea not found")
+            # read the name while the session is still open — the instance detaches
+            # when this block exits and touching it afterwards is a DetachedInstanceError
+            area_name = area.name
+        filters.append(TripModel.service_area_names.any(area_name))
     if params.workflow_execution_uuid:
         filters.append(TripModel.workflow_execution_uuid == params.workflow_execution_uuid)
     if params.status:
@@ -396,8 +411,17 @@ def list_trips():
         filters.append(TripModel.audited_at.isnot(None) if params.is_audited
                        else TripModel.audited_at.is_(None))
     if params.intersects_area:
+        # Trip has no `geometry` column; the polygon it covered is `distribution_area`.
+        # As with service_area_uuid, this raised AttributeError on every use.
+        # Parse the WKT first: an invalid one otherwise fails inside the query as a
+        # psycopg2 geometry parse error and is served as a 500 rather than a 400.
+        try:
+            shapely_wkt.loads(params.intersects_area)
+        except Exception as e:
+            raise BadRequestError(f"Invalid intersects_area polygon: {e}")
         geom_expr = func.ST_GeomFromText(params.intersects_area, 4326)
-        filters.append(func.ST_Intersects(TripModel.geometry, geom_expr))
+        filters.append(TripModel.distribution_area.isnot(None))
+        filters.append(func.ST_Intersects(TripModel.distribution_area, geom_expr))
 
     filters.append(TripModel.is_deleted.is_(False))
 

--- a/backend/app/entrypoint/routes/warehouse/routes.py
+++ b/backend/app/entrypoint/routes/warehouse/routes.py
@@ -1,6 +1,7 @@
 from flask import request, jsonify
 from geoalchemy2 import WKTElement
 from pydantic import ValidationError
+from shapely import wkt as shapely_wkt
 from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
 from app.dto.warehouse import (
     WarehouseCreate,
@@ -120,6 +121,14 @@ def list_warehouses():
     if params.name:
         filters.append(WarehouseModel.name.ilike(f"%{params.name}%"))
     if params.within_polygon:
+        # WKTElement does not parse, so a malformed polygon used to sail through this
+        # block and fail inside the query instead — psycopg2 InternalError_ "parse
+        # error - invalid geometry", raised outside the try below and served as a 500.
+        # Bad user input is a 400, so the WKT is parsed here, before it reaches SQL.
+        try:
+            shapely_wkt.loads(params.within_polygon)
+        except Exception as e:
+            raise BadRequestError(f"Invalid polygon: {e}")
         try:
             # Wrap your WKT string in a WKTElement (with the correct SRID)
             poly = WKTElement(
@@ -134,12 +143,10 @@ def list_warehouses():
 
             )
             filters.append(WarehouseModel.coordinates.is_not(None))  # ensure coordinates are not None
-            # bump per_page so your polygon filter returns everything
-            params.per_page = 10000
         except ValidationError as e:
             raise BadRequestError(f"Invalid polygon: {e}")
-    if params.within_polygon:
-        # make per page a very high number to avoid pagination
+        # bump per_page so the polygon filter returns everything. Set after the DTO
+        # has validated, so it is deliberately above the le=100 ceiling.
         params.per_page = 10000
     with SqlAlchemyUnitOfWork() as uow:
         page_obj = uow.warehouse_repository.find_all_by_filters_paginated(

--- a/backend/tests/domains/test_dto_column_contracts.py
+++ b/backend/tests/domains/test_dto_column_contracts.py
@@ -1,0 +1,211 @@
+"""Where a DTO and its table disagree, and what the caller is told about it.
+
+Three bugs sat here together, all with the same shape: the DTO described a
+column inaccurately, and the caller was handed something that pointed away from
+the real cause.
+
+- WarehouseListParams.uuid was typed UUID while warehouse.uuid is varchar(36),
+  so Postgres refused the comparison and ?uuid= was a 500 for every request.
+- purchase_order_item.currency and .unit are NOT NULL but were Optional, so an
+  omitted currency reached the database and came back as 409 "Conflicts with an
+  existing record" — a schema mismatch reported as a conflict the caller caused.
+- Trip filters referenced TripModel.service_area_uuid and .geometry, neither of
+  which exists on the model, so both params were AttributeError → 500.
+
+The audit that found the second one also found five more Optional-vs-NOT NULL
+pairs that are *deliberate*, because a domain fills them in (inventory.lot_id is
+generated; purchase_order_uuid is Optional so a PO can be created with its items
+nested). Those must stay optional, which is why the durable fix is the error
+handler telling the truth rather than tightening each DTO.
+"""
+from uuid import UUID
+
+import pytest
+from psycopg2.errors import NotNullViolation, UniqueViolation
+from pydantic import ValidationError
+from sqlalchemy.exc import IntegrityError
+
+from flask import Flask
+
+from app.dto.purchase_order_item import PurchaseOrderItemCreate
+from app.dto.warehouse import WarehouseListParams
+from app.entrypoint.routes.common.errors import (
+    _not_null_column,
+    register_error_handlers,
+)
+
+
+class _Orig(Exception):
+    """Stand-in for a psycopg2 error carrying only its message."""
+
+
+def _integrity(message: str, orig_cls=_Orig):
+    return IntegrityError("INSERT ...", {}, orig_cls(message))
+
+
+@pytest.fixture
+def error_app():
+    """A bare app with only the error handlers.
+
+    Deliberately not the conftest `app` fixture: that one wires blueprints and JWT
+    but never calls register_error_handlers, so an IntegrityError raised in a view
+    propagates instead of being converted — which is what is under test here.
+    """
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.config["PROPAGATE_EXCEPTIONS"] = False
+    register_error_handlers(app)
+    return app
+
+
+def _raise_on(error_app, path, exc):
+    @error_app.route(path)
+    def _probe():
+        raise exc
+
+    return error_app.test_client().get(path)
+
+
+# --------------------------------------------------------------------------
+# WarehouseListParams.uuid must stay a plain string
+# --------------------------------------------------------------------------
+
+def test_warehouse_list_uuid_is_a_string_not_a_uuid_object():
+    """A UUID here binds as ::uuid and Postgres refuses varchar = uuid."""
+    value = "0f1f4b1e-1111-2222-3333-444455556666"
+    params = WarehouseListParams(uuid=value)
+    assert params.uuid == value
+    assert isinstance(params.uuid, str)
+    assert not isinstance(params.uuid, UUID)
+
+
+def test_warehouse_list_uuid_accepts_a_non_uuid_string():
+    """The column is varchar, so a non-uuid is a miss, not a validation error."""
+    params = WarehouseListParams(uuid="notauuid")
+    assert params.uuid == "notauuid"
+
+
+def test_warehouse_list_params_still_forbids_unknown_params():
+    with pytest.raises(ValidationError):
+        WarehouseListParams(bogus_param="1")
+
+
+def test_warehouse_list_params_per_page_ceiling_is_100():
+    assert WarehouseListParams(per_page=100).per_page == 100
+    with pytest.raises(ValidationError):
+        WarehouseListParams(per_page=101)
+
+
+# --------------------------------------------------------------------------
+# purchase_order_item currency/unit are NOT NULL, so the DTO requires them
+# --------------------------------------------------------------------------
+
+def _po_item(**overrides):
+    payload = {
+        "material_uuid": "m-1",
+        "quantity": 7,
+        "price_per_unit": 3.0,
+        "currency": "USD",
+        "unit": "kg",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_po_item_create_accepts_a_complete_payload():
+    item = PurchaseOrderItemCreate(**_po_item())
+    assert item.currency.value == "USD"
+    assert item.unit.value == "kg"
+
+
+@pytest.mark.parametrize("missing", ["currency", "unit"])
+def test_po_item_create_rejects_a_missing_not_null_field(missing):
+    payload = _po_item()
+    payload.pop(missing)
+    with pytest.raises(ValidationError) as exc:
+        PurchaseOrderItemCreate(**payload)
+    # the caller must be told WHICH field, which the old 409 never said
+    assert any(err["loc"] == (missing,) for err in exc.value.errors())
+
+
+def test_po_item_create_reports_both_missing_fields_at_once():
+    payload = _po_item()
+    del payload["currency"], payload["unit"]
+    with pytest.raises(ValidationError) as exc:
+        PurchaseOrderItemCreate(**payload)
+    locs = {err["loc"] for err in exc.value.errors()}
+    assert locs == {("currency",), ("unit",)}
+
+
+def test_po_item_purchase_order_uuid_stays_optional():
+    """Deliberately optional: a PO can be created with its items nested."""
+    item = PurchaseOrderItemCreate(**_po_item())
+    assert item.purchase_order_uuid is None
+
+
+# --------------------------------------------------------------------------
+# The IntegrityError handler must separate "you are missing a field" from
+# "you collided with an existing row"
+# --------------------------------------------------------------------------
+
+NOT_NULL_DETAIL = (
+    'null value in column "currency" of relation "purchase_order_item" '
+    "violates not-null constraint"
+)
+
+
+def test_not_null_column_is_extracted_from_the_postgres_message():
+    assert _not_null_column(NOT_NULL_DETAIL) == "currency"
+
+
+def test_not_null_column_is_none_when_the_message_has_no_column():
+    assert _not_null_column("some other integrity problem") is None
+    assert _not_null_column("") is None
+
+def test_not_null_violation_answers_422_naming_the_column(error_app):
+    res = _raise_on(error_app, "/p1", _integrity(NOT_NULL_DETAIL, NotNullViolation))
+    assert res.status_code == 422, res.get_json()
+    body = res.get_json()
+    assert body["error"] == "'currency' is required"
+    assert body["detail"] == "not_null_violation"
+
+
+def test_not_null_violation_is_detected_by_message_without_psycopg2_class(error_app):
+    """The driver class is the strong signal; the message is the fallback."""
+    res = _raise_on(error_app, "/p2", _integrity(NOT_NULL_DETAIL))
+    assert res.status_code == 422
+    assert res.get_json()["error"] == "'currency' is required"
+
+
+def test_not_null_without_a_named_column_still_avoids_409(error_app):
+    res = _raise_on(
+        error_app, "/p3", _integrity("violates not-null constraint", NotNullViolation)
+    )
+    assert res.status_code == 422
+    assert res.get_json()["error"] == "A required field was missing"
+
+
+def test_a_real_uniqueness_conflict_is_still_409(error_app):
+    res = _raise_on(
+        error_app,
+        "/p4",
+        _integrity(
+            'duplicate key value violates unique constraint "some_uq"', UniqueViolation
+        ),
+    )
+    assert res.status_code == 409, res.get_json()
+    assert res.get_json()["error"] == "Conflicts with an existing record"
+
+
+def test_the_internal_account_conflict_keeps_its_specific_message(error_app):
+    res = _raise_on(
+        error_app,
+        "/p5",
+        _integrity(
+            'duplicate key value violates unique constraint '
+            '"uq_financial_account_internal_currency"',
+            UniqueViolation,
+        ),
+    )
+    assert res.status_code == 409
+    assert "Only one is allowed per currency" in res.get_json()["error"]


### PR DESCRIPTION
Five endpoints answered **500** for well-formed requests, and a sixth blamed the caller for a schema mismatch. Every one was reproduced before being touched, and re-verified after.

## The fixes

**`GET /warehouse/?uuid=` — 500 on every request.** `WarehouseListParams.uuid` was typed `UUID` while `warehouse.uuid` is `character varying(36)`, so the value bound as `::uuid` and Postgres refused the comparison: `operator does not exist: character varying = uuid`. Now `str`, as every other list DTO already had it. I audited all list DTOs — this was the only one.

**`GET /warehouse/?within_polygon=` — 500 on malformed WKT.** Not on all input, as I first reported: a *valid* polygon always worked. `WKTElement` doesn't parse, so bad WKT sailed past the route's `try` (which only catches pydantic errors) and failed inside the query as a psycopg2 geometry parse error. The WKT is now parsed with shapely before it reaches SQL, so bad input is a 400 carrying the real reason — `Invalid polygon: ParseException: Unknown type: 'NOTAPOLYGON'`.

**`GET /trip/?service_area_uuid=` and `?intersects_area=` — 500 always.** Both referenced model attributes that don't exist (`TripModel.service_area_uuid`, `TripModel.geometry`), so they raised `AttributeError` for valid uuids, invalid uuids and every polygon alike. A trip stores `service_area_names`, a `varchar[]` snapshot, so the uuid is resolved to its name and matched against that array — which is what the filter always meant. The polygon column is `distribution_area`.

**`POST /purchase-order-item/` without `currency` — 409 "Conflicts with an existing record".** `currency` and `unit` are NOT NULL columns but were `Optional`, and nothing fills them — not the single-item route, not `PurchaseOrderItemDomain.create_items`, which dumps the DTO straight into the model. Both are now required, so it's a 422 naming them.

## The systemic half

That 409 was the more interesting problem. The global `IntegrityError` handler treated **every** constraint as a conflict, so any NOT NULL violation anywhere in the app sent the caller hunting for a duplicate that never existed. A not-null violation is now a **422 naming the column**; genuine uniqueness conflicts keep their 409, and the internal-account message keeps its specific text.

Auditing every Create DTO against its table found **five more** Optional-vs-NOT NULL pairs: `inventory.lot_id`, `inventory.warehouse_uuid`, `payment.financial_account_uuid`, `purchase_order_item.purchase_order_uuid`, `trip_stop.coordinates`. I deliberately left those alone — a domain fills each one (`lot_id` is generated; `purchase_order_uuid` is optional so a PO can be created with its items nested), so tightening them would break working flows. They're precisely why the handler is the durable fix rather than chasing each DTO.

## Verification

Live, against the running stack:

| Request | Before | After |
|---|---|---|
| `/warehouse/?uuid=<real>` | 500 | **200**, exactly 1 row, correct name |
| `/warehouse/?uuid=<valid, absent>` | 500 | 200, 0 rows |
| `/warehouse/?within_polygon=garbage` | 500 | **400** + parse reason |
| `/warehouse/?within_polygon=<valid>` | 200 | 200, 1 in-polygon row of 6 total |
| `/trip/?service_area_uuid=<real>` | 500 | **200** |
| `/trip/?service_area_uuid=<absent>` | 500 | 404 `ServiceArea not found` |
| `/trip/?intersects_area=<valid>` | 500 | **200** |
| `/trip/?intersects_area=garbage` | 500 | **400** + parse reason |
| `POST /purchase-order-item/` no currency | 409 | **422** `loc: [currency], [unit]` |
| `POST /purchase-order-item/` no `purchase_order_uuid` | 409 conflict | **422** `'purchase_order_uuid' is required` |

**Asserted against independent recomputation, not just "it returns 200":** five service areas return exactly the counts a direct SQL query gives (5/4/3/3/3). For `intersects_area`, I temporarily attached a polygon to one trip and confirmed overlapping, containing and edge-touching areas all match while a disjoint one does not — then set it back to NULL (0 trips with a `distribution_area`, as before).

Regressions checked on the same endpoints: bare list, `name`, valid polygon, `status`, `vehicle_uuid`, and `extra="forbid"` still 422-ing an unknown param.

## Tests

16 new tests, and **each of the three code fixes was mutation-tested** — reverting any one fails exactly the tests that cover it:

| Reverted | Result |
|---|---|
| warehouse uuid back to `UUID` | 2 failed |
| PO item currency/unit back to Optional | 3 failed |
| drop the NOT NULL branch | 3 failed |

Full suite failure set is **byte-identical to main** (`comm` on sorted FAILED lists: zero new, zero fixed). The 237 pre-existing failures are a broken auth fixture that 401s the route tests — unrelated, and unchanged here.

No frontend or app changes.