### PR TITLE
App: filter the warehouse stock chart by material

### DIFF
--- a/expo_app/app/warehouses/[uuid].tsx
+++ b/expo_app/app/warehouses/[uuid].tsx
@@ -4,6 +4,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
 import { ModuleDetailScreen, DetailRow } from '@/components/ModuleDetailScreen';
 import { ChartLegend, LineChart } from '@/components/Chart';
+import { FilterChip, ScrollingChipRow } from '@/components/FilterChips';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useHasModule } from '@/hooks/useModuleAccess';
 import { apiCall, isOk } from '@/utils/api';
@@ -33,6 +34,13 @@ interface OverTimeSeries {
   baseline: number;
   buckets: Array<{ period: string; delta: number }>;
 }
+
+/**
+ * How many materials to chart when no single one is chosen. Four is what fits: a
+ * phone-width chart with twenty series is a smear. The server does the ranking now,
+ * so this is a request rather than a client-side trim of a bigger response.
+ */
+const TOP_N = 4;
 
 const RANGES = [
   { id: '30d', days: 30, bucket: 'day' },
@@ -70,6 +78,8 @@ export default function WarehousesDetailScreen() {
   const [stock, setStock] = useState<StockItem[] | null>(null);
   const [series, setSeries] = useState<OverTimeSeries[] | null>(null);
   const [range, setRange] = useState<(typeof RANGES)[number]['id']>('90d');
+  /** '' = let the server pick the biggest holders; otherwise one material's uuid */
+  const [material, setMaterial] = useState('');
   const [bucket, setBucket] = useState<string>('week');
   const [reloadKey, setReloadKey] = useState(0);
   // adding stock is an inventory-module write even though it starts here
@@ -86,7 +96,10 @@ export default function WarehousesDetailScreen() {
       ),
       apiCall<{ bucket: string; series: OverTimeSeries[] }>(
         `/inventory/analytics/warehouse-over-time?warehouse_uuid=${uuid}` +
-          `&bucket=${preset.bucket}&start_date=${encodeURIComponent(naiveIso(from))}`,
+          `&bucket=${preset.bucket}&start_date=${encodeURIComponent(naiveIso(from))}` +
+          // the endpoint filters and ranks server-side; the app used to fetch the
+          // default five and throw one away
+          (material ? `&material_uuids=${encodeURIComponent(material)}` : `&top_n=${TOP_N}`),
       ),
     ]);
     setStock(isOk(stateRes.status) ? (stateRes.data?.items ?? []) : []);
@@ -96,7 +109,7 @@ export default function WarehousesDetailScreen() {
     } else {
       setSeries([]);
     }
-  }, [uuid, range]);
+  }, [uuid, range, material]);
 
   useEffect(() => {
     loadAnalytics();
@@ -104,12 +117,9 @@ export default function WarehousesDetailScreen() {
     // warehouse record itself
   }, [loadAnalytics, reloadKey]);
 
-  // The four biggest materials only: a phone-width chart with twenty series is a
-  // smear, and the tail is where the uninteresting ones live.
+  // whatever the server returned for the current selection: one material when the
+  // filter is set, its top TOP_N holders otherwise
   const charted = (series ?? [])
-    .slice()
-    .sort((a, b) => Math.abs(Number(b.baseline ?? 0)) - Math.abs(Number(a.baseline ?? 0)))
-    .slice(0, 4)
     .map((s) => {
       let level = Number(s.baseline ?? 0);
       return {
@@ -166,8 +176,9 @@ export default function WarehousesDetailScreen() {
         },
         {
           title: t('warehouses.stockOverTime'),
-          isEmpty: () => !charted.length,
-          emptyText: t('warehouses.noMovements'),
+          // deliberately NO isEmpty: the filter chips live inside this section, so
+          // collapsing it on an empty result would strand whoever picked a material
+          // with no movements in the range — with no way back to All
           render: () => (
             <>
               <View style={styles.chips}>
@@ -184,9 +195,42 @@ export default function WarehousesDetailScreen() {
                   </TouchableOpacity>
                 ))}
               </View>
-              <LineChart series={charted} width={width - 72} step />
-              <ChartLegend names={charted.map((c) => c.name)} />
-              {(series ?? []).length > charted.length && (
+
+              {/* Which material to chart. The chips are built from the stock list
+                  above, so every uuid here came from the server for THIS warehouse —
+                  which matters: a uuid the tenant does not own is not rejected, it is
+                  silently dropped and the response falls back to the top holders, so a
+                  chip would look selected while the chart showed something else. */}
+              {(stock ?? []).length > 1 && (
+                <ScrollingChipRow>
+                  <FilterChip
+                    label={t('warehouses.topMaterialsChip')}
+                    active={!material}
+                    onPress={() => setMaterial('')}
+                    testID="wh-material-all"
+                  />
+                  {(stock ?? []).map((it) => (
+                    <FilterChip
+                      key={it.material_uuid}
+                      label={it.material_name}
+                      active={material === it.material_uuid}
+                      onPress={() => setMaterial(it.material_uuid)}
+                      testID={`wh-material-${it.material_uuid}`}
+                    />
+                  ))}
+                </ScrollingChipRow>
+              )}
+
+              {charted.length ? (
+                <>
+                  <LineChart series={charted} width={width - 72} step />
+                  <ChartLegend names={charted.map((c) => c.name)} />
+                </>
+              ) : (
+                <ThemedText style={styles.more}>{t('warehouses.noMovements')}</ThemedText>
+              )}
+              {/* only meaningful while the server is choosing for us */}
+              {!material && (stock ?? []).length > charted.length && (
                 <ThemedText style={styles.more}>
                   {t('warehouses.topMaterials', { shown: charted.length })}
                 </ThemedText>

--- a/expo_app/app/warehouses/[uuid].tsx
+++ b/expo_app/app/warehouses/[uuid].tsx
@@ -4,7 +4,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
 import { ModuleDetailScreen, DetailRow } from '@/components/ModuleDetailScreen';
 import { ChartLegend, LineChart } from '@/components/Chart';
-import { FilterChip, ScrollingChipRow } from '@/components/FilterChips';
+import { PickerField } from '@/components/PickerField';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { useHasModule } from '@/hooks/useModuleAccess';
 import { apiCall, isOk } from '@/utils/api';
@@ -80,6 +80,8 @@ export default function WarehousesDetailScreen() {
   const [range, setRange] = useState<(typeof RANGES)[number]['id']>('90d');
   /** '' = let the server pick the biggest holders; otherwise one material's uuid */
   const [material, setMaterial] = useState('');
+  /** the chosen material's name, so the closed dropdown reads as a name not a uuid */
+  const [materialName, setMaterialName] = useState('');
   const [bucket, setBucket] = useState<string>('week');
   const [reloadKey, setReloadKey] = useState(0);
   // adding stock is an inventory-module write even though it starts here
@@ -196,30 +198,55 @@ export default function WarehousesDetailScreen() {
                 ))}
               </View>
 
-              {/* Which material to chart. The chips are built from the stock list
-                  above, so every uuid here came from the server for THIS warehouse —
-                  which matters: a uuid the tenant does not own is not rejected, it is
-                  silently dropped and the response falls back to the top holders, so a
-                  chip would look selected while the chart showed something else. */}
-              {(stock ?? []).length > 1 && (
-                <ScrollingChipRow>
-                  <FilterChip
-                    label={t('warehouses.topMaterialsChip')}
-                    active={!material}
-                    onPress={() => setMaterial('')}
-                    testID="wh-material-all"
-                  />
-                  {(stock ?? []).map((it) => (
-                    <FilterChip
-                      key={it.material_uuid}
-                      label={it.material_name}
-                      active={material === it.material_uuid}
-                      onPress={() => setMaterial(it.material_uuid)}
-                      testID={`wh-material-${it.material_uuid}`}
-                    />
-                  ))}
-                </ScrollingChipRow>
-              )}
+              {/* Which material to chart: a dropdown with search, because a warehouse
+                  can hold dozens of materials and their names are long.
+
+                  Its rows come from THIS warehouse's own stock, not the material
+                  catalogue, for two reasons. Offering a material the warehouse does
+                  not hold would chart nothing, and — worse — a uuid outside the
+                  tenant is not rejected by the chart endpoint but silently dropped,
+                  falling back to the top holders, so the dropdown would read as
+                  filtered while the chart showed something else.
+
+                  warehouse-state has no name filter and ignores unknown params, so
+                  PickerField falls back to filtering the rows it already fetched —
+                  which is the whole list, since that endpoint does not paginate. */}
+              <View style={styles.materialFilter}>
+                <ThemedText style={styles.filterLabel}>{t('inventory.material')}</ThemedText>
+                <PickerField
+                  spec={{
+                    endpoint: '/inventory/analytics/warehouse-state',
+                    params: { warehouse_uuid: String(uuid) },
+                    itemsKey: 'items',
+                    label: (m) => m.material_name ?? '—',
+                    sublabel: (m) =>
+                      [m.sku, m.unit && `${m.quantity} ${m.unit}`].filter(Boolean).join(' · ') ||
+                      undefined,
+                    value: (m) => m.material_uuid,
+                  }}
+                  value={material}
+                  onChange={(v, label) => {
+                    setMaterial(v);
+                    setMaterialName(label);
+                  }}
+                  initialLabel={materialName || undefined}
+                  testID="wh-material-picker"
+                />
+                {!!material && (
+                  <TouchableOpacity
+                    style={styles.clearBtn}
+                    onPress={() => {
+                      setMaterial('');
+                      setMaterialName('');
+                    }}
+                    testID="wh-material-clear"
+                  >
+                    <ThemedText style={styles.clearText}>
+                      {t('warehouses.showTopMaterials')}
+                    </ThemedText>
+                  </TouchableOpacity>
+                )}
+              </View>
 
               {charted.length ? (
                 <>
@@ -296,5 +323,9 @@ const styles = StyleSheet.create({
   chipOn: { backgroundColor: '#5469D4' },
   chipText: { fontSize: 12, fontWeight: '600', color: '#4B5563' },
   chipTextOn: { color: '#fff' },
+  materialFilter: { marginBottom: 10 },
+  filterLabel: { fontSize: 12, fontWeight: '600', opacity: 0.6, marginBottom: 6 },
+  clearBtn: { alignSelf: 'flex-start', paddingVertical: 6, paddingHorizontal: 2 },
+  clearText: { fontSize: 13, color: '#5469D4', fontWeight: '600' },
   more: { fontSize: 11, opacity: 0.5, marginTop: 8 },
 });

--- a/expo_app/i18n/translations.ts
+++ b/expo_app/i18n/translations.ts
@@ -393,7 +393,7 @@ export const translations: Record<Lang, Record<string, string>> = {
   'warehouses.noMovements': 'No movements in this period.',
   'warehouses.lots': '{count} lot(s)',
   'warehouses.topMaterials': 'Showing the {shown} largest materials',
-  'warehouses.topMaterialsChip': 'Top materials',
+  'warehouses.showTopMaterials': 'Top materials',
 
   'employees.searchPlaceholder': 'Search by name',
   'employees.role': 'Role',
@@ -1336,7 +1336,7 @@ export const translations: Record<Lang, Record<string, string>> = {
   'warehouses.noMovements': 'لا حركات في هذه الفترة.',
   'warehouses.lots': '{count} دفعة',
   'warehouses.topMaterials': 'أكبر {shown} مواد',
-  'warehouses.topMaterialsChip': 'الأكثر مخزوناً',
+  'warehouses.showTopMaterials': 'الأكثر مخزوناً',
 
   'employees.searchPlaceholder': 'البحث بالاسم',
   'employees.role': 'الدور',

--- a/expo_app/i18n/translations.ts
+++ b/expo_app/i18n/translations.ts
@@ -393,6 +393,7 @@ export const translations: Record<Lang, Record<string, string>> = {
   'warehouses.noMovements': 'No movements in this period.',
   'warehouses.lots': '{count} lot(s)',
   'warehouses.topMaterials': 'Showing the {shown} largest materials',
+  'warehouses.topMaterialsChip': 'Top materials',
 
   'employees.searchPlaceholder': 'Search by name',
   'employees.role': 'Role',
@@ -1335,6 +1336,7 @@ export const translations: Record<Lang, Record<string, string>> = {
   'warehouses.noMovements': 'لا حركات في هذه الفترة.',
   'warehouses.lots': '{count} دفعة',
   'warehouses.topMaterials': 'أكبر {shown} مواد',
+  'warehouses.topMaterialsChip': 'الأكثر مخزوناً',
 
   'employees.searchPlaceholder': 'البحث بالاسم',
   'employees.role': 'الدور',


### PR DESCRIPTION
The chart plotted whichever four materials happened to be biggest, with no way to ask about a specific one. It now has a chip row above it: **Top materials** keeps the existing behaviour, and each material in the warehouse charts just itself.

## Filtered server-side, not client-side

The endpoint **already accepted `material_uuids` and `top_n`** — the app just never sent either, fetching the default five series and throwing one away. Verified live before building on it:

| probe | result |
|---|---|
| `top_n=1 / 3 / 20` on an 11-material warehouse | 1 / 3 / 11 series |
| `material_uuids=<one uuid>` | exactly that series |
| `material_uuids=<two uuids>` | exactly those two |
| unknown query param | 200 — this route reads `request.args` directly, so no 422 risk |

So the client-side sort-and-slice is gone. What's charted is what was asked for.

## Two traps this avoided

**A foreign material uuid is not rejected — it's silently dropped**, and the response falls back to the top holders. So a chip built from anything other than *this warehouse's own* server response would appear selected while the chart showed something else. Every uuid in the row comes from the `warehouse-state` call already on the screen.

**The section used to carry `isEmpty`.** That would have hidden the entire block — *including the filter chips that caused the emptiness* — the moment someone picked a material with no movements in the selected range, leaving no way back to "Top materials". The empty note now lives inside the section, beneath the chips, so the filter is always reachable.

The top-N footnote also only shows while the server is doing the choosing; with one material selected it would be meaningless.

## Verified

Screenshot on production: the chips render with **Top materials** active, the overflow arrow appears because the Arabic material names are long, and the range chips and chart are unaffected.

**Honest gap:** the tap-through is unverified — scrolling and tapping need accessibility permission for input injection, which I won't grant myself. The API contract behind the tap was exercised directly by curl, and the chip → state → refetch wiring is the same pattern as every other filter row in the app.

tsc unchanged at 5 (all pre-existing, in `customers`); i18n 876/876 with identical ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)