### PR TITLE
Let a material's sku be corrected while it is in use

### DIFF
--- a/backend/app/domains/material/domain.py
+++ b/backend/app/domains/material/domain.py
@@ -15,9 +15,18 @@ from app.entrypoint.routes.common.errors import BadRequestError
 
 class MaterialDomain:
 
+    # Frozen once a material is in use, because existing rows would silently
+    # change meaning: quantities and costs already recorded are denominated in
+    # measure_unit, and type decides how the material is handled (a PO of a
+    # raw_material becomes stock; a product does not).
+    #
+    # sku is deliberately NOT here. It is a label, not a unit of account: no
+    # table stores a copy of it, and every report joins on material_uuid and
+    # reads the current value — so correcting a mistyped code re-labels the
+    # history rather than misstating it. It stays globally unique, which
+    # update_material checks before writing.
     SENSITIVE_UPDATE_FIELDS = [
         'measure_unit',
-        'sku',
         'type'
     ]
 
@@ -50,6 +59,24 @@ class MaterialDomain:
         # save, so keying on presence rejected harmless edits (renaming, or
         # adding a description) for any material that had ever been stocked,
         # priced or ordered — which is nearly all of them.
+        # sku is unique across the whole table, so a collision would otherwise
+        # surface as an IntegrityError 500 on commit. Checked with a raw query
+        # because the constraint is global while the repositories are scoped to
+        # one account — a clash with another tenant's code still has to be
+        # reported as a clash, not as a server error.
+        if 'sku' in data and data['sku'] != m.sku:
+            clash = (
+                uow.session.query(MaterialModel)
+                .filter(
+                    MaterialModel.sku == data['sku'],
+                    MaterialModel.uuid != m.uuid,
+                    MaterialModel.is_deleted == False,  # noqa: E712
+                )
+                .first()
+            )
+            if clash:
+                raise BadRequestError(f"SKU {data['sku']!r} is already used by another material")
+
         changed_sensitive = [
             field for field in data
             if field in MaterialDomain.SENSITIVE_UPDATE_FIELDS

--- a/backend/tests/domains/test_material_update_guard.py
+++ b/backend/tests/domains/test_material_update_guard.py
@@ -54,12 +54,29 @@ class _Repo:
         self.saved = model
 
 
+class _Session:
+    """Stands in for the raw query the sku-uniqueness check makes."""
+
+    def __init__(self, clash=None):
+        self._clash = clash
+
+    def query(self, _model):
+        return self
+
+    def filter(self, *_args):
+        return self
+
+    def first(self):
+        return self._clash
+
+
 class _Uow:
     """Every relation repository reports the same answer, which is enough:
     the guard only asks 'is this material referenced anywhere'."""
 
-    def __init__(self, material, in_use):
+    def __init__(self, material, in_use, sku_clash=None):
         self.material_repository = _Repo(material)
+        self.session = _Session(sku_clash)
         for name in (
             "pricing_repository", "customer_order_item_repository",
             "inventory_repository", "purchase_order_item_repository",
@@ -68,8 +85,8 @@ class _Uow:
             setattr(self, name, _Repo(has_relation=in_use))
 
 
-def _update(material, in_use, **fields):
-    uow = _Uow(material, in_use)
+def _update(material, in_use, sku_clash=None, **fields):
+    uow = _Uow(material, in_use, sku_clash)
     dto = MaterialDomain.update_material(
         uow=uow, uuid=material.uuid, payload=MaterialUpdate(**fields)
     )
@@ -104,10 +121,36 @@ def test_changing_the_unit_of_an_in_use_material_is_refused():
         _update(m, in_use=True, measure_unit="liters")
 
 
-def test_changing_the_sku_of_an_in_use_material_is_refused():
+def test_the_sku_of_an_in_use_material_CAN_be_changed():
+    """A sku is a label, not a unit of account: nothing stores a copy, and
+    every report joins on material_uuid and reads the current value — so
+    correcting a mistyped code re-labels history rather than misstating it."""
     m = make_material()
-    with pytest.raises(BadRequestError, match="sku"):
-        _update(m, in_use=True, sku="PNT-2")
+    _, dto = _update(m, in_use=True, sku="PNT-CORRECTED")
+    assert dto.sku == "PNT-CORRECTED"
+
+
+def test_sku_and_name_can_be_changed_together_on_an_in_use_material():
+    m = make_material()
+    _, dto = _update(m, in_use=True, name="Roasted peanuts", sku="RPNT-1")
+    assert (dto.name, dto.sku) == ("Roasted peanuts", "RPNT-1")
+
+
+def test_a_sku_already_taken_is_refused_cleanly():
+    """The column is globally unique, so without this the collision would
+    surface as an IntegrityError 500 at commit."""
+    m = make_material()
+    with pytest.raises(BadRequestError, match="already used"):
+        _update(m, in_use=True, sku="TAKEN-1", sku_clash=object())
+
+
+def test_reposting_the_same_sku_is_not_treated_as_a_collision():
+    """The form sends sku on every save; matching itself must not trip the
+    uniqueness check (the query excludes the row being edited, but the
+    equality short-circuit means it is never even run)."""
+    m = make_material()
+    _, dto = _update(m, in_use=True, name="Renamed", sku=m.sku, sku_clash=object())
+    assert dto.name == "Renamed"
 
 
 def test_changing_the_type_of_an_in_use_material_is_refused():
@@ -119,9 +162,9 @@ def test_changing_the_type_of_an_in_use_material_is_refused():
 def test_the_refusal_names_every_offending_field():
     m = make_material()
     with pytest.raises(BadRequestError) as exc:
-        _update(m, in_use=True, sku="PNT-2", measure_unit="liters", name="fine")
+        _update(m, in_use=True, type="product", measure_unit="liters", name="fine")
     message = str(exc.value)
-    assert "sku" in message and "measure_unit" in message
+    assert "type" in message and "measure_unit" in message
 
 
 def test_a_refused_change_leaves_the_material_untouched():


### PR DESCRIPTION
## What

`name` was already editable on an in-use material; `sku` was not — so a mistyped code became permanent the moment the material was stocked, priced or ordered. This unfreezes `sku`.

## Why this is safe, and why the other two stay frozen

`sku` is a **label, not a unit of account**. Checked before changing it: **no table stores a copy** — every reader (the warehouse analytics join, the material list filter) resolves it live through `material_uuid`. So correcting a code *re-labels* the history rather than misstating it.

`measure_unit` and `type` stay frozen, because those genuinely change what existing rows mean: quantities and costs already recorded **are** denominated in the unit, and `type` decides whether a purchase becomes stock at all.

## The uniqueness check that unfreezing requires

`sku` is `unique=True` **across the whole table**, so without a pre-check a collision arrives as an `IntegrityError` 500 at commit. Added one, with two deliberate details:

- **A raw query, not the repository.** The constraint is global while repositories are scoped to one account — a clash with *another tenant's* code still has to read as a clash, not a server error.
- **Short-circuits when unchanged.** The detail form posts `sku` on every save, so matching itself must not trip the check.

## Verified against the live API

| Attempt (material with stock + events) | Result |
|---|---|
| `name` + `sku` changed together | **200** — both applied |
| `sku` another material already holds | **400** `"SKU 'IV-71f56ef3' is already used by another material"` |
| `measure_unit` change | **400** — still frozen |
| `type` change | **400** — still frozen |

11 tests in `tests/domains/test_material_update_guard.py` (was 8). Suite vs main: 227 failed / 358 passed, no new failures.

Backend only. No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)