### PR TITLE
App: label the customer filter on the orders list

### DIFF
--- a/expo_app/app/customer-orders.tsx
+++ b/expo_app/app/customer-orders.tsx
@@ -75,6 +75,11 @@ export default function CustomerOrdersScreen() {
         onCreate={() => router.push('/customer-orders/create')}
         header={
           <View style={styles.customerFilter}>
+            {/* labelled, because unlabelled it reads as a stray form field rather than
+                a filter — the picker's own placeholder is just "Choose…" */}
+            <ThemedText style={styles.filterLabel}>
+              {t('customerOrders.filterCustomer')}
+            </ThemedText>
             <PickerField
               spec={{
                 endpoint: '/customer/',
@@ -162,6 +167,7 @@ export default function CustomerOrdersScreen() {
 const styles = StyleSheet.create({
   root: { flex: 1 },
   customerFilter: { marginBottom: 12 },
+  filterLabel: { fontSize: 12, fontWeight: '600', opacity: 0.6, marginBottom: 6 },
   clearBtn: { alignSelf: 'flex-start', paddingVertical: 6, paddingHorizontal: 2 },
   clearText: { fontSize: 13, color: '#5469D4', fontWeight: '600' },
   card: {

--- a/expo_app/i18n/translations.ts
+++ b/expo_app/i18n/translations.ts
@@ -900,6 +900,7 @@ export const translations: Record<Lang, Record<string, string>> = {
 
   // customer-orders parity (create, notes, void, unfulfil, per-invoice payment)
   'customerOrders.allCustomers': 'All customers',
+  'customerOrders.filterCustomer': 'Filter by customer',
   'customerOrders.notes': 'Notes',
   'customerOrders.notesPlaceholder': 'Order notes…',
   'customerOrders.editNotes': 'Edit notes',
@@ -1814,6 +1815,7 @@ export const translations: Record<Lang, Record<string, string>> = {
 
   // customer-orders parity (create, notes, void, unfulfil, per-invoice payment)
   'customerOrders.allCustomers': 'كل العملاء',
+  'customerOrders.filterCustomer': 'تصفية حسب العميل',
   'customerOrders.notes': 'ملاحظات',
   'customerOrders.notesPlaceholder': 'ملاحظات الطلب…',
   'customerOrders.editNotes': 'تعديل الملاحظات',


### PR DESCRIPTION
The customer filter was a full-width unlabelled box reading only **"Choose…"**, sitting directly under the status chips — so it read as a stray form field rather than a filter. It now says **"Filter by customer"** above it, styled like the form labels elsewhere in the app.

**Verified in the simulator, not just in the bundle** — deep-linked to the screen and screenshotted it: the label renders above the picker, chips above, list below. This is the first change this week where I checked the rendered result rather than only that the code compiled.

## One honest gap

The Arabic string (`تصفية حسب العميل`) is added and the en/ar key sets are in step (850/850, identical order), but it is **not** visually verified. The app takes its language from the signed-in user's profile — it overwrote a local storage change I made to test — so rendering Arabic would mean writing to a production user record, which I won't do unprompted. Flagging it rather than implying I checked.

tsc unchanged at 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)