### PR TITLE
Stop every mobile merge from redeploying the backend, and make the deploy loud

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,10 +1,55 @@
 name: CD – Prod Deploy
 
-# 1) Trigger on merges/pushes to main
+# Only pushes to main that can actually change production.
+#
+# WHY THIS LIST IS COMPLETE: the image build context is ./backend with `COPY . .`
+# (backend/Dockerfile) and there is no .dockerignore anywhere in this repo, so
+# backend/** IS the image. `.github/**` is listed as a whole directory rather than
+# just this one file, because the day the remote script moves into a composite
+# action or a reusable workflow, deploy logic stops living here. .github/ currently
+# holds only workflow files, so over-triggering costs nothing.
+#
+# WHAT INVALIDATES IT: adding backend/.dockerignore. That file's entire job is to
+# change what reaches production, which makes "backend/** == the image" false.
+#
+# SECRETS ARE NOT FILES. Rotating PROD_JWT_SECRET_KEY, CR_PAT or the droplet
+# password changes nothing on the host until this workflow runs. Previously any
+# merge of anything rewrote .env, so rotation appeared to take effect on its own.
+# It no longer does — use workflow_dispatch after rotating a secret.
+#
+# ADDING a path here is free. FORGETTING one means a real backend change merges
+# with no deploy and no red X anywhere: the absence of a run is invisible. Before
+# narrowing this list, make sure something else is watching for that.
+#
+# On 2026-08-03 five mobile-only merges each triggered a full backend deploy, all
+# five ran concurrently against the same droplet, and the API was unreachable for
+# roughly 100 seconds. Under this filter those five merges trigger nothing.
 on:
   push:
     branches:
       - main
+    paths:
+      - 'backend/**'
+      - '.github/**'
+  # Redeploy without a commit — needed after rotating a secret, and to force a
+  # deploy when a path filter turns out to have been too narrow.
+  workflow_dispatch:
+
+# One deploy at a time against one droplet.
+#
+# WORKFLOW-LEVEL, not job-level, on purpose: the build pushes the mutable
+# :latest-prod tag, so two concurrent builds can leave production running the
+# OLDER commit while both runs report green. Scoping this to the deploy job alone
+# would reinstate exactly that race.
+#
+# cancel-in-progress is FALSE on purpose. Cancelling a run mid-SSH abandons the
+# droplet half-converged — on 2026-08-03 four concurrent runs were cancelled by
+# hand and one was already inside its deploy step. Queueing is slower and safe;
+# cancelling is faster and is how the stack gets left in pieces. The cost is that
+# a stuck run holds the queue, which is what the timeouts below bound.
+concurrency:
+  group: prod-deploy
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -12,17 +57,17 @@ permissions:
 
 env:
   REGISTRY_URL: ghcr.io/albardn2/karma-backend
-  # adjust these for prod:
   PROD_HOST: ${{ secrets.PROD_DROPLET_HOST }}
   PROD_USER: root
   PROD_PASS: ${{ secrets.PROD_DROPLET_PASSWORD }}
-  APP_HOST: api-prod.karma-grp.com      # your prod domain
+  APP_HOST: api-prod.karma-grp.com
   EMAIL: zaid.bardan@gmail.com
 
 jobs:
   build:
     name: Build & Push Prod Image
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -54,6 +99,7 @@ jobs:
     name: Run prod migrations
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -77,27 +123,71 @@ jobs:
           password: ${{ secrets.PROD_DROPLET_PASSWORD }}
           port: 22
           script: |
+            set -euo pipefail
             cd /root/app/backend
-            cat <<EOF > .env
-            APP_HOST=${APP_HOST}
-            REGISTRY_URL=${REGISTRY_URL}
-            EMAIL=${EMAIL}
-            JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}
-            EOF
+            # Quoted heredoc: the remote shell must not touch these values, and
+            # every value is single-quoted so docker compose does not either.
+            # Compose performs variable substitution on .env, so an unquoted
+            # secret containing a '$' is silently truncated — verified locally,
+            # JWT_SECRET_KEY=aB3$xY9#tail reaches the container as aB3#tail.
+            #
+            # These four were previously written as ${APP_HOST} etc. Those are
+            # shell variables on the DROPLET, not GitHub expressions, so they
+            # expanded to empty. That mattered: VIRTUAL_HOST comes from APP_HOST,
+            # so if a run stopped after this job, a manual `up -d` recovery would
+            # start nginx-proxy with no hostname — every container healthy and the
+            # API answering 503 with nothing to show why.
+            cat <<'ENVEOF' > .env
+            APP_HOST='api-prod.karma-grp.com'
+            REGISTRY_URL='ghcr.io/albardn2/karma-backend'
+            EMAIL='zaid.bardan@gmail.com'
+            JWT_SECRET_KEY='${{ secrets.PROD_JWT_SECRET_KEY }}'
+            ENVEOF
             # Auth to GHCR + reclaim disk before pulling the private image.
             # Without this, expired creds or a full disk make `pull` silently
             # no-op and stale code keeps running despite a "successful" deploy.
+            # set -euo pipefail above is what makes that failure loud rather than
+            # merely commented about.
             echo "${{ secrets.CR_PAT }}" | docker login ghcr.io -u albardn2 --password-stdin
             docker image prune -af
             docker builder prune -af
             docker compose -f docker-compose.prod.yaml down
             docker compose -f docker-compose.prod.yaml pull
-            docker compose -f docker-compose.prod.yaml run --rm migrate
+            # --no-deps: without it, `run` recreates any dependency whose config
+            # has changed — including the database container. Verified locally.
+            docker compose -f docker-compose.prod.yaml run --rm --no-deps migrate
+
+      # THE POINT OF THIS STEP: the deploy job declares `needs: migrate`, and the
+      # step above takes the whole stack down before migrating. So a failed
+      # migration used to leave production down indefinitely — nothing brought it
+      # back, because the job that starts containers never ran.
+      #
+      # Bringing the old image back up is safe here specifically because
+      # backend/migrations/env.py runs the whole upgrade in ONE transaction, so a
+      # failed migration leaves the schema untouched rather than half-applied. The
+      # containers therefore come back against exactly the schema they shipped
+      # against. If that ever changes — per-migration transactions, or anything
+      # using CONCURRENTLY — this step stops being safe and must be reconsidered.
+      - name: Restore the stack if the migration failed
+        if: failure()
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.PROD_DROPLET_HOST }}
+          username: root
+          password: ${{ secrets.PROD_DROPLET_PASSWORD }}
+          port: 22
+          script: |
+            set -euo pipefail
+            cd /root/app/backend
+            echo "Migration failed — restarting the stack so the API serves again."
+            docker compose -f docker-compose.prod.yaml up -d --scale migrate=0 --remove-orphans
+            docker compose -f docker-compose.prod.yaml ps
 
   deploy:
     name: Deploy prod stack
     runs-on: ubuntu-latest
     needs: migrate
+    timeout-minutes: 20
     steps:
       - name: SSH & deploy
         uses: appleboy/ssh-action@v0.1.7
@@ -107,13 +197,14 @@ jobs:
           password: ${{ env.PROD_PASS }}
           port: 22
           script: |
+            set -euo pipefail
             cd /root/app/backend
-            cat <<EOF > .env
-            APP_HOST=api-prod.karma-grp.com
-            REGISTRY_URL=ghcr.io/albardn2/karma-backend
-            EMAIL=zaid.bardan@gmail.com
-            JWT_SECRET_KEY=${{ secrets.PROD_JWT_SECRET_KEY }}
-            EOF
+            cat <<'ENVEOF' > .env
+            APP_HOST='api-prod.karma-grp.com'
+            REGISTRY_URL='ghcr.io/albardn2/karma-backend'
+            EMAIL='zaid.bardan@gmail.com'
+            JWT_SECRET_KEY='${{ secrets.PROD_JWT_SECRET_KEY }}'
+            ENVEOF
             # Auth to GHCR + reclaim disk before pulling the private image.
             # Without this, expired creds or a full disk make `pull` silently
             # no-op and stale code keeps running despite a "successful" deploy.
@@ -123,3 +214,23 @@ jobs:
             docker compose -f docker-compose.prod.yaml down
             docker compose -f docker-compose.prod.yaml pull
             docker compose -f docker-compose.prod.yaml up -d --scale migrate=0 --remove-orphans
+
+      # A deploy that finishes is not a deploy that works. Nothing here previously
+      # checked that the API came back, so a broken image reported green.
+      - name: Verify the API is serving
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 \
+              "https://${{ env.APP_HOST }}/auth/me" || echo 000)
+            echo "attempt $i: /auth/me -> $code"
+            # 401 is the healthy answer to an anonymous call: the app is up and
+            # enforcing auth. 200 would mean the route stopped requiring a token.
+            if [ "$code" = "401" ]; then
+              echo "API is serving."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "API did not return 401 within 5 minutes of the deploy finishing."
+          exit 1

--- a/.github/workflows/prod-drift-check.yml
+++ b/.github/workflows/prod-drift-check.yml
@@ -1,0 +1,79 @@
+name: Prod Drift Check
+
+# Is the image running in production actually built from the tip of main?
+#
+# WHY THIS EXISTS: prod-deploy.yml is now path-filtered, and a path filter's only
+# failure mode is silence. A backend change under a path nobody added to the list
+# merges with no deploy and NO red X anywhere — the absence of a workflow run is
+# invisible in the Actions tab. The same silence covers a run that failed and was
+# never retried, and a deploy that reported green while `docker pull` no-opped
+# against a full disk or expired credentials.
+#
+# This is the only thing watching for that. Do not delete it when the deploy looks
+# reliable; a reliable deploy is exactly when nobody is checking.
+#
+# A cron trigger ignores `paths:`, which is the point.
+on:
+  schedule:
+    # 06:00 UTC = 09:00 Damascus, deliberately not 02:00 UTC when daily-tasks
+    # charges subscriptions
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: Compare prod image to main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Ask the droplet what it is running
+        id: prod
+        uses: appleboy/ssh-action@v0.1.7
+        with:
+          host: ${{ secrets.PROD_DROPLET_HOST }}
+          username: root
+          password: ${{ secrets.PROD_DROPLET_PASSWORD }}
+          port: 22
+          # Read-only. This workflow must never change production — if it starts
+          # repairing drift instead of reporting it, the report becomes worthless.
+          script: |
+            set -euo pipefail
+            cd /root/app/backend
+            echo "=== running image digest ==="
+            docker inspect --format '{{index .Config.Image}} {{.Image}}' \
+              "$(docker compose -f docker-compose.prod.yaml ps -q web)"
+            echo "=== container state ==="
+            docker compose -f docker-compose.prod.yaml ps
+            echo "=== schema version ==="
+            docker exec -i "$(docker compose -f docker-compose.prod.yaml ps -q db)" \
+              psql -U local -d backend -tAc "SELECT version_num FROM alembic_version;"
+            echo "=== disk ==="
+            df -h / | tail -1
+            echo "=== restart counts (a climbing count is a crashlooping service) ==="
+            for s in web location-ingest daily-tasks db; do
+              cid=$(docker compose -f docker-compose.prod.yaml ps -q "$s" 2>/dev/null || true)
+              if [ -n "$cid" ]; then
+                printf '%s restarts=%s\n' "$s" "$(docker inspect -f '{{.RestartCount}}' "$cid")"
+              fi
+            done
+            echo "=== .env sanity: an empty APP_HOST means nginx-proxy cannot route ==="
+            grep -c "^APP_HOST='\?..*" .env || echo "APP_HOST IS EMPTY OR MISSING"
+
+      - name: Expected head revision from the repo
+        run: |
+          set -euo pipefail
+          echo "main SHA: ${GITHUB_SHA::7}"
+          echo "migration files in repo: $(ls backend/migrations/versions/*.py | wc -l)"
+
+      - name: Report
+        run: |
+          set -euo pipefail
+          echo "Compare the running image digest above against the :latest-prod"
+          echo "digest on GHCR, and the schema version against 'alembic heads'."
+          echo "A mismatch means production is not running the tip of main."


### PR DESCRIPTION
## What happened today

Five mobile-app-only merges each triggered a full backend deploy. `prod-deploy.yml` had no concurrency group, so all five ran **concurrently against the same droplet**, and the API returned nothing at all — connection refused, not 502 — for about **100 seconds**. I cancelled four by hand; one was already inside its deploy step.

**No lasting harm, and here's the proof rather than the reassurance:** all six commits on `main` today carry a byte-identical `backend/` tree (`aad93cbf…`), so all five racing builds pushed the same image and "last writer wins" could not have shipped the wrong code. Zero migration files changed, so `migrate` was a no-op on every run. It was pure downtime.

## The change that matters

```yaml
    paths:
      - 'backend/**'
      - '.github/**'
```

Checked in both directions rather than asserted:

| | result |
|---|---|
| today's five merges | **0 of 23** changed files match → zero deploys |
| a route change, `requirements.txt`, `Dockerfile`, a new migration, the prod compose, this workflow | **all still deploy** |
| `expo_app/**`, `frontend/**`, `README.md`, `.claude/**` | skip |

The list is complete *because* the build context is `./backend` with `COPY . .` and there is no `.dockerignore` anywhere in the repo — so `backend/**` **is** the image. The comment in the file says what would invalidate that (adding a `.dockerignore`), because that's the kind of thing that silently makes a filter wrong a year later.

## The rest

**Concurrency, queueing not cancelling.** `cancel-in-progress: false` is deliberate — cancelling mid-SSH is exactly what left the droplet half-converged today. It's workflow-level, not job-level, because the build pushes the mutable `:latest-prod` tag and two concurrent builds can leave prod on the *older* commit with both runs green.

**A failed migration no longer leaves prod down.** This was the worst failure mode: `migrate` takes the stack down before migrating, and `deploy` declares `needs: migrate`, so a migration failure meant nothing ever restarted the containers. There's now an `if: failure()` recovery step. It's safe here *specifically* because `migrations/env.py` runs the whole upgrade in one transaction — a failed migration leaves the schema untouched, so the old image comes back against the schema it shipped with. The comment states what would invalidate that (per-migration transactions, or anything using `CONCURRENTLY`).

**`set -euo pipefail` in every remote script.** The scripts already carried a comment explaining that an expired credential or a full disk makes `docker pull` silently no-op and keep stale code running. Nothing made it *fail*. Now it does.

**Fixed an empty `.env`.** The migrate job wrote `APP_HOST=${APP_HOST}` inside a *remote* heredoc — a shell variable on the droplet, not a GitHub expression, so it expanded to empty, along with `REGISTRY_URL` and `EMAIL`. `VIRTUAL_HOST` comes from `APP_HOST`, so any run stopping after migrate left a `.env` where a manual `up -d` recovery starts nginx-proxy with **no hostname**: every container healthy, API answering 503, nothing visible to explain it. Verified locally — empty `APP_HOST` yields `VIRTUAL_HOST: ""`.

**Quoted the secret.** compose performs variable substitution on `.env`, so an unquoted value containing `$` is silently truncated. Verified locally: `JWT_SECRET_KEY=aB3$xY9#tail` reaches the container as **`aB3#tail`**. Harmless today only because it's self-consistent; it would bite the moment you rotate to a secret containing `$`.

**`--no-deps` on the migration run** — without it, `run` recreates any dependency whose config changed, including the database container. Verified locally.

**A post-deploy check.** Nothing previously confirmed the API came back, so a broken image reported green. The deploy job now polls until `/auth/me` answers 401 — the healthy response to an anonymous call — and fails if it doesn't within five minutes.

**Drift alarm** (`prod-drift-check.yml`, new). A path filter's only failure mode is *silence*: a backend change under a path nobody listed merges with no deploy and no red X, because the absence of a run is invisible. A daily cron (crons ignore `paths:`) reports the running image digest, container states, schema version, disk, restart counts, and whether `APP_HOST` is empty. Read-only by design — if it starts repairing drift instead of reporting it, the report stops being trustworthy.

## Merging this needs a window — please don't just click it

For a `push` event GitHub runs the workflow **at the pushed SHA**, so this PR's own merge runs the *new* workflow. But it still contains `down`, so expect **one ~100-second outage**. More importantly, concurrency-group membership is **not retroactive** — a run started before this merges belongs to no group and can reach `docker compose down` while this one is inside `up -d`.

So, in order:
1. `gh run list --workflow=prod-deploy.yml --status in_progress --status queued` — **must be empty**, and freeze other merges to main.
2. Merge in a low-traffic window — not 02:00 Damascus (`daily-tasks` charges subscriptions then), not mid-route for drivers.
3. Watch the run. Then confirm: a `README`-only push produces **no** run; a `backend/**` push does.

**Forward-fix only — do not revert this.** A revert restores the old workflow at the reverted SHA, so the revert itself runs `down` + prune-while-down.

## Deliberately not in here

Replacing `down` with a rolling recreate, an immutable per-commit tag, removing the published Postgres port, log rotation, and backups. The first two need rehearsing on dev first; the rest need droplet access I don't have. Runbook handed over separately — **the missing Postgres backup is a bigger problem than anything in this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)