### PR TITLE
Dashboards (1/n): reporting-currency conversion on /dashboard/overview

### DIFF
--- a/backend/app/domains/exchange_rate/converter.py
+++ b/backend/app/domains/exchange_rate/converter.py
@@ -1,0 +1,139 @@
+"""One place that turns money in one currency into money in another, at a date.
+
+This is the money-layer promotion of the conversion that inventory costing has
+done for a while (InventoryDomain._usd_syp_rate_for_day / _unit_cost_in_target).
+Dashboards restate revenue, spend and debt into a single reporting currency, and
+the rule that math must obey is the same one costing already follows:
+
+  - the rate is the one whose market day is NEAREST the amount's own day, in
+    either direction and with no distance cap — the market does not move every
+    day, so an exact-day lookup would miss constantly. `ExchangeRateDomain.closest`
+    already answers exactly this.
+  - a genuine hole (no rate within a week, and the day young enough that the
+    source could still reach it) triggers ONE backfill per converter instance,
+    always the full year, so a single pull fixes every gap this request and every
+    later one will hit.
+  - when there is no usable rate at all, or the currency is one this system does
+    not convert, the answer is None — "unknown", never a fabricated number and
+    never silently zero. The caller decides what to do with an unknown; it must
+    not average a wrong figure into a total.
+
+Rates are per-account (ExchangeRate.account_uuid is NOT NULL), so a converter is
+scoped to whatever account the unit of work is scoped to.
+
+WHY THIS DOES NOT SUM ACROSS CURRENCIES BLINDLY. The app's standing rule is that
+SYP and USD are never added together — they are ~orders of magnitude apart, and a
+July 2026 redenomination divided every SYP figure (and every stored SYP rate) by
+100. Converting each amount at its OWN day's rate before summing is the one way to
+combine them honestly: both sides of the multiply are post-redenomination
+new-pounds, so the conversion never straddles that boundary, and the result is a
+real single-currency total rather than a meaningless mixed sum.
+"""
+
+from __future__ import annotations
+
+from datetime import date as date_type
+from typing import Optional
+
+from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+from app.domains.exchange_rate.domain import ExchangeRateDomain
+from app.dto.common_enums import Currency
+from app.dto.exchange_rate import BackfillRange
+
+
+class CurrencyConverter:
+    """Convert amounts into one target currency, caching each day's rate.
+
+    One instance per request: the rate cache and the backfill-once latch both
+    live on it, so a dashboard that converts thousands of orders across a window
+    does at most one rate lookup per distinct day and at most one backfill pull.
+    """
+
+    # A rate within this many days of the amount is "the rate in effect"; the
+    # source skips idle market days, so a miss inside this window is normal and
+    # is NOT a reason to go pull data. Mirrors InventoryDomain.
+    RATE_GAP_TOLERANCE_DAYS = 7
+    # sp-today's history bottoms out around a year; a pull can never reach
+    # further, so never fire one for older days.
+    RATE_SOURCE_REACH_DAYS = 365
+
+    def __init__(self, uow: SqlAlchemyUnitOfWork, target: Currency):
+        self.uow = uow
+        self.target = target
+        self._rates: dict = {}          # day -> USD->SYP rate, or None
+        self._backfill_attempted = False
+        # observability for the caller: did we have to pull, and did any amount
+        # come back unconvertible
+        self.rates_ingested = False
+
+    def _usd_syp_rate_for_day(self, day: date_type) -> Optional[float]:
+        """USD→SYP rate for one market day, cached, with a single backfill on a gap.
+
+        Never raises: a dashboard tile must not 500 because sp-today is down.
+        """
+        if day in self._rates:
+            return self._rates[day]
+
+        row = ExchangeRateDomain.closest(
+            uow=self.uow, from_currency=Currency.USD, to_currency=Currency.SYP, on=day
+        )
+        gap_is_fine = (
+            row is not None
+            and abs((row.rate_date - day).days) <= self.RATE_GAP_TOLERANCE_DAYS
+        )
+        source_can_reach = (date_type.today() - day).days <= self.RATE_SOURCE_REACH_DAYS
+        if not gap_is_fine and source_can_reach and not self._backfill_attempted:
+            self._backfill_attempted = True
+            try:
+                ExchangeRateDomain.backfill(uow=self.uow, backfill_range=BackfillRange.ONE_YEAR)
+                self.rates_ingested = True
+                row = (
+                    ExchangeRateDomain.closest(
+                        uow=self.uow,
+                        from_currency=Currency.USD,
+                        to_currency=Currency.SYP,
+                        on=day,
+                    )
+                    or row
+                )
+            except Exception:
+                # unreachable source is a missing rate, not a crash
+                pass
+
+        rate = row.rate if row else None
+        self._rates[day] = rate
+        return rate
+
+    def convert(self, amount, source_currency, on) -> Optional[float]:
+        """`amount` restated in the target currency, or None if it cannot be.
+
+        None means "unknown" — no source currency, a currency this system does
+        not convert, or no usable rate anywhere near the day. The caller excludes
+        it rather than averaging in a number off by a factor of the rate.
+        """
+        if amount is None:
+            return None
+        if amount == 0:
+            # zero is zero in every currency, and needs no rate — so a real
+            # zero stays known even when the rate table cannot answer
+            return 0.0
+        if source_currency is None:
+            return None
+        try:
+            source = Currency(source_currency)
+        except ValueError:
+            return None
+        if source == self.target:
+            return float(amount)
+
+        day = on.date() if hasattr(on, "date") else on
+        rate = self._usd_syp_rate_for_day(day)
+        if rate is None or rate <= 0:
+            return None
+        if source == Currency.SYP and self.target == Currency.USD:
+            return float(amount) / rate
+        if source == Currency.USD and self.target == Currency.SYP:
+            return float(amount) * rate
+        # any other pair is unconvertible today (USD<->SYP is the only pair the
+        # rate table holds); unknown, not a guess
+        return None

--- a/backend/app/entrypoint/routes/dashboard/routes.py
+++ b/backend/app/entrypoint/routes/dashboard/routes.py
@@ -6,7 +6,9 @@ from flask_jwt_extended import jwt_required
 from sqlalchemy import func
 
 from app.adapters.unit_of_work.sqlalchemy_unit_of_work import SqlAlchemyUnitOfWork
+from app.domains.exchange_rate.converter import CurrencyConverter
 from app.dto.auth import PermissionScope
+from app.dto.common_enums import Currency
 from app.entrypoint.routes.common.auth import scopes_required
 from app.entrypoint.routes.dashboard import dashboard_blueprint
 from models.common import (
@@ -16,6 +18,21 @@ from models.common import (
     Payment as PaymentModel,
     Trip as TripModel,
 )
+
+# When the caller names no reporting currency, USD is the reference unit: it is
+# stable against SYP volatility and the redenomination, so a converted total is
+# comparable across the whole window. A tenant can still ask for SYP explicitly.
+DEFAULT_TARGET_CURRENCY = Currency.USD
+
+
+def _target_currency() -> Currency:
+    raw = (request.args.get("target_currency") or "").strip().upper()
+    try:
+        return Currency(raw) if raw else DEFAULT_TARGET_CURRENCY
+    except ValueError:
+        # an unknown target is a client mistake, not a reason to 500 a landing
+        # page; fall back to the default rather than reject
+        return DEFAULT_TARGET_CURRENCY
 
 
 def _day(dt) -> str:
@@ -42,6 +59,8 @@ def overview():
     except ValueError:
         days_window = 30
 
+    target = _target_currency()
+
     now = datetime.utcnow()
     start = (now - timedelta(days=days_window - 1)).replace(
         hour=0, minute=0, second=0, microsecond=0
@@ -51,13 +70,44 @@ def overview():
     with SqlAlchemyUnitOfWork() as uow:
         s = uow.session
 
+        # One converter per request: it caches each day's rate and pulls at most
+        # once, so restating a whole window of orders costs one rate lookup per
+        # distinct day. Every amount is converted at ITS OWN day's rate before it
+        # is summed — the only honest way to combine SYP and USD into one number.
+        conv = CurrencyConverter(uow, target)
+
+        # An amount that cannot be converted (a currency with no rate anywhere)
+        # is never zeroed into the total; it is counted here and reported raw, so
+        # a converted headline can always say "plus N records not converted".
+        # With USD<->SYP the only pair and a full year of rates, this stays empty
+        # in practice, but the contract must be able to admit a gap.
+        unconv_count: dict = defaultdict(int)
+        unconv_raw: dict = defaultdict(float)
+
+        def _add(bucket_total, bucket_by_day, cur, day, amount, when):
+            """Sum the raw per-currency figure AND the converted one, or bank the
+            unconvertible amount for honest disclosure."""
+            bucket_total[cur] += amount
+            bucket_by_day[cur][day] += amount
+            c = conv.convert(amount, cur if cur != "?" else None, when)
+            if c is None:
+                if amount:
+                    unconv_count[cur] += 1
+                    unconv_raw[cur] += amount
+                return None
+            return c
+
         # ---- money metrics from orders created in the window ----
-        # totals/series keyed by currency; amount_due needs the hybrid props,
-        # so iterate the window's orders (dashboard windows are bounded)
+        # per-currency maps kept as-is (existing consumers read them); converted
+        # totals/series added alongside. amount_due needs the hybrid props, so
+        # iterate the window's orders (dashboard windows are bounded).
         revenue_total: dict = defaultdict(float)
         debt_total: dict = defaultdict(float)
         revenue_by_day: dict = defaultdict(lambda: defaultdict(float))
         orders_by_day: dict = defaultdict(int)
+        revenue_conv_total = 0.0
+        debt_conv_total = 0.0
+        revenue_conv_by_day: dict = defaultdict(float)
         orders_count = 0
         window_orders = (
             s.query(CustomerOrderModel)
@@ -72,15 +122,26 @@ def overview():
             cur = o.currency or "?"
             day = _day(o.created_at)
             total = o.total_adjusted_amount or 0
-            revenue_total[cur] += total
-            revenue_by_day[cur][day] += total
-            debt_total[cur] += o.net_amount_due or 0
+            rc = _add(revenue_total, revenue_by_day, cur, day, total, o.created_at)
+            if rc is not None:
+                revenue_conv_total += rc
+                revenue_conv_by_day[day] += rc
+            due = o.net_amount_due or 0
+            debt_total[cur] += due
+            dc = conv.convert(due, cur if cur != "?" else None, o.created_at)
+            if dc is not None:
+                debt_conv_total += dc
+            elif due:
+                unconv_count[cur] += 1
+                unconv_raw[cur] += due
             orders_by_day[day] += 1
             orders_count += 1
 
         # ---- collected: payments in the window (skip deleted/voided chains) ----
         collected_total: dict = defaultdict(float)
         collected_by_day: dict = defaultdict(lambda: defaultdict(float))
+        collected_conv_total = 0.0
+        collected_conv_by_day: dict = defaultdict(float)
         payments = (
             s.query(PaymentModel)
             .outerjoin(InvoiceModel, PaymentModel.invoice_uuid == InvoiceModel.uuid)
@@ -95,8 +156,11 @@ def overview():
         for p in payments:
             cur = p.currency or "?"
             day = _day(p.created_at)
-            collected_total[cur] += p.amount or 0
-            collected_by_day[cur][day] += p.amount or 0
+            amount = p.amount or 0
+            cc = _add(collected_total, collected_by_day, cur, day, amount, p.created_at)
+            if cc is not None:
+                collected_conv_total += cc
+                collected_conv_by_day[day] += cc
 
         # ---- counts: new customers + trips per day ----
         new_customers_rows = (
@@ -137,6 +201,9 @@ def overview():
             "to": now.isoformat(),
             "days": days_window,
             "currencies": currencies,
+            # what the converted figures below are denominated in, echoed back so
+            # a client that fell back to the default knows which currency it got
+            "target_currency": target.value,
             "totals": {
                 "revenue": dict(revenue_total),
                 "collected": dict(collected_total),
@@ -144,6 +211,20 @@ def overview():
                 "new_customers": sum(customers_by_day.values()),
                 "orders": orders_count,
                 "trips": sum(trips_by_day.values()),
+            },
+            # single-currency figures: every amount restated at its own day's
+            # rate and summed. These are what the revamped dashboards read; the
+            # per-currency maps above stay for the existing consumers.
+            "totals_converted": {
+                "revenue": round(revenue_conv_total, 2),
+                "collected": round(collected_conv_total, 2),
+                "window_debt": round(debt_conv_total, 2),
+            },
+            # non-empty only when some amount had no rate to convert by; never
+            # folded into the totals above
+            "unconverted": {
+                "count": sum(unconv_count.values()),
+                "by_currency": {k: round(v, 2) for k, v in unconv_raw.items()},
             },
             "series": {
                 "revenue": {
@@ -155,6 +236,10 @@ def overview():
                 "new_customers": _series(day_keys, customers_by_day),
                 "orders": _series(day_keys, orders_by_day),
                 "trips": _series(day_keys, trips_by_day),
+            },
+            "series_converted": {
+                "revenue": _series(day_keys, revenue_conv_by_day),
+                "collected": _series(day_keys, collected_conv_by_day),
             },
         }
     return jsonify(result), 200


### PR DESCRIPTION
First step of the dashboard revamp. Establishes the shared, invariant-sensitive foundation everything else reuses: a currency converter and a `/dashboard/overview` that returns one comparable total instead of a per-currency split. **Backend only — no client changes yet**, and fully backward-compatible, so nothing that reads the current per-currency fields breaks.

## The rule this reverses, deliberately

Everywhere else in the app, SYP and USD are never added together. Dashboards need the opposite — a single number you can compare across a window — so this **converts each amount at its own day's exchange rate and sums the result**. `target_currency` **converts, never filters**: no currency's data is dropped, it's restated.

## What's here

**`app/domains/exchange_rate/converter.py`** — a `CurrencyConverter` that promotes the conversion inventory costing already does (nearest-day rate via `ExchangeRateDomain.closest`, one backfill pull per request on a genuine gap, `None` when there's no usable rate) up to the money layer. One instance per request caches each day's rate, so a whole window of orders costs one lookup per distinct day. It never fabricates a rate and never silently zeroes — an unconvertible amount comes back `None` for the caller to disclose.

**`/dashboard/overview`** gains an optional `target_currency` (default **USD**) and, *alongside* the untouched per-currency maps, returns `totals_converted`, `series_converted`, and an `unconverted` bucket (count + raw by-currency) for anything with no rate.

## Why it's safe across the July 2026 redenomination

Migration `f2a7b3d91c05` divided every stored SYP money column **and** every SYP-quoted `exchange_rate` row by 100 in one shot, so both sides of the multiply are post-redenomination new-pounds — a convert-at-date never crosses a 100× boundary. Verified against the live rate curve: 132.875 on 2026-07-26, 129.875 on 2026-07-30, no cliff.

## Verification

- **8/8 converter invariants** (run in-container against real data): same-currency passthrough applies no rate; SYP→USD→SYP round-trips; a date with no exact rate uses the nearest recorded day (2026-07-24 → 2026-07-23); no 100× cliff at the boundary; unknown/null currency → unconvertible, not a guess; zero converts to 0 with no rate.
- **Live endpoint**: same window to USD vs SYP is consistent at ~132 SYP/USD (matches the real curve); USD-native passes through 1:1 when target is USD; `unconverted` is 0 on real data (USD+SYP only, full-year coverage).
- **Backward-compatible**: `totals.revenue` and every existing per-currency field are byte-identical to before.
- Full backend suite still collects (617 tests, no import breakage). The 20 failing inventory-route tests **pre-date this change** — they build `Inventory(...)` with a `cost_per_unit` kwarg the model dropped, and reproduce with this change reverted.

## Decisions taken with the user

Default reporting currency **USD**; missing-rate policy is **nearest recorded date, no tolerance cap** (already how `closest()` behaves — a genuine rate hole only leaves an amount unconverted, which the data never triggers); **USD+SYP only** convertible pair for now; existing per-module analytics screens **stay**.

## Next (not in this PR)

Web Business Overview and app Business Overview consuming `totals_converted`/`series_converted` with a convert-mode currency selector; then Sales, Field-Ops, Spend, Inventory dashboards as thin re-slices through this same converter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)