### PR TITLE
Allow the prod deploys to be triggered manually

### DIFF
--- a/.github/workflows/frontend-prod-deploy.yml
+++ b/.github/workflows/frontend-prod-deploy.yml
@@ -8,6 +8,11 @@ on:
     paths:
       - 'frontend/**'
       - '.github/workflows/frontend-prod-deploy.yml'
+  # Manual re-run, for the same reason as the backend deploy: a failed or
+  # wedged run otherwise needs a fresh push to main to retry. The path filter
+  # above also means a backend-only merge never refreshes the frontend, so
+  # this is the only way to redeploy it on demand.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -5,6 +5,13 @@ on:
   push:
     branches:
       - main
+  # Manual re-run. Without this, a prod deploy that fails or gets wedged has no
+  # retry path: the only way to trigger it is another push to main, so a fix
+  # already merged can sit undeployed while someone invents a commit to nudge
+  # it. Happened on 94aebe5 — the build hung for 15 minutes, was cancelled,
+  # both deploy jobs skipped, and re-running the run left it queued
+  # indefinitely.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

Both prod deploy workflows fire **only** on a push to `main`. So a run that fails or gets wedged has **no retry path** — the only way to trigger another is to push again, i.e. invent a commit to nudge a fix that is already merged.

Not hypothetical. It is blocking right now:

- `94aebe5` (the purchase-order fix) triggered `CD – Prod Deploy` at 17:47
- The image build **hung 15 minutes** against a ~2 minute norm, then was cancelled
- `Run prod migrations` and `Deploy prod stack` were both **skipped**
- Re-running the run left it **queued indefinitely** while unrelated workflows completed normally
- `gh run cancel` refused it as "already completed" while `gh run view` still reported `queued`

Net effect: **a merged fix sitting undeployed with nothing to press.** GitHub's UI re-run hits the same wedged run.

## What

`workflow_dispatch:` on both prod deploys.

The frontend one needs it for a second reason too: its `paths:` filter means a backend-only merge never refreshes the frontend, so a manual trigger is the only way to redeploy it on demand.

## Note

Merging this is itself a push to `main`, so it will trigger a fresh `CD – Prod Deploy` — which is what finally ships the purchase-order fix in `94aebe5`. After that, both deploys are re-runnable from the Actions tab without inventing commits.

Workflow files only. No app code, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)