### PR TITLE
Dashboards (2/n): assign dashboards per role from the super-admin console

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -79,6 +79,7 @@ def _load_request_identity():
         RESOURCE_SET,
         endpoint_allowed,
         effective_permissions,
+        dashboards_for_scope,
         perms_version,
     )
     try:
@@ -166,11 +167,16 @@ def _load_request_identity():
         g.user_scopes = set((user.permission_scope or "").split(","))
         # effective perms: explicit checklist or role preset (None = admin)
         g.user_acl = effective_permissions(user)
+        # which dashboards this role may see (None = admin, all). Resolved from
+        # the ROLE, not the ACL, so it reaches users with a custom per-user
+        # checklist too.
+        g.user_dashboards = dashboards_for_scope(user.permission_scope)
         # Fingerprint of what governs this caller, emitted on every response by
         # _emit_perms_version below. Computed here because this is the one place
-        # that has all four inputs already resolved and DB-fresh.
+        # that has all the inputs already resolved and DB-fresh.
         g.perms_version = perms_version(
-            g.user_scopes, g.user_acl, g.account_perms, g.account_verified
+            g.user_scopes, g.user_acl, g.account_perms, g.account_verified,
+            g.user_dashboards,
         )
 
     if request.blueprint in RESOURCE_SET:

--- a/backend/app/entrypoint/routes/auth/routes.py
+++ b/backend/app/entrypoint/routes/auth/routes.py
@@ -345,6 +345,12 @@ def me():
             account = uow.account_repository.find_one(uuid=imp_account)
             dto["impersonating_account_uuid"] = imp_account
             dto["impersonating_company"] = account.company_name if account else None
+        # the dashboards this user's role may see, resolved server-side. None
+        # means all (admin/superuser); a list means exactly these ids, ordered.
+        # Both clients render `catalog ∩ this ∩ screens-this-build-ships`, so an
+        # id a client does not recognise is simply not drawn. Read from `g` (set
+        # at the chokepoint) so it and perms_version agree.
+        dto["dashboards"] = getattr(g, "user_dashboards", None)
         # The baseline a client compares later responses against. Read from `g`
         # rather than recomputed here so the body and the X-Perms-Version header
         # can never disagree — computing it twice from two code paths is how a

--- a/backend/app/entrypoint/routes/common/permissions.py
+++ b/backend/app/entrypoint/routes/common/permissions.py
@@ -143,6 +143,129 @@ MODULE_SET = set(MODULES)
 ACTION_SET = set(ACTIONS)
 
 
+# ---------------------------------------------------------------------------
+# DASHBOARDS — which of the pre-defined dashboards each role may see.
+#
+# A separate concern from `modules`/`endpoints`, deliberately. The `dashboard`
+# module answers "can this user reach the Dashboards section at all"; this map
+# answers "which dashboards render inside it". Keeping it out of the module
+# namespace means a dashboard never shows up as a toggle in the per-user CRUD
+# checklist, and — because it resolves from the ROLE directly rather than from a
+# user's frozen permissions column — a platform-owner change to a role's
+# dashboards reaches every user of that role, including ones who carry a
+# customised per-user ACL. Platform-wide, like ROLE_PRESETS: one config for all
+# tenants, written only by the platform owner.
+#
+# THE CATALOG is the single place a dashboard is declared. A client renders
+# whichever of these it actually ships a screen for; an id it does not recognise
+# is silently ignored (never a crash), so a new dashboard added here stays
+# invisible until a build ships its screen. Adding a dashboard = one entry here
+# + one screen per client + its translation keys.
+DASHBOARD_CATALOG = [
+    {"id": "business-overview", "title_key": "dashboards.businessOverview", "order": 1},
+    {"id": "sales-performance", "title_key": "dashboards.salesPerformance", "order": 2},
+    {"id": "field-ops", "title_key": "dashboards.fieldOps", "order": 3},
+    {"id": "spend", "title_key": "dashboards.spend", "order": 4},
+    {"id": "inventory-health", "title_key": "dashboards.inventoryHealth", "order": 5},
+]
+DASHBOARD_IDS = {d["id"] for d in DASHBOARD_CATALOG}
+_DASHBOARD_ORDER = {d["id"]: d["order"] for d in DASHBOARD_CATALOG}
+
+# Baseline role -> dashboard ids. An absent role sees none. admin/superuser see
+# every dashboard (resolved to None below) and are never stored here. A role only
+# actually reaches these if it ALSO holds the `dashboard` module (role_presets) —
+# today that is accountant + operation_manager; granting a dashboard to another
+# role presupposes granting it the module too.
+DASHBOARD_DEFAULTS = {
+    "operation_manager": ["business-overview", "sales-performance", "field-ops", "spend", "inventory-health"],
+    "accountant": ["business-overview", "spend"],
+    "sales_manager": ["business-overview", "sales-performance", "field-ops"],
+    "sales": ["sales-performance", "field-ops"],
+    "sales_associate": ["sales-performance", "field-ops"],
+    "warehouse_keeper": ["inventory-health"],
+    "operator": [],
+    "driver": [],
+}
+
+# Platform-owner overrides live in platform_setting under this key, as
+# {role: [dashboard_id, ...]} for OVERRIDDEN roles only — absent means "use the
+# DASHBOARD_DEFAULTS baseline for that role".
+ROLE_DASHBOARDS_SETTING_KEY = "role_dashboards"
+_dash_override_cache: dict = {"at": None, "value": {}}
+
+
+def invalidate_role_dashboards() -> None:
+    """Drop the cached dashboard overrides so the next read hits the database."""
+    _dash_override_cache["at"] = None
+
+
+def role_dashboard_overrides() -> dict:
+    """Platform-owner overrides for role dashboards, cached with the same short
+    TTL and the same authorization-path safety as role_overrides()."""
+    import time
+
+    now = time.monotonic()
+    at = _dash_override_cache["at"]
+    if at is not None and (now - at) < _ROLE_OVERRIDE_TTL_SECONDS:
+        return _dash_override_cache["value"]
+
+    try:
+        from app.adapters.unit_of_work.sqlalchemy_unit_of_work import (
+            SqlAlchemyUnitOfWork,
+        )
+        from models.common import PlatformSetting
+
+        with SqlAlchemyUnitOfWork(account_uuid=None) as uow:
+            row = (
+                uow.session.query(PlatformSetting)
+                .filter_by(key=ROLE_DASHBOARDS_SETTING_KEY)
+                .one_or_none()
+            )
+            value = dict(row.value) if row and row.value else {}
+    except Exception:
+        # same rule as role_overrides: this sits on the auth path, so a
+        # transient DB problem serves the last known value rather than 500ing
+        return _dash_override_cache["value"]
+
+    _dash_override_cache["at"] = now
+    _dash_override_cache["value"] = value
+    return value
+
+
+def resolved_role_dashboards() -> dict:
+    """Every configurable role's dashboard ids: the override where one exists,
+    else the baseline. Only ids still in the catalog survive, so retiring a
+    dashboard cannot leave a dangling grant."""
+    overrides = role_dashboard_overrides()
+    out = {}
+    for role in DASHBOARD_DEFAULTS:
+        ids = overrides[role] if role in overrides else DASHBOARD_DEFAULTS[role]
+        out[role] = [i for i in (ids or []) if i in DASHBOARD_IDS]
+    return out
+
+
+def dashboards_for_scope(permission_scope):
+    """Ordered dashboard ids a scope may see, or None for admin/superuser (all).
+
+    Mirrors effective_permissions' admin bypass: None means "every dashboard",
+    a list means exactly these. Deduped across a comma-joined scope and ordered
+    by the catalog so both clients render the same sequence.
+    """
+    scopes = set((permission_scope or "").split(","))
+    if scopes & _ADMIN_SCOPES:
+        return None
+    resolved = resolved_role_dashboards()
+    seen: set = set()
+    out: list = []
+    for s in scopes:
+        for did in resolved.get(s, []):
+            if did not in seen:
+                seen.add(did)
+                out.append(did)
+    out.sort(key=lambda i: _DASHBOARD_ORDER.get(i, 999))
+    return out
+
+
 _ADMIN_SCOPES = {"admin", "superuser"}
 
 
@@ -193,7 +316,7 @@ def endpoint_allowed(permissions: dict, blueprint: str, method: str) -> bool:
     return action in allowed
 
 
-def perms_version(scopes, user_acl, account_perms, account_verified) -> str:
+def perms_version(scopes, user_acl, account_perms, account_verified, dashboards="__unset__") -> str:
     """A short fingerprint of everything that governs what a client may see.
 
     The server revokes access on the caller's very next request, because the
@@ -218,15 +341,21 @@ def perms_version(scopes, user_acl, account_perms, account_verified) -> str:
     """
     import hashlib
 
+    governing = {
+        "scopes": sorted(s for s in (scopes or []) if s),
+        "acl": user_acl,
+        "account": account_perms,
+        "verified": bool(account_verified),
+    }
+    # The set of dashboards a role sees governs visibility too, so an edit to it
+    # must move the fingerprint and tell open clients to re-read. Only folded in
+    # when the caller passes it (sentinel default), so a caller that predates this
+    # — a test, say — keeps its old fingerprint rather than forcing a spurious
+    # refresh; the one caller that matters (the request chokepoint) passes it.
+    if dashboards != "__unset__":
+        governing["dashboards"] = dashboards
+
     payload = json.dumps(
-        {
-            "scopes": sorted(s for s in (scopes or []) if s),
-            "acl": user_acl,
-            "account": account_perms,
-            "verified": bool(account_verified),
-        },
-        sort_keys=True,
-        separators=(",", ":"),
-        default=str,
+        governing, sort_keys=True, separators=(",", ":"), default=str
     )
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]

--- a/backend/app/entrypoint/routes/dashboard/routes.py
+++ b/backend/app/entrypoint/routes/dashboard/routes.py
@@ -18,6 +18,21 @@ from models.common import (
 )
 
 
+@dashboard_blueprint.route("/catalog", methods=["GET"])
+@jwt_required()
+def catalog():
+    """The pre-defined set of dashboards, declared once server-side.
+
+    The single source of truth that the super-admin assignment matrix, both
+    clients' labels/ordering, and the assignment validator all read, so a new
+    dashboard is declared in exactly one place. Open to any authenticated user:
+    it is a static menu of ids and label keys, not data.
+    """
+    from app.entrypoint.routes.common.permissions import DASHBOARD_CATALOG
+
+    return jsonify(DASHBOARD_CATALOG), 200
+
+
 def _day(dt) -> str:
     return dt.strftime("%Y-%m-%d") if dt else ""
 

--- a/backend/app/entrypoint/routes/super_admin/routes.py
+++ b/backend/app/entrypoint/routes/super_admin/routes.py
@@ -514,3 +514,149 @@ def impersonate(account_uuid: str):
             "company_name": account.company_name,
         }
     return jsonify(result), 200
+
+
+# ---------------------------------------------------------------------------
+# Role -> dashboards: which of the pre-defined dashboards each role sees.
+# Platform-wide, like role-presets: one config for every tenant, written only by
+# the platform owner. A separate concern from role permissions, so it lives in
+# its own PlatformSetting key and never appears in the CRUD permission checklist.
+# ---------------------------------------------------------------------------
+
+
+def _role_dashboards_payload(uow):
+    """Every configurable role's dashboard ids, plus what the matrix needs to act
+    safely: the baseline (so it can offer reset + show what an override changed),
+    whether each role is overridden, and how many users follow the role."""
+    from app.entrypoint.routes.common.permissions import (
+        DASHBOARD_CATALOG,
+        DASHBOARD_DEFAULTS,
+        resolved_role_dashboards,
+        role_dashboard_overrides,
+    )
+    from models.common import User as UserModel
+
+    overrides = role_dashboard_overrides()
+    resolved = resolved_role_dashboards()
+    counts = dict(
+        uow.session.query(UserModel.permission_scope, func.count(UserModel.uuid))
+        .filter(UserModel.is_deleted.is_(False), UserModel.permissions.is_(None))
+        .group_by(UserModel.permission_scope)
+        .all()
+    )
+    return {
+        "catalog": DASHBOARD_CATALOG,
+        "roles": {
+            role: {
+                "dashboards": resolved[role],
+                "baseline": DASHBOARD_DEFAULTS[role],
+                "is_overridden": role in overrides,
+                "following_count": counts.get(role, 0),
+            }
+            for role in DASHBOARD_DEFAULTS
+        },
+    }
+
+
+@super_admin_blueprint.route("/settings/role-dashboards", methods=["GET"])
+@scopes_required(SUPER)
+def get_role_dashboards():
+    """Per-role dashboard assignment for the super-admin matrix."""
+    with SqlAlchemyUnitOfWork(account_uuid=None) as uow:
+        result = _role_dashboards_payload(uow)
+    return jsonify(result), 200
+
+
+@super_admin_blueprint.route("/settings/role-dashboards/<string:role>", methods=["PUT"])
+@scopes_required(SUPER)
+def set_role_dashboards(role: str):
+    """Set which dashboards one role sees, platform-wide.
+
+    Takes effect without a deploy: the perms-version fingerprint folds the
+    dashboard set in, so every open client of a user following this role re-reads
+    /auth/me on its next request and re-renders its dashboard strip.
+    """
+    from pydantic import BaseModel, ConfigDict, field_validator
+    from app.entrypoint.routes.common.permissions import (
+        DASHBOARD_DEFAULTS,
+        DASHBOARD_IDS,
+        ROLE_DASHBOARDS_SETTING_KEY,
+        invalidate_role_dashboards,
+    )
+    from models.common import PlatformSetting
+
+    # admin/superuser are excluded: they see every dashboard by construction, so
+    # an entry for them would be stored, shown, and silently ignored.
+    if role not in DASHBOARD_DEFAULTS:
+        raise BadRequestError(
+            f"unknown role {role!r} — must be one of {sorted(DASHBOARD_DEFAULTS)}"
+        )
+
+    class _Body(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        dashboards: list[str]
+
+        @field_validator("dashboards")
+        @classmethod
+        def _known_ids(cls, v):
+            # reject unknown ids rather than store a dangling grant no client can
+            # ever render; dedupe while preserving order
+            seen, out = set(), []
+            for i in v:
+                if i not in DASHBOARD_IDS:
+                    raise ValueError(
+                        f"unknown dashboard {i!r} — must be one of {sorted(DASHBOARD_IDS)}"
+                    )
+                if i not in seen:
+                    seen.add(i)
+                    out.append(i)
+            return out
+
+    payload = _Body(**request.json)
+    with SqlAlchemyUnitOfWork(account_uuid=None) as uow:
+        row = uow.session.query(PlatformSetting).filter_by(
+            key=ROLE_DASHBOARDS_SETTING_KEY).one_or_none()
+        # rebuilt, not mutated: MutableDict tracks top-level assignment only
+        value = dict(row.value) if row and row.value else {}
+        value[role] = payload.dashboards
+        if row:
+            row.value = value
+        else:
+            uow.session.add(
+                PlatformSetting(key=ROLE_DASHBOARDS_SETTING_KEY, value=value)
+            )
+        # commit, THEN invalidate — same ordering rule as the role presets: the
+        # override read goes through its own session and cannot see an uncommitted
+        # write, so invalidating first would re-cache the stale value with a fresh
+        # timestamp and serve it for the whole TTL.
+        uow.commit()
+        invalidate_role_dashboards()
+        result = _role_dashboards_payload(uow)
+    return jsonify(result), 200
+
+
+@super_admin_blueprint.route("/settings/role-dashboards/<string:role>", methods=["DELETE"])
+@scopes_required(SUPER)
+def reset_role_dashboards(role: str):
+    """Drop the override and return this role to the baseline dashboard set."""
+    from app.entrypoint.routes.common.permissions import (
+        DASHBOARD_DEFAULTS,
+        ROLE_DASHBOARDS_SETTING_KEY,
+        invalidate_role_dashboards,
+    )
+    from models.common import PlatformSetting
+
+    if role not in DASHBOARD_DEFAULTS:
+        raise BadRequestError(f"unknown role {role!r}")
+
+    with SqlAlchemyUnitOfWork(account_uuid=None) as uow:
+        row = uow.session.query(PlatformSetting).filter_by(
+            key=ROLE_DASHBOARDS_SETTING_KEY).one_or_none()
+        if row and row.value and role in row.value:
+            value = dict(row.value)
+            value.pop(role, None)
+            row.value = value
+        uow.commit()
+        invalidate_role_dashboards()
+        result = _role_dashboards_payload(uow)
+    return jsonify(result), 200


### PR DESCRIPTION
Second step of the dashboard revamp: the framework so a **platform owner** picks which of the pre-defined dashboards each role sees, applied **automatically by both clients**. **Backend only** — the web super-admin tab and the client rendering follow as separate steps.

## The model

A **separate concern from module/CRUD permissions**, on purpose. The existing `dashboard` module still answers *"can this user reach the Dashboards section at all"*; the new `role_dashboards` map answers *"which dashboards render inside it"*. Keeping it out of the module namespace means:
- a dashboard never shows up as a toggle in the per-user permission checklist, and
- it resolves from the **role**, not a user's frozen `permissions` column — so a change reaches every user of that role, *including* ones who carry a customised per-user ACL (with dashboards-as-modules, those users' lists are frozen and a role change would silently skip them).

**Platform-wide**, reusing the role-presets machinery (your decision): one config for all tenants in a `PlatformSetting` row, written only by the platform owner, same 30s-TTL cache and commit-then-invalidate ordering as role presets.

## What's here

- **`DASHBOARD_CATALOG`** — the pre-defined set declared once: `business-overview`, `sales-performance`, `field-ops`, `spend`, `inventory-health`. A client renders whichever it ships a screen for; an unknown id is ignored, so a new dashboard stays invisible until a build ships it — **degrade, not crash**.
- **`DASHBOARD_DEFAULTS`** — baseline role → ids; admin/superuser → `None` (all). `dashboards_for_scope()` validates against the catalog so a retired dashboard can't leave a dangling grant.
- **`perms_version`** now folds the dashboard set in (sentinel default leaves other callers' fingerprints unchanged), so a super-admin edit bumps the header both clients already watch → they re-read `/auth/me`.
- **Endpoints:** `GET /dashboard/catalog` (any authed user); `GET/PUT/DELETE /super-admin/settings/role-dashboards[/<role>]` (superuser-only, cloned from the role-preset routes — unknown role → 400, unknown id → 422); `/auth/me` gains a resolved `dashboards` field (`null` = all).

## Verification — the whole loop, live

- catalog lists 5 ids; superuser `/auth/me` → `dashboards: null`; the matrix GET returns all 8 configurable roles with baseline / overridden / following-count.
- a PUT narrowing `accountant` round-trips and flips `is_overridden`; an unknown id → **422**; DELETE resets to baseline.
- **The payoff, with a real user:** `wael` (sales) `/auth/me` showed `[sales-performance, field-ops]`; the super-admin narrowed the `sales` role to `[field-ops]`; wael's next `/auth/me` returned exactly that **and bumped `perms_version`** (`7660…` → `f930…`); reset restored the baseline. No override left in local state.
- Full backend suite still collects (617 tests). The 6 failing `test_auth` cases **pre-date this change** — they reproduce on main's own auth route (the baked test image drifted from current models, same as the inventory suite).

## Notes

- Independent of **#110** (the currency converter), but both touch `dashboard/routes.py` in different regions; whichever merges second may need a trivial conflict resolution there.
- Today only `accountant` and `operation_manager` hold the `dashboard` module at all, so granting a dashboard to another role presupposes also granting it the module. The defaults are a sensible seed — the whole point is that they're editable in the tab.

## Next

The web super-admin **Dashboards** tab (roles × dashboards matrix), then both clients rendering `catalog ∩ your-set ∩ screens-this-build-ships`. The expo app consumes only (editing stays on web, matching the read-only Roles screen precedent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)