### PR TITLE
App: vehicles parity — chart material filter, delete, and stock writes

### DIFF
--- a/expo_app/app/vehicles.tsx
+++ b/expo_app/app/vehicles.tsx
@@ -41,6 +41,11 @@ export default function VehiclesScreen() {
           { id: 'active', label: tef('active'), params: { status: 'active' } },
           { id: 'maintenance', label: tef('maintenance'), params: { status: 'maintenance' } },
           { id: 'inactive', label: tef('inactive'), params: { status: 'inactive' } },
+          // the remaining three VehicleStatus values — the enum has six and the list
+          // offered three, so sold/retired/utilized vehicles were unreachable by filter
+          { id: 'sold', label: tef('sold'), params: { status: 'sold' } },
+          { id: 'retired', label: tef('retired'), params: { status: 'retired' } },
+          { id: 'utilized', label: tef('utilized'), params: { status: 'utilized' } },
         ]}
         keyExtractor={(x) => x.uuid}
         renderItem={(x) => (

--- a/expo_app/app/vehicles/[uuid].tsx
+++ b/expo_app/app/vehicles/[uuid].tsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { StyleSheet, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import { Alert, StyleSheet, TouchableOpacity, useWindowDimensions, View } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { ThemedText } from '@/components/ThemedText';
 import { ModuleDetailScreen, DetailRow } from '@/components/ModuleDetailScreen';
 import { ChartLegend, LineChart } from '@/components/Chart';
+import { PickerField } from '@/components/PickerField';
+import { FilterChip, ScrollingChipRow } from '@/components/FilterChips';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { useAuth } from '@/contexts/AuthContext';
 import { apiCall, isOk } from '@/utils/api';
-import { formatNumericDate } from '@/utils/date';
+import { formatNumericDate, parseTs } from '@/utils/date';
 
 interface Vehicle {
   uuid: string;
@@ -18,6 +21,8 @@ interface Vehicle {
   color?: string | null;
   vin?: string | null;
   notes?: string | null;
+  created_at?: string | null;
+  created_by_uuid?: string | null;
 }
 
 /** A material line carried on this vehicle. `current_quantity` is derived, not stored. */
@@ -40,16 +45,28 @@ interface LotEvent {
 }
 
 const RANGES = [
+  { id: '7d', days: 7 },
   { id: '30d', days: 30 },
   { id: '90d', days: 90 },
   { id: '12m', days: 365 },
+  // the web's own default: no start_date at all
+  { id: 'all', days: null },
 ] as const;
 
-/** Naive ISO — the backend rejects a zone suffix outright with "Invalid date". */
+/**
+ * Naive ISO, no zone suffix.
+ *
+ * NOT because this endpoint rejects one — it accepts `…Z` with a 200 and then
+ * silently shifts the window by the offset, which is worse than a rejection. The
+ * analytics routes DO reject it outright; this one does not. Same output, and the
+ * reason matters if anyone edits this.
+ */
 const naiveIso = (d: Date) => d.toISOString().replace(/\.\d+Z$/, '').replace(/Z$/, '');
 
+/** parseTs, not new Date: the column is naive UTC, so a bare parse shifts every
+ *  label near midnight by the viewer's offset. */
 const tick = (iso: string) => {
-  const d = new Date(iso);
+  const d = parseTs(iso);
   return isNaN(d.getTime()) ? '' : `${d.getMonth() + 1}/${d.getDate()}`;
 };
 
@@ -90,6 +107,7 @@ const PER_PAGE = 100;
 export default function VehiclesDetailScreen() {
   const { uuid } = useLocalSearchParams<{ uuid: string }>();
   const { t, tef } = useLanguage();
+  const { isAdmin } = useAuth();
   const router = useRouter();
   const { width } = useWindowDimensions();
   const [reloadKey, setReloadKey] = useState(0);
@@ -98,6 +116,16 @@ export default function VehiclesDetailScreen() {
     Array<{ name: string; points: Array<{ label: string; value: number }> }>
   >([]);
   const [range, setRange] = useState<(typeof RANGES)[number]['id']>('90d');
+  /**
+   * Which line to chart. Keyed on the LOT uuid rather than the material's, for two
+   * reasons: the event endpoint only accepts vehicle_inventory_uuid, and a unique
+   * index on (vehicle_uuid, material_uuid) where not deleted makes lot and material
+   * one-to-one within a vehicle — so the two keyings are the same thing here.
+   */
+  const [lot, setLot] = useState('');
+  const [lotName, setLotName] = useState('');
+  /** what would be orphaned by a delete: the API has no guard, so the app warns */
+  const [tripCount, setTripCount] = useState<number | null>(null);
   // a sub-fetch that FAILED must not read as a sub-fetch that returned nothing:
   // during development a per_page over the DTO's cap of 100 gave a 422, which the
   // empty-state fallback rendered as "no movements" and very nearly shipped
@@ -113,35 +141,51 @@ export default function VehiclesDetailScreen() {
     setLots(isOk(res.status) ? (res.data?.vehicle_inventories ?? []) : []);
   }, [uuid]);
 
+  // DELETE /vehicle/ has no server guard — it flips is_deleted and leaves the
+  // vehicle's stock rows live under a vehicle that then 404s. The confirm says what
+  // is about to be orphaned, which is the only place that can be said.
+  const loadTripCount = useCallback(async () => {
+    const res = await apiCall<{ total_count?: number }>(`/trip/?vehicle_uuid=${uuid}&per_page=1`);
+    setTripCount(isOk(res.status) ? (res.data?.total_count ?? 0) : null);
+  }, [uuid]);
+
   useEffect(() => {
     loadStock();
-  }, [loadStock, reloadKey]);
+    loadTripCount();
+  }, [loadStock, loadTripCount, reloadKey]);
 
   const loadMovements = useCallback(async () => {
     setMovesFailed(false);
     if (!lots?.length) return setCharted([]);
     const preset = RANGES.find((r) => r.id === range)!;
-    const from = new Date();
-    from.setDate(from.getDate() - preset.days);
+    let fromParam = '';
+    if (preset.days != null) {
+      const from = new Date();
+      from.setDate(from.getDate() - preset.days);
+      fromParam = `&start_date=${encodeURIComponent(naiveIso(from))}`;
+    }
 
     // Biggest lines only, so this is at most MAX_SERIES requests however long the
     // van's manifest is. There is no vehicle_uuid filter on the event endpoint, so
     // the alternative is fetching every vehicle's events and discarding most.
-    const top = lots
-      .slice()
-      .sort(
-        (a, b) => Math.abs(Number(b.current_quantity ?? 0)) - Math.abs(Number(a.current_quantity ?? 0)),
-      )
-      .slice(0, MAX_SERIES);
+    const top = lot
+      ? lots.filter((l) => l.uuid === lot)
+      : lots
+          .slice()
+          .sort(
+            (a, b) =>
+              Math.abs(Number(b.current_quantity ?? 0)) - Math.abs(Number(a.current_quantity ?? 0)),
+          )
+          .slice(0, MAX_SERIES);
 
     const results = await Promise.all(
-      top.map((lot) =>
+      top.map((l) =>
         apiCall<{ events: LotEvent[] }>(
-          `/vehicle-inventory-event/?vehicle_inventory_uuid=${lot.uuid}` +
-            `&start_date=${encodeURIComponent(naiveIso(from))}&per_page=${PER_PAGE}`,
+          `/vehicle-inventory-event/?vehicle_inventory_uuid=${l.uuid}` +
+            `${fromParam}&per_page=${PER_PAGE}`,
         ).then((res) => {
-          if (!isOk(res.status)) return { lot, events: [], ok: false };
-          return { lot, events: res.data?.events ?? [], ok: true };
+          if (!isOk(res.status)) return { lot: l, events: [], ok: false };
+          return { lot: l, events: res.data?.events ?? [], ok: true };
         }),
       ),
     );
@@ -167,7 +211,7 @@ export default function VehiclesDetailScreen() {
         })
         .filter((s) => s.points.length),
     );
-  }, [lots, range]);
+  }, [lots, range, lot]);
 
   useEffect(() => {
     loadMovements();
@@ -187,6 +231,13 @@ export default function VehiclesDetailScreen() {
         [t('vehicles.year'), x.year != null ? String(x.year) : '—'],
         [t('vehicles.color'), x.color || '—'],
         [t('vehicles.vin'), x.vin || '—'],
+        // parseTs, not new Date: created_at is naive UTC
+        [
+          t('inventory.received'),
+          x.created_at ? formatNumericDate(parseTs(x.created_at)) : '—',
+        ],
+        [t('inventory.createdBy'), x.created_by_uuid ?? '—'],
+        [t('materials.uuid'), x.uuid],
       ]}
       sections={[
         {
@@ -196,7 +247,23 @@ export default function VehiclesDetailScreen() {
           render: () => (
             <>
               {(lots ?? []).map((l) => (
-                <View key={l.uuid} style={styles.stockRow}>
+                // tappable: load, unload or correct this line's balance
+                <TouchableOpacity
+                  key={l.uuid}
+                  style={styles.stockRow}
+                  onPress={() =>
+                    router.push({
+                      pathname: '/vehicles/stock-event',
+                      params: {
+                        vehicle_inventory_uuid: l.uuid,
+                        material_name: l.material_name ?? '',
+                        unit: l.unit ?? '',
+                        on_hand: String(l.current_quantity ?? 0),
+                      },
+                    })
+                  }
+                  testID={`veh-lot-${l.uuid}`}
+                >
                   <View style={styles.stockLeft}>
                     <ThemedText style={styles.stockName} numberOfLines={1}>
                       {l.material_name ?? '—'}
@@ -214,34 +281,85 @@ export default function VehiclesDetailScreen() {
                     {qty(Number(l.current_quantity ?? 0))}
                     {l.unit ? ` ${l.unit}` : ''}
                   </ThemedText>
-                </View>
+                </TouchableOpacity>
               ))}
             </>
           ),
         },
         {
           title: t('vehicles.movements'),
-          isEmpty: () => !charted.length,
-          emptyText: movesFailed ? t('moduleList.failed') : t('vehicles.noMovements'),
+          // deliberately NO isEmpty: the material filter lives inside this section, so
+          // collapsing it on an empty result would remove the very control that chose
+          // the quiet material, with no way back to the top lines
           render: () => (
             <>
-              <View style={styles.chips}>
+              {/* a scrolling row, not a plain one: five ranges do not fit 375pt and the
+                  fifth was clipped off the edge of the screen */}
+              <ScrollingChipRow>
                 {RANGES.map((r) => (
-                  <TouchableOpacity
+                  <FilterChip
                     key={r.id}
-                    style={[styles.chip, range === r.id && styles.chipOn]}
+                    label={r.id === '7d' ? t('vehicles.range7d') : t(`expenses.range.${r.id}`)}
+                    active={range === r.id}
                     onPress={() => setRange(r.id)}
                     testID={`veh-range-${r.id}`}
+                  />
+                ))}
+              </ScrollingChipRow>
+
+              {/* Which material to chart: a dropdown with search, sourced from this
+                  vehicle's OWN lots rather than the material catalogue — a material
+                  that is not on the truck would chart nothing. No searchParam: every
+                  vehicle list DTO is extra="forbid", so ?search= 422s the request
+                  rather than being ignored; per_page is raised instead so PickerField
+                  filters the full manifest locally. */}
+              <View style={styles.materialFilter}>
+                <ThemedText style={styles.filterLabel}>{t('inventory.material')}</ThemedText>
+                <PickerField
+                  spec={{
+                    endpoint: '/vehicle-inventory/',
+                    itemsKey: 'vehicle_inventories',
+                    params: { vehicle_uuid: String(uuid), per_page: String(PER_PAGE) },
+                    label: (r) => r.material_name ?? '—',
+                    sublabel: (r) =>
+                      `${qty(Number(r.current_quantity ?? 0))}${r.unit ? ` ${r.unit}` : ''}`,
+                    value: (r) => r.uuid,
+                  }}
+                  value={lot}
+                  onChange={(v, label) => {
+                    setLot(v);
+                    setLotName(label);
+                  }}
+                  initialLabel={lotName || undefined}
+                  testID="veh-material-picker"
+                />
+                {!!lot && (
+                  <TouchableOpacity
+                    style={styles.clearBtn}
+                    onPress={() => {
+                      setLot('');
+                      setLotName('');
+                    }}
+                    testID="veh-material-clear"
                   >
-                    <ThemedText style={[styles.chipText, range === r.id && styles.chipTextOn]}>
-                      {t(`expenses.range.${r.id}`)}
+                    <ThemedText style={styles.clearText}>
+                      {t('warehouses.showTopMaterials')}
                     </ThemedText>
                   </TouchableOpacity>
-                ))}
+                )}
               </View>
-              <LineChart series={charted} width={width - 72} step />
-              <ChartLegend names={charted.map((c) => c.name)} />
-              {(lots ?? []).length > charted.length && (
+
+              {charted.length ? (
+                <>
+                  <LineChart series={charted} width={width - 72} step />
+                  <ChartLegend names={charted.map((c) => c.name)} />
+                </>
+              ) : (
+                <ThemedText style={styles.more}>
+                  {movesFailed ? t('moduleList.failed') : t('vehicles.noMovements')}
+                </ThemedText>
+              )}
+              {!lot && (lots ?? []).length > charted.length && (
                 <ThemedText style={styles.more}>
                   {t('warehouses.topMaterials', { shown: charted.length })}
                 </ThemedText>
@@ -251,6 +369,17 @@ export default function VehiclesDetailScreen() {
         },
       ]}
       actions={[
+        {
+          label: t('vehicles.addMaterial'),
+          testID: 'vehicle-add-material',
+          onPress: (x) => {
+            setReloadKey((k) => k + 1);
+            router.push({
+              pathname: '/vehicles/add-material',
+              params: { vehicle_uuid: x.uuid, plate_number: x.plate_number ?? '' },
+            });
+          },
+        },
         {
           label: t('detail.edit'),
           testID: 'vehicle-edit',
@@ -271,6 +400,34 @@ export default function VehiclesDetailScreen() {
                 notes: x.notes ?? '',
               },
             });
+          },
+        },
+        {
+          label: t('detail.delete'),
+          destructive: true,
+          testID: 'vehicle-delete',
+          // admin-only server-side. There is NO server guard beyond that: the route
+          // flips is_deleted and leaves this vehicle's stock rows live under a
+          // vehicle that then 404s, and its trips keep pointing at it. Nothing can
+          // stop that from here, so the confirm at least says what is about to be
+          // orphaned — and that the plate is gone for good, since plate_number is
+          // unique across every tenant with no exemption for deleted rows.
+          visible: () => isAdmin,
+          confirmText:
+            t('vehicles.deleteConfirm') +
+            (lots?.length || tripCount
+              ? ` ${t('vehicles.deleteStillHas', {
+                  materials: lots?.length ?? 0,
+                  trips: tripCount ?? 0,
+                })}`
+              : ''),
+          onPress: async (x) => {
+            const res = await apiCall(`/vehicle/${x.uuid}`, { method: 'DELETE' });
+            if (isOk(res.status)) return router.replace('/vehicles');
+            Alert.alert(
+              t('vehicles.deleteFailed'),
+              String(res.error ?? '').slice(0, 300) || t('form.tryAgain'),
+            );
           },
         },
       ]}
@@ -305,6 +462,10 @@ const styles = StyleSheet.create({
   chipOn: { backgroundColor: '#5469D4' },
   chipText: { fontSize: 12, fontWeight: '600', color: '#374151' },
   chipTextOn: { color: '#fff' },
+  materialFilter: { marginBottom: 10 },
+  filterLabel: { fontSize: 12, fontWeight: '600', opacity: 0.6, marginBottom: 6 },
+  clearBtn: { alignSelf: 'flex-start', paddingVertical: 6, paddingHorizontal: 2 },
+  clearText: { fontSize: 13, color: '#5469D4', fontWeight: '600' },
   more: { fontSize: 11, opacity: 0.5, marginTop: 8 },
   notes: { marginTop: 18 },
   notesText: { fontSize: 13, opacity: 0.7, lineHeight: 19 },

--- a/expo_app/app/vehicles/add-material.tsx
+++ b/expo_app/app/vehicles/add-material.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { useLocalSearchParams } from 'expo-router';
+import { ModuleForm, FormField } from '@/components/ModuleForm';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+/**
+ * Put a material onto a vehicle — the line, not the quantity.
+ *
+ * This creates the vehicle-inventory row at a balance of zero; loading an amount onto
+ * it is a separate movement, on the stock-event screen. That two-step shape is the
+ * API's, not a choice: POST /vehicle-inventory/ takes no quantity, and the balance is
+ * a derived sum over that line's events. The note says so, because a form that asks
+ * for a material and then reports success with nothing on the truck would otherwise
+ * read as broken.
+ *
+ * THIS is the one screen in the vehicle module where the material CATALOGUE is the
+ * right source — everywhere else the picker must come from the vehicle's own lots,
+ * because everywhere else you are acting on something already aboard. Here you are
+ * adding something that by definition is not.
+ *
+ * One material per vehicle: a unique index on (vehicle_uuid, material_uuid) for live
+ * rows means a repeat is a 400, so the duplicate case gets its own message rather
+ * than the server's phrasing.
+ *
+ * Gated on the module, not on admin: a driver holds vehicle_inventory create, which is
+ * exactly the point — loading a van is the driver's job.
+ */
+export default function VehicleAddMaterialScreen() {
+  const { vehicle_uuid, plate_number } = useLocalSearchParams<{
+    vehicle_uuid: string;
+    plate_number?: string;
+  }>();
+  const { t } = useLanguage();
+
+  const fields: FormField[] = [
+    {
+      name: 'material_uuid',
+      label: t('inventory.material'),
+      required: true,
+      kind: 'picker',
+      picker: {
+        endpoint: '/material/',
+        itemsKey: 'materials',
+        searchParam: 'name',
+        label: (m) => m.name ?? '—',
+        value: (m) => m.uuid,
+        sublabel: (m) =>
+          [m.sku, m.measure_unit ?? m.unit].filter(Boolean).join(' · ') || undefined,
+      },
+    },
+    { name: 'notes', label: t('warehouses.notes'), kind: 'multiline' },
+  ];
+
+  return (
+    <ModuleForm
+      module="vehicles"
+      title={
+        plate_number
+          ? t('vehicles.addMaterialTo', { plate: plate_number })
+          : t('vehicles.addMaterial')
+      }
+      note={t('vehicles.addMaterialNote')}
+      fields={fields}
+      extra={{ vehicle_uuid }}
+      // unit is copied server-side from the material's own measure_unit — sending one
+      // is not just redundant, it would be a second source of truth for the same fact
+      method="POST"
+      endpoint="/vehicle-inventory/"
+      errorMessages={{ 400: t('vehicles.materialAlreadyOn') }}
+    />
+  );
+}

--- a/expo_app/app/vehicles/create.tsx
+++ b/expo_app/app/vehicles/create.tsx
@@ -21,7 +21,9 @@ export default function VehicleFormScreen() {
     { name: 'plate_number', label: t('vehicles.plate'), required: !editing },
     { name: 'make', label: t('vehicles.make'), required: !editing },
     { name: 'model', label: t('vehicles.model'), required: !editing },
-    { name: 'year', label: t('vehicles.year'), required: !editing, kind: 'number' },
+    // the server has NO year bounds at all: 0, -5 and 99999 are all accepted, and a
+    // 32-bit overflow comes back as an HTML 500 page. This is the only guard.
+    { name: 'year', label: t('vehicles.year'), kind: 'number', integer: true, min: 1900, max: new Date().getFullYear() + 1 },
     { name: 'color', label: t('vehicles.color'), required: !editing },
     {
       name: 'status',
@@ -43,6 +45,7 @@ export default function VehicleFormScreen() {
       title={t(editing ? 'form.editTitle' : 'form.createTitle', { what: t('vehicles.one') })}
       fields={fields}
       initial={editing ? initial : undefined}
+      errorMessages={{ 409: t('vehicles.plateTaken') }}
       method={editing ? 'PUT' : 'POST'}
       endpoint={editing ? `/vehicle/${uuid}` : '/vehicle/'}
     />

--- a/expo_app/app/vehicles/stock-event.tsx
+++ b/expo_app/app/vehicles/stock-event.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { useLocalSearchParams } from 'expo-router';
+import { ModuleForm, FormField } from '@/components/ModuleForm';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+/**
+ * Load, unload or correct one material's balance on a vehicle.
+ *
+ * The three movement types are not interchangeable, and the server enforces the
+ * difference: load and unload both take a POSITIVE amount and the domain applies the
+ * sign, while a correction is signed and may be negative. Zero is refused outright for
+ * all three. So the quantity field carries no minimum — a correction of -20 is a legal
+ * body, and a min of 0 would block the one case that needs it.
+ *
+ * Taking more off than the van holds is refused with the balance quoted back. Loading
+ * ONTO an already-negative van is allowed, which sounds wrong and is not: a negative
+ * balance means more was sold than was recorded as loaded, and loading is how that gets
+ * corrected.
+ *
+ * The current balance rides in the note so it is on screen while the number is being
+ * typed. Without it this is a form that asks "how much" with no way to see how much
+ * there is.
+ *
+ * `sale` is a fourth event type the API will happily accept from any client — it is not
+ * system-only, whatever the UI convention suggests. It is deliberately absent here: a
+ * sale belongs to a customer order and a trip stop, and one entered by hand would be
+ * revenue with nothing attached to it.
+ */
+export default function VehicleStockEventScreen() {
+  const { vehicle_inventory_uuid, material_name, unit, on_hand } = useLocalSearchParams<{
+    vehicle_inventory_uuid: string;
+    material_name?: string;
+    unit?: string;
+    on_hand?: string;
+  }>();
+  const { t } = useLanguage();
+
+  const balance = `${on_hand ?? '0'}${unit ? ` ${unit}` : ''}`;
+
+  const fields: FormField[] = [
+    {
+      name: 'event_type',
+      label: t('vehicles.movement'),
+      required: true,
+      kind: 'select',
+      options: [
+        { value: 'manual', label: t('vehicles.eventManual') },
+        { value: 'unload', label: t('vehicles.eventUnload') },
+        { value: 'adjustment', label: t('vehicles.eventAdjust') },
+      ],
+    },
+    {
+      name: 'quantity',
+      label: t('inventory.quantity'),
+      required: true,
+      kind: 'number',
+      // no min: a correction is signed and may legitimately be negative
+    },
+  ];
+
+  return (
+    <ModuleForm
+      module="vehicles"
+      title={
+        material_name ? t('vehicles.updateStock', { material: material_name }) : t('inventory.quantity')
+      }
+      note={`${t('inventory.current')}: ${balance} — ${t('vehicles.qtyNote')}`}
+      fields={fields}
+      extra={{ vehicle_inventory_uuid }}
+      method="POST"
+      endpoint="/vehicle-inventory-event/"
+      // the server refuses an over-decrement with the balance quoted in its own words;
+      // this says the same thing in the app's
+      errorMessages={{ 400: t('vehicles.insufficient') }}
+    />
+  );
+}

--- a/expo_app/components/ModuleForm.tsx
+++ b/expo_app/components/ModuleForm.tsx
@@ -93,6 +93,14 @@ interface ModuleFormProps {
   /** POST to create, PUT to edit */
   method: 'POST' | 'PUT';
   endpoint: string;
+  /**
+   * Friendlier copy for specific failure statuses, e.g. {409: t('vehicles.plateTaken')}.
+   *
+   * apiCall surfaces res.error as raw response TEXT, so without this a duplicate plate
+   * shows the literal {"error":"Conflicts with an existing record"} and a 500 shows an
+   * HTML page. Only override statuses whose meaning is unambiguous for this form.
+   */
+  errorMessages?: Record<number, string>;
   /** where to go after a successful write */
   onDone?: () => void;
 }
@@ -126,6 +134,7 @@ export function ModuleForm({
   note,
   method,
   endpoint,
+  errorMessages,
   onDone,
 }: ModuleFormProps) {
   const router = useRouter();
@@ -219,7 +228,11 @@ export function ModuleForm({
       } else {
         // surface what the server actually said — a 422 names the offending field,
         // and hiding that behind "something went wrong" makes it unfixable
-        Alert.alert(t('form.saveFailed'), String(res.error ?? '').slice(0, 300) || t('form.tryAgain'));
+        Alert.alert(
+          t('form.saveFailed'),
+          errorMessages?.[res.status] ??
+            (String(res.error ?? '').slice(0, 300) || t('form.tryAgain')),
+        );
       }
     } catch (e) {
       Alert.alert(t('form.saveFailed'), t('form.tryAgain'));

--- a/expo_app/i18n/translations.ts
+++ b/expo_app/i18n/translations.ts
@@ -954,6 +954,24 @@ export const translations: Record<Lang, Record<string, string>> = {
   'inventoryEvents.costWarning': 'Leaving the cost blank keeps the current cost. Costs cannot be cleared from the app.',
   'inventoryEvents.deleteConfirm': 'Delete this movement? The lot\'s quantity will change as a result.',
   'inventoryEvents.deleteFailed': 'Failed to delete movement',
+
+  // vehicles parity (delete, stock writes, chart material filter)
+  'vehicles.range7d': '7 days',
+  'vehicles.deleteConfirm': 'Delete this vehicle? Its trips and any stock still loaded on it stay in the system but will no longer belong to a vehicle. The plate number can never be used again.',
+  'vehicles.deleteStillHas': 'It still carries {materials} material line(s) and has {trips} trip(s).',
+  'vehicles.deleteFailed': 'Couldn\'t delete this vehicle',
+  'vehicles.plateTaken': 'That plate number or VIN is already registered. Both are unique across the whole system, not just your company.',
+  'vehicles.addMaterial': 'Add a material',
+  'vehicles.addMaterialTo': 'Add a material — {plate}',
+  'vehicles.addMaterialNote': 'This puts the material on the vehicle with a balance of zero. Load a quantity onto it afterwards by tapping its line.',
+  'vehicles.materialAlreadyOn': 'That material is already on this vehicle.',
+  'vehicles.updateStock': 'Stock — {material}',
+  'vehicles.movement': 'Movement',
+  'vehicles.eventManual': 'Load on',
+  'vehicles.eventUnload': 'Unload',
+  'vehicles.eventAdjust': 'Correct',
+  'vehicles.qtyNote': 'Load and unload take a positive amount. A correction may be negative to take stock off.',
+  'vehicles.insufficient': 'The vehicle does not hold that much. Check what is on hand and try a smaller amount.',
   },
   ar: {
     // trips module (admin)
@@ -1897,5 +1915,23 @@ export const translations: Record<Lang, Record<string, string>> = {
   'inventoryEvents.costWarning': 'ترك التكلفة فارغة يحافظ على التكلفة الحالية. لا يمكن مسح التكلفة من التطبيق.',
   'inventoryEvents.deleteConfirm': 'هل تريد حذف هذه الحركة؟ سيتغير رصيد الدفعة نتيجة لذلك.',
   'inventoryEvents.deleteFailed': 'فشل حذف الحركة',
+
+  // vehicles parity (delete, stock writes, chart material filter)
+  'vehicles.range7d': '٧ أيام',
+  'vehicles.deleteConfirm': 'حذف هذه المركبة؟ ستبقى رحلاتها وأي مخزون محمّل عليها في النظام لكن لن تعود تابعة لأي مركبة. ولا يمكن استخدام رقم اللوحة مرة أخرى.',
+  'vehicles.deleteStillHas': 'ما زالت تحمل {materials} بنداً من المواد ولها {trips} رحلة.',
+  'vehicles.deleteFailed': 'تعذر حذف هذه المركبة',
+  'vehicles.plateTaken': 'رقم اللوحة أو رقم الهيكل مُسجَّل مسبقاً. كلاهما فريد على مستوى النظام بالكامل، وليس على مستوى شركتك فقط.',
+  'vehicles.addMaterial': 'إضافة مادة',
+  'vehicles.addMaterialTo': 'إضافة مادة — {plate}',
+  'vehicles.addMaterialNote': 'يضيف هذا المادة إلى المركبة برصيد صفر. حمّل الكمية عليها بعد ذلك بالضغط على بندها.',
+  'vehicles.materialAlreadyOn': 'هذه المادة موجودة على هذه المركبة بالفعل.',
+  'vehicles.updateStock': 'المخزون — {material}',
+  'vehicles.movement': 'نوع الحركة',
+  'vehicles.eventManual': 'تحميل',
+  'vehicles.eventUnload': 'تنزيل',
+  'vehicles.eventAdjust': 'تصحيح',
+  'vehicles.qtyNote': 'التحميل والتنزيل يأخذان كمية موجبة. أما التصحيح فيمكن أن يكون سالباً لخفض الرصيد.',
+  'vehicles.insufficient': 'لا تحمل المركبة هذه الكمية. راجع المتوفر وجرّب كمية أقل.',
   },
 };


### PR DESCRIPTION
## The chart filter, answered first

**There is no vehicle analytics endpoint.** `/inventory/analytics/vehicle-over-time` and `vehicle-state` both **404** — only the warehouse pair exists. So unlike #103 this can't be filtered server-side.

It doesn't need to be. The app already assembles these series **client-side** from the vehicle's lots plus one events call per lot, so filtering is a selection over data already in hand — no new endpoint, no backend work.

It's keyed on the **lot** uuid, not the material's, for two reasons that happen to agree: the events endpoint accepts only `vehicle_inventory_uuid`, and a unique index on `(vehicle_uuid, material_uuid)` for live rows makes lot↔material one-to-one within a vehicle.

Two hazards avoided:
- **No `searchParam` on the picker.** Every vehicle list DTO is `extra="forbid"` — `?search=` **422s the whole request** rather than being ignored (the opposite of the analytics routes). `per_page` is raised instead so the full manifest filters locally.
- **The section no longer collapses when empty.** It carried `isEmpty`, which would have hidden the filter that *caused* the emptiness the moment someone picked a quiet material.

## Delete — with the warning the API can't give

The route has no guard beyond the scope check: it flips `is_deleted` and leaves the vehicle's stock rows **live under a vehicle that then 404s**, while its trips keep pointing at it. Nothing client-side can prevent that, so the confirm counts what's about to be orphaned — material lines and trips — and says the plate is gone for good, because `plate_number` is unique across **every tenant** with no exemption for deleted rows.

## Stock writes — the web features the app had none of

Adding a material creates the line at zero (the API takes no quantity there; the balance is a derived sum), and each on-board line is now tappable to **load / unload / correct**.

The three movement types aren't interchangeable: load and unload take a positive amount with the sign applied server-side, while a correction is **signed and may be negative** — so the quantity field carries no minimum, since `min: 0` would block the only case that needs it. The current balance sits in the note, on screen while you type.

`sale` is deliberately absent. The API accepts it from any client — it is *not* system-only whatever the UI suggests — but a sale entered by hand is revenue with no order or trip stop attached.

Both screens gate on the **module, not admin**: a driver holds exactly these grants, and loading a van is the driver's job.

## Also

Three missing status chips (six enum values; `sold`/`retired`/`utilized` were unreachable), metadata rows, a 7-day and an all-time range, and **year bounds on create** — the server has *none*: 0, −5 and 99999 are all accepted, and a 32-bit overflow returns an HTML 500 page. Plus a new `errorMessages` prop on `ModuleForm`, so a duplicate plate reads as English instead of raw `{"error":…}`.

## Two bugs found by looking, not reading

- Adding two ranges **overflowed the chip row and clipped the fifth off the screen edge**. It scrolls now, like every other chip row in the app. My regression, caught in the screenshot.
- `tick()` parsed naive UTC with a bare `new Date`, shifting labels near midnight by the viewer's offset. Uses `parseTs` now. The comment claiming this endpoint *rejects* a zone suffix is also **false** — it accepts one and silently shifts the window, which is worse. Right behaviour, wrong reason, now stated correctly.

## Verified

Screenshot on production: actions at the top, metadata rows, the tappable on-board line, the range row, the **Material** dropdown, and the chart. tsc **5** (all pre-existing, in `customers`); i18n **892/892**, identical order.

**Not verified:** the tap-through on any of it — input injection needs accessibility permission I won't grant myself.

**Flagged, not fixed (backend, one character):** `?status=active` also matches every `inactive` vehicle, because the filter uses `ilike('%active%')`. `'inactive' ILIKE '%active%'` is true. The app's Active chip is wrong today and gets worse the moment a tenant deactivates a van; the fix is `==` instead of `ilike` in `routes/vehicle/routes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)