### PR TITLE
Dashboards: materials sold (per-material, fulfilled vs unfulfilled)

### DIFF
--- a/backend/app/entrypoint/routes/common/permissions.py
+++ b/backend/app/entrypoint/routes/common/permissions.py
@@ -166,10 +166,11 @@ DASHBOARD_CATALOG = [
     {"id": "profitability", "title_key": "dashboards.profitability", "order": 2},
     {"id": "revenue-over-time", "title_key": "dashboards.revenueOverTime", "order": 3},
     {"id": "customer-orders", "title_key": "dashboards.customerOrders", "order": 4},
-    {"id": "sales-performance", "title_key": "dashboards.salesPerformance", "order": 5},
-    {"id": "field-ops", "title_key": "dashboards.fieldOps", "order": 6},
-    {"id": "spend", "title_key": "dashboards.spend", "order": 7},
-    {"id": "inventory-health", "title_key": "dashboards.inventoryHealth", "order": 8},
+    {"id": "materials-sold", "title_key": "dashboards.materialsSold", "order": 5},
+    {"id": "sales-performance", "title_key": "dashboards.salesPerformance", "order": 6},
+    {"id": "field-ops", "title_key": "dashboards.fieldOps", "order": 7},
+    {"id": "spend", "title_key": "dashboards.spend", "order": 8},
+    {"id": "inventory-health", "title_key": "dashboards.inventoryHealth", "order": 9},
 ]
 DASHBOARD_IDS = {d["id"] for d in DASHBOARD_CATALOG}
 _DASHBOARD_ORDER = {d["id"]: d["order"] for d in DASHBOARD_CATALOG}
@@ -180,9 +181,9 @@ _DASHBOARD_ORDER = {d["id"]: d["order"] for d in DASHBOARD_CATALOG}
 # today that is accountant + operation_manager; granting a dashboard to another
 # role presupposes granting it the module too.
 DASHBOARD_DEFAULTS = {
-    "operation_manager": ["business-overview", "profitability", "revenue-over-time", "customer-orders", "sales-performance", "field-ops", "spend", "inventory-health"],
-    "accountant": ["business-overview", "profitability", "revenue-over-time", "customer-orders", "spend"],
-    "sales_manager": ["business-overview", "revenue-over-time", "customer-orders", "sales-performance", "field-ops"],
+    "operation_manager": ["business-overview", "profitability", "revenue-over-time", "customer-orders", "materials-sold", "sales-performance", "field-ops", "spend", "inventory-health"],
+    "accountant": ["business-overview", "profitability", "revenue-over-time", "customer-orders", "materials-sold", "spend"],
+    "sales_manager": ["business-overview", "revenue-over-time", "customer-orders", "materials-sold", "sales-performance", "field-ops"],
     "sales": ["sales-performance", "field-ops"],
     "sales_associate": ["sales-performance", "field-ops"],
     "warehouse_keeper": ["inventory-health"],

--- a/backend/app/entrypoint/routes/dashboard/routes.py
+++ b/backend/app/entrypoint/routes/dashboard/routes.py
@@ -911,3 +911,123 @@ def customer_orders_count():
         )
 
     return jsonify({"granularity": gran, "groups": groups}), 200
+
+
+# ---------------------------------------------------------------------------
+# Materials sold — for ONE period (this month, last week, ...), a stacked bar
+# per MATERIAL: quantity sold via customer-order items, split into fulfilled vs
+# unfulfilled. Quantities are in each material's own unit and are never summed
+# across materials — which is why the x-axis is materials, not time.
+# ---------------------------------------------------------------------------
+
+# Bars are materials, so the time dimension collapses to one window; `offset`
+# steps that window back (0 = the current period). More material bars than this
+# turn into a smear at phone width, so the chart carries the top N by quantity
+# and reports how many it left out.
+_MATERIALS_TOP_N = 12
+_MATERIALS_MAX_OFFSET = 120
+
+
+@dashboard_blueprint.route("/materials-sold", methods=["GET"])
+@jwt_required()
+@scopes_required(
+    PermissionScope.ADMIN.value,
+    PermissionScope.SUPER_ADMIN.value,
+    PermissionScope.OPERATION_MANAGER.value,
+    PermissionScope.ACCOUNTANT.value,
+)
+def materials_sold():
+    """Quantities of materials sold in one period, fulfilled vs unfulfilled.
+
+    Sold = customer-order items, bucketed by their ORDER's created_at (the same
+    convention as revenue: the sale happens when the order is placed), with the
+    order's and the item's soft-deletes both respected. Fulfilled means the item
+    is marked fulfilled (fulfilled_at set — the model's own convention, and
+    is_fulfilled tracks it 1:1), regardless of WHEN that happened: this answers
+    "of what was ordered in this period, how much has been delivered by now".
+
+    Grouping is by (material, item unit): materials are never summed with each
+    other — quantities only mean anything in their own unit — and the unit is
+    carried per bar so a client can label it. A material sold in two units would
+    become two bars rather than one dishonest sum.
+    """
+    gran = (request.args.get("granularity") or "month").strip().lower()
+    if gran not in _ORDERS_CAPS:
+        gran = "month"
+    try:
+        offset = max(0, min(_MATERIALS_MAX_OFFSET, int(request.args.get("offset", 0))))
+    except ValueError:
+        offset = 0
+
+    now = datetime.utcnow()
+    start = _step_back(now, gran, offset)
+    end = _step_back(now, gran, offset - 1)  # next period's start
+
+    # (material_uuid, unit) -> [fulfilled_qty, unfulfilled_qty, name]
+    agg: dict = {}
+
+    with SqlAlchemyUnitOfWork() as uow:
+        s = uow.session
+        from models.common import (
+            CustomerOrderItem as ItemModel,
+            Material as MaterialModel,
+        )
+
+        rows = (
+            s.query(
+                ItemModel.material_uuid,
+                ItemModel.unit,
+                ItemModel.quantity,
+                ItemModel.fulfilled_at,
+                MaterialModel.name,
+            )
+            .join(
+                CustomerOrderModel,
+                ItemModel.customer_order_uuid == CustomerOrderModel.uuid,
+            )
+            # no is_deleted filter on Material: a retired material's history is
+            # still history, and its name is still the honest label
+            .join(MaterialModel, ItemModel.material_uuid == MaterialModel.uuid)
+            .filter(
+                ItemModel.is_deleted.is_(False),
+                CustomerOrderModel.is_deleted.is_(False),
+                CustomerOrderModel.created_at >= start,
+                CustomerOrderModel.created_at < end,
+                ItemModel.account_uuid == uow.account_uuid,
+            )
+            .all()
+        )
+        for mat_uuid, unit, qty, fulfilled_at, name in rows:
+            key = (mat_uuid, unit or "")
+            if key not in agg:
+                agg[key] = [0, 0, name]
+            agg[key][0 if fulfilled_at is not None else 1] += qty or 0
+
+    ranked = sorted(
+        (
+            {
+                "material_uuid": mu,
+                "name": rec[2],
+                "unit": unit,
+                "total": rec[0] + rec[1],
+                "fulfilled": rec[0],
+                "unfulfilled": rec[1],
+            }
+            for (mu, unit), rec in agg.items()
+        ),
+        key=lambda m: -m["total"],
+    )
+
+    return jsonify(
+        {
+            "granularity": gran,
+            "offset": offset,
+            "period_label": _period_key(start, gran),
+            "period_start": start.strftime("%Y-%m-%d"),
+            "materials": ranked[:_MATERIALS_TOP_N],
+            "disclosure": {
+                # bars beyond the top N by quantity — reported, never silent
+                "materials_omitted": max(0, len(ranked) - _MATERIALS_TOP_N),
+            },
+        }
+    ), 200

--- a/expo_app/app/dashboards/index.tsx
+++ b/expo_app/app/dashboards/index.tsx
@@ -53,6 +53,13 @@ const IMPLEMENTED: Entry[] = [
     descKey: 'dashboards.customerOrdersDesc',
   },
   {
+    id: 'materials-sold',
+    route: '/dashboards/materials-sold',
+    icon: '📦',
+    titleKey: 'dashboards.materialsSold',
+    descKey: 'dashboards.materialsSoldDesc',
+  },
+  {
     id: 'spend',
     route: '/dashboards/spend',
     icon: '🧾',

--- a/expo_app/app/dashboards/materials-sold.tsx
+++ b/expo_app/app/dashboards/materials-sold.tsx
@@ -1,0 +1,272 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { ModuleGuard } from '@/components/ModuleGuard';
+import { FilterChip, ScrollingChipRow } from '@/components/FilterChips';
+import { StackedBarChart, ChartLegend } from '@/components/Chart';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { apiCall, isOk } from '@/utils/api';
+
+interface MaterialRow {
+  material_uuid: string;
+  name: string;
+  unit: string;
+  total: number;
+  fulfilled: number;
+  unfulfilled: number;
+}
+interface Payload {
+  granularity: string;
+  offset: number;
+  period_label: string;
+  period_start: string;
+  materials: MaterialRow[];
+  disclosure: { materials_omitted: number };
+}
+
+type Gran = 'day' | 'week' | 'month' | 'quarter' | 'year';
+
+// fulfilled reads as green (delivered), unfulfilled as amber (still pending, not an
+// error) — the web page uses the same pair
+const FULFILLED = '#16a34a';
+const UNFULFILLED = '#d97706';
+
+const short = (s: string, n = 7) => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+/**
+ * Quantities of materials sold in ONE period — each bar is a MATERIAL, stacked
+ * into fulfilled vs unfulfilled quantity.
+ *
+ * The x-axis is materials rather than time, so the granularity picks a window and
+ * the ‹ › row steps it back and forth. Quantities are in each material's own unit;
+ * the server groups by (material, unit) and never sums across materials. Bar labels
+ * are truncated for phone width — the table below carries the full names.
+ */
+export default function MaterialsSoldScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { width } = useWindowDimensions();
+  const { t } = useLanguage();
+
+  const [gran, setGranRaw] = useState<Gran>('month');
+  const [offset, setOffset] = useState(0);
+  const [data, setData] = useState<Payload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  // switching granularity re-anchors to the current period — an offset of 3
+  // months means nothing in weeks
+  const setGran = (g: Gran) => {
+    setGranRaw(g);
+    setOffset(0);
+  };
+
+  const load = useCallback(
+    async (isRefresh = false) => {
+      if (!isRefresh) setLoading(true);
+      setFailed(false);
+      const res = await apiCall<Payload>(
+        `/dashboard/materials-sold?granularity=${gran}&offset=${offset}`,
+      );
+      if (isOk(res.status) && res.data) setData(res.data);
+      else setFailed(true);
+      setLoading(false);
+      setRefreshing(false);
+    },
+    [gran, offset],
+  );
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const chartWidth = width - 72;
+  const materials = data?.materials ?? [];
+  const hasAny = materials.length > 0;
+  const omitted = data?.disclosure.materials_omitted ?? 0;
+  const names = [t('dashboards.fulfilled'), t('dashboards.unfulfilled')];
+
+  const GRANS: Array<[Gran, string]> = [
+    ['day', t('dashboards.gDay')],
+    ['week', t('dashboards.gWeek')],
+    ['month', t('dashboards.gMonth')],
+    ['quarter', t('dashboards.gQuarter')],
+    ['year', t('dashboards.gYear')],
+  ];
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="ms-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>{t('dashboards.materialsSold')}</ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          <View style={styles.controls}>
+            <ScrollingChipRow>
+              {GRANS.map(([g, label]) => (
+                <FilterChip key={g} label={label} active={gran === g} onPress={() => setGran(g)} testID={`ms-gran-${g}`} />
+              ))}
+            </ScrollingChipRow>
+
+            {/* period navigator: ‹ steps back one period, › returns toward now */}
+            <View style={styles.periodRow}>
+              <TouchableOpacity
+                style={styles.periodBtn}
+                onPress={() => setOffset(offset + 1)}
+                hitSlop={8}
+                testID="ms-prev"
+              >
+                <ThemedText style={styles.periodBtnText}>‹</ThemedText>
+              </TouchableOpacity>
+              <ThemedText style={styles.periodLabel} testID="ms-period">
+                {data?.period_label ?? '…'}
+              </ThemedText>
+              <TouchableOpacity
+                style={[styles.periodBtn, offset === 0 && styles.periodBtnOff]}
+                onPress={() => setOffset(Math.max(0, offset - 1))}
+                disabled={offset === 0}
+                hitSlop={8}
+                testID="ms-next"
+              >
+                <ThemedText style={styles.periodBtnText}>›</ThemedText>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          {loading ? (
+            <View style={styles.centre}>
+              <ActivityIndicator size="large" color="#5469D4" />
+            </View>
+          ) : failed ? (
+            <View style={styles.centre}>
+              <ThemedText style={styles.stateText}>{t('moduleList.failed')}</ThemedText>
+              <TouchableOpacity style={styles.retry} onPress={() => load()}>
+                <ThemedText style={styles.retryText}>{t('moduleList.retry')}</ThemedText>
+              </TouchableOpacity>
+            </View>
+          ) : !hasAny ? (
+            <View style={styles.centre}>
+              <ThemedText style={styles.stateText}>{t('dashboards.noData')}</ThemedText>
+            </View>
+          ) : (
+            <>
+              <View style={styles.panel}>
+                <StackedBarChart
+                  width={chartWidth}
+                  colours={[FULFILLED, UNFULFILLED]}
+                  series={names}
+                  data={materials.map((m) => ({
+                    label: short(m.name),
+                    segments: [m.fulfilled, m.unfulfilled],
+                  }))}
+                />
+                <ChartLegend names={names} colours={[FULFILLED, UNFULFILLED]} />
+              </View>
+
+              <ThemedText style={styles.defn}>{t('dashboards.materialUnitsNote')}</ThemedText>
+              {omitted > 0 && (
+                <ThemedText style={styles.caveat}>
+                  {t('dashboards.materialsOmitted', { count: String(omitted) })}
+                </ThemedText>
+              )}
+
+              {/* full names + the numbers, biggest first (server order) */}
+              <View style={styles.table}>
+                <View style={styles.row}>
+                  <ThemedText style={[styles.rowLabel, styles.head]} />
+                  <View style={styles.rowVals}>
+                    <ThemedText style={[styles.rowVal, styles.head]}>{t('dashboards.total')}</ThemedText>
+                    <ThemedText style={[styles.rowVal, styles.head]}>{t('dashboards.fulfilled')}</ThemedText>
+                    <ThemedText style={[styles.rowVal, styles.head]}>{t('dashboards.unfulfilled')}</ThemedText>
+                  </View>
+                </View>
+                {materials.map((m) => (
+                  <View key={`${m.material_uuid}-${m.unit}`} style={styles.row}>
+                    <ThemedText style={styles.rowLabel} numberOfLines={2}>
+                      {m.name}
+                      <ThemedText style={styles.unitText}> ({m.unit})</ThemedText>
+                    </ThemedText>
+                    <View style={styles.rowVals}>
+                      <ThemedText style={styles.rowVal}>{m.total}</ThemedText>
+                      <ThemedText style={[styles.rowVal, { color: FULFILLED }]}>{m.fulfilled}</ThemedText>
+                      <ThemedText style={[styles.rowVal, m.unfulfilled > 0 && { color: UNFULFILLED }]}>
+                        {m.unfulfilled}
+                      </ThemedText>
+                    </View>
+                  </View>
+                ))}
+              </View>
+            </>
+          )}
+        </ScrollView>
+      </ThemedView>
+    </ModuleGuard>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#f1f5f9' },
+  topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
+  back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },
+  backSpacer: { width: 24 },
+  topTitle: { flex: 1, textAlign: 'center', fontSize: 17, fontWeight: '600' },
+  body: { paddingHorizontal: 20, paddingTop: 6 },
+  controls: { gap: 10, marginBottom: 14 },
+  periodRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 14 },
+  periodBtn: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#E5E7EB',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  periodBtnOff: { opacity: 0.35 },
+  periodBtnText: { fontSize: 20, lineHeight: 22, color: '#5469D4', fontWeight: '700' },
+  periodLabel: { fontSize: 14, fontWeight: '700', color: '#111827', minWidth: 92, textAlign: 'center' },
+  panel: { backgroundColor: '#fff', borderRadius: 12, padding: 16 },
+  defn: { fontSize: 11, color: '#6B7280', lineHeight: 16, marginTop: 8 },
+  caveat: { fontSize: 12, color: '#B45309', lineHeight: 17, marginTop: 8 },
+  table: { backgroundColor: '#fff', borderRadius: 12, padding: 12, marginTop: 16 },
+  row: { flexDirection: 'row', alignItems: 'center', paddingVertical: 6, gap: 10 },
+  rowLabel: { flexBasis: 120, flexShrink: 0, fontSize: 12, fontWeight: '700', color: '#111827', lineHeight: 15 },
+  unitText: { fontSize: 10, fontWeight: '400', color: '#9ca3af' },
+  rowVals: { flex: 1, flexDirection: 'row', justifyContent: 'space-between' },
+  rowVal: { fontSize: 12, color: '#374151', fontVariant: ['tabular-nums'] },
+  head: { color: '#9ca3af', fontWeight: '700', fontSize: 10 },
+  centre: { alignItems: 'center', justifyContent: 'center', padding: 32, gap: 10 },
+  stateText: { fontSize: 14, color: '#6B7280', textAlign: 'center' },
+  retry: { backgroundColor: '#5469D4', paddingHorizontal: 20, paddingVertical: 10, borderRadius: 10 },
+  retryText: { color: '#fff', fontWeight: '600' },
+});

--- a/expo_app/i18n/translations.ts
+++ b/expo_app/i18n/translations.ts
@@ -351,6 +351,14 @@ export const translations: Record<Lang, Record<string, string>> = {
   'dashboards.newCustomers': 'New customers',
   'dashboards.repeatCustomers': 'Returning customers',
   'dashboards.gDay': 'Day',
+  'dashboards.materialsSold': 'Materials Sold',
+  'dashboards.materialsSoldDesc': 'Quantities sold per material, fulfilled vs unfulfilled.',
+  'dashboards.fulfilled': 'Fulfilled',
+  'dashboards.unfulfilled': 'Unfulfilled',
+  'dashboards.unit': 'Unit',
+  'dashboards.materialsOmitted': '{count} more material(s) not shown — top 12 by quantity are charted.',
+  'dashboards.materialUnitsNote':
+    'Quantities are in each material’s own unit; every bar is one material, so different units are never summed. Fulfilled counts what has been delivered by now, out of what was ordered in this period.',
   'dashboards.newRepeatNote':
     'An order counts as “new” when it falls in the period of the customer’s first-ever order — repeat purchases inside that same period still count as new; later periods count as returning.',
   'dashboards.modeCumulative': 'Cumulative',
@@ -1556,6 +1564,14 @@ export const translations: Record<Lang, Record<string, string>> = {
   'dashboards.newCustomers': 'عملاء جدد',
   'dashboards.repeatCustomers': 'عملاء عائدون',
   'dashboards.gDay': 'يوم',
+  'dashboards.materialsSold': 'المواد المباعة',
+  'dashboards.materialsSoldDesc': 'الكميات المباعة لكل مادة، منفَّذ مقابل غير منفَّذ.',
+  'dashboards.fulfilled': 'منفَّذ',
+  'dashboards.unfulfilled': 'غير منفَّذ',
+  'dashboards.unit': 'الوحدة',
+  'dashboards.materialsOmitted': 'لم تُعرض {count} مادة إضافية — يعرض المخطط أعلى 12 مادة كمّيةً.',
+  'dashboards.materialUnitsNote':
+    'الكميات بوحدة كل مادة؛ كل عمود يمثل مادة واحدة، فلا تُجمع وحدات مختلفة. يُحتسب "منفَّذ" ما سُلِّم حتى الآن مما طُلب في هذه الفترة.',
   'dashboards.newRepeatNote':
     'يُحتسب الطلب "جديداً" إذا وقع في الفترة التي تضم أول طلب للعميل على الإطلاق — وتُحتسب مشترياته المتكررة ضمن الفترة نفسها جديدة أيضاً؛ أما الفترات اللاحقة فتُحتسب كعميل عائد.',
   'dashboards.modeCumulative': 'تراكمي',

--- a/frontend/client/src/App.tsx
+++ b/frontend/client/src/App.tsx
@@ -15,6 +15,7 @@ import ProfitabilityDashboard from "@/pages/ProfitabilityDashboard";
 import RevenueOverTimeDashboard from "@/pages/RevenueOverTimeDashboard";
 import SpendDashboard from "@/pages/SpendDashboard";
 import CustomerOrdersDashboard from "@/pages/CustomerOrdersDashboard";
+import MaterialsSoldDashboard from "@/pages/MaterialsSoldDashboard";
 import Customers from "@/pages/Customers";
 import CustomerDetail from "@/pages/CustomerDetail";
 import Vendors from "@/pages/Vendors";
@@ -116,6 +117,7 @@ function Router() {
       <Route path="/dashboards/revenue-over-time" component={() => <ProtectedRoute><RevenueOverTimeDashboard /></ProtectedRoute>} />
       <Route path="/dashboards/spend" component={() => <ProtectedRoute><SpendDashboard /></ProtectedRoute>} />
       <Route path="/dashboards/customer-orders" component={() => <ProtectedRoute><CustomerOrdersDashboard /></ProtectedRoute>} />
+      <Route path="/dashboards/materials-sold" component={() => <ProtectedRoute><MaterialsSoldDashboard /></ProtectedRoute>} />
       <Route path="/customers" component={() => <ProtectedRoute><Customers /></ProtectedRoute>} />
       <Route path="/customers/:uuid" component={() => <ProtectedRoute><CustomerDetail /></ProtectedRoute>} />
       <Route path="/vendors" component={() => <ProtectedRoute><Vendors /></ProtectedRoute>} />

--- a/frontend/client/src/i18n/translations/dashboard.ts
+++ b/frontend/client/src/i18n/translations/dashboard.ts
@@ -31,6 +31,8 @@ export const en: Record<string, string> = {
   'dashboards.revenueOverTimeDesc': 'Revenue, received and debt per period, and cumulative.',
   'dashboards.customerOrders': 'Customer Orders',
   'dashboards.customerOrdersDesc': 'Order counts per period, new vs returning customers.',
+  'dashboards.materialsSold': 'Materials Sold',
+  'dashboards.materialsSoldDesc': 'Quantities sold per material, fulfilled vs unfulfilled.',
   'dashboards.salesPerformance': 'Sales Performance',
   'dashboards.fieldOps': 'Field Operations',
   'dashboards.spend': 'Expenses & Salaries',
@@ -53,6 +55,13 @@ export const en: Record<string, string> = {
   'dashboards.gDay': 'Daily',
   'dashboards.newCustomers': 'New customers',
   'dashboards.repeatCustomers': 'Returning customers',
+  'dashboards.fulfilled': 'Fulfilled',
+  'dashboards.unfulfilled': 'Unfulfilled',
+  'dashboards.unit': 'Unit',
+  'dashboards.materialsOmitted':
+    '{count} more material(s) not shown — the chart carries the top 12 by quantity.',
+  'dashboards.materialUnitsNote':
+    'Quantities are in each material’s own unit; every bar is one material, so different units are never summed. Fulfilled counts what has been delivered by now, out of what was ordered in this period.',
   'dashboards.newRepeatNote':
     'An order counts as “new” when it falls in the period of the customer’s first-ever order — repeat purchases inside that same period still count as new; later periods count as returning.',
   'dashboards.modeCumulative': 'Cumulative',
@@ -101,6 +110,8 @@ export const ar: Record<string, string> = {
   'dashboards.revenueOverTimeDesc': 'الإيرادات والمحصَّل والدين لكل فترة، وتراكمياً.',
   'dashboards.customerOrders': 'طلبات العملاء',
   'dashboards.customerOrdersDesc': 'عدد الطلبات لكل فترة، عملاء جدد مقابل عائدين.',
+  'dashboards.materialsSold': 'المواد المباعة',
+  'dashboards.materialsSoldDesc': 'الكميات المباعة لكل مادة، منفَّذ مقابل غير منفَّذ.',
   'dashboards.salesPerformance': 'أداء المبيعات',
   'dashboards.fieldOps': 'العمليات الميدانية',
   'dashboards.spend': 'المصروفات والرواتب',
@@ -123,6 +134,13 @@ export const ar: Record<string, string> = {
   'dashboards.gDay': 'يومي',
   'dashboards.newCustomers': 'عملاء جدد',
   'dashboards.repeatCustomers': 'عملاء عائدون',
+  'dashboards.fulfilled': 'منفَّذ',
+  'dashboards.unfulfilled': 'غير منفَّذ',
+  'dashboards.unit': 'الوحدة',
+  'dashboards.materialsOmitted':
+    'لم تُعرض {count} مادة إضافية — يعرض المخطط أعلى 12 مادة من حيث الكمية.',
+  'dashboards.materialUnitsNote':
+    'الكميات بوحدة كل مادة؛ كل عمود يمثل مادة واحدة، فلا تُجمع وحدات مختلفة. يُحتسب "منفَّذ" ما سُلِّم حتى الآن مما طُلب في هذه الفترة.',
   'dashboards.newRepeatNote':
     'يُحتسب الطلب "جديداً" إذا وقع في الفترة التي تضم أول طلب للعميل على الإطلاق — وتُحتسب مشترياته المتكررة ضمن الفترة نفسها جديدة أيضاً؛ أما الفترات اللاحقة فتُحتسب كعميل عائد.',
   'dashboards.modeCumulative': 'تراكمي',

--- a/frontend/client/src/lib/dashboards.ts
+++ b/frontend/client/src/lib/dashboards.ts
@@ -4,6 +4,7 @@ import {
   TrendingUp,
   Receipt,
   ClipboardList,
+  Package,
   type LucideIcon,
 } from "lucide-react";
 
@@ -53,6 +54,13 @@ export const IMPLEMENTED_DASHBOARDS: DashboardEntry[] = [
     icon: ClipboardList,
     titleKey: "dashboards.customerOrders",
     descKey: "dashboards.customerOrdersDesc",
+  },
+  {
+    id: "materials-sold",
+    href: "/dashboards/materials-sold",
+    icon: Package,
+    titleKey: "dashboards.materialsSold",
+    descKey: "dashboards.materialsSoldDesc",
   },
   {
     id: "spend",

--- a/frontend/client/src/pages/MaterialsSoldDashboard.tsx
+++ b/frontend/client/src/pages/MaterialsSoldDashboard.tsx
@@ -1,0 +1,265 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { AppLayout } from "@/components/layout/AppLayout";
+import { Card, CardContent } from "@/components/ui/card";
+import { apiRequest } from "@/lib/queryClient";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+interface MaterialRow {
+  material_uuid: string;
+  name: string;
+  unit: string;
+  total: number;
+  fulfilled: number;
+  unfulfilled: number;
+}
+interface Payload {
+  granularity: string;
+  offset: number;
+  period_label: string;
+  period_start: string;
+  materials: MaterialRow[];
+  disclosure: { materials_omitted: number };
+}
+
+type Gran = "day" | "week" | "month" | "quarter" | "year";
+
+// fulfilled reads as green (delivered), unfulfilled as amber (still pending, not an
+// error) — the app uses the same pair so a segment means the same in both clients
+const FULFILLED = "#16a34a";
+const UNFULFILLED = "#d97706";
+
+const short = (s: string, n = 12) => (s.length > n ? `${s.slice(0, n - 1)}…` : s);
+
+/**
+ * Quantities of materials sold in ONE period — each bar is a MATERIAL, stacked
+ * into fulfilled vs unfulfilled quantity.
+ *
+ * Unlike the time-series dashboards, the x-axis here is materials, so the
+ * granularity picks a window and ‹ › steps it back and forth (offset periods from
+ * the current one). Quantities are in each material's own unit — the server groups
+ * by (material, unit) and never sums across materials, so the bars are honest even
+ * though the y-axis mixes units.
+ */
+export default function MaterialsSoldDashboard() {
+  const { t } = useLanguage();
+  const [gran, setGranRaw] = useState<Gran>("month");
+  const [offset, setOffset] = useState(0);
+
+  // switching granularity re-anchors to the current period — an offset of 3
+  // months means nothing in weeks
+  const setGran = (g: Gran) => {
+    setGranRaw(g);
+    setOffset(0);
+  };
+
+  const { data, isLoading, error } = useQuery<Payload>({
+    queryKey: ["/dashboard/materials-sold", gran, offset],
+    queryFn: () =>
+      apiRequest(`/dashboard/materials-sold?granularity=${gran}&offset=${offset}`),
+    retry: false,
+  });
+
+  const forbidden = error && /^403/.test((error as Error).message || "");
+  const rows = (data?.materials ?? []).map((m) => ({
+    name: short(m.name),
+    fullName: `${m.name} (${m.unit})`,
+    fulfilled: m.fulfilled,
+    unfulfilled: m.unfulfilled,
+  }));
+  const hasAny = rows.length > 0;
+  const omitted = data?.disclosure.materials_omitted ?? 0;
+
+  const GRANS: { key: Gran; label: string }[] = [
+    { key: "day", label: t("dashboards.gDay") },
+    { key: "week", label: t("dashboards.gWeek") },
+    { key: "month", label: t("dashboards.gMonth") },
+    { key: "quarter", label: t("dashboards.gQuarter") },
+    { key: "year", label: t("dashboards.gYear") },
+  ];
+
+  const segLabel = (key: string) =>
+    key === "fulfilled" ? t("dashboards.fulfilled") : t("dashboards.unfulfilled");
+
+  return (
+    <AppLayout>
+      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+        <div className="flex items-end justify-between flex-wrap gap-3">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900">{t("dashboards.materialsSold")}</h2>
+            <p className="text-sm text-gray-600">{t("dashboards.materialsSoldDesc")}</p>
+          </div>
+          {!forbidden && (
+            <div className="flex items-center gap-2 flex-wrap">
+              {/* period navigator: ‹ steps back one period, › returns toward now */}
+              <div className="inline-flex items-center gap-1 p-1 rounded-lg bg-gray-100 border border-gray-200">
+                <button
+                  onClick={() => setOffset(offset + 1)}
+                  data-testid="ms-prev"
+                  className="px-2 py-1 rounded-md text-gray-500 hover:text-gray-900"
+                  aria-label="previous period"
+                >
+                  <ChevronLeft className="w-4 h-4 rtl:rotate-180" />
+                </button>
+                <span
+                  className="px-2 text-xs font-medium text-gray-900 tabular-nums"
+                  data-testid="ms-period"
+                >
+                  {data?.period_label ?? "…"}
+                </span>
+                <button
+                  onClick={() => setOffset(Math.max(0, offset - 1))}
+                  disabled={offset === 0}
+                  data-testid="ms-next"
+                  className="px-2 py-1 rounded-md text-gray-500 hover:text-gray-900 disabled:opacity-30"
+                  aria-label="next period"
+                >
+                  <ChevronRight className="w-4 h-4 rtl:rotate-180" />
+                </button>
+              </div>
+              <div className="inline-flex items-center gap-1 p-1 rounded-lg bg-gray-100 border border-gray-200">
+                {GRANS.map((g) => (
+                  <button
+                    key={g.key}
+                    onClick={() => setGran(g.key)}
+                    data-testid={`ms-gran-${g.key}`}
+                    className={`px-3 py-1 rounded-md text-xs font-medium transition-colors ${
+                      gran === g.key
+                        ? "bg-white text-gray-900 shadow-sm"
+                        : "text-gray-500 hover:text-gray-900"
+                    }`}
+                  >
+                    {g.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {forbidden ? (
+          <Card>
+            <CardContent className="pt-6 text-sm text-gray-500">
+              {t("dashboard.analyticsRestricted")}
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            <Card>
+              <CardContent className="pt-6">
+                <div className="h-80" dir="ltr">
+                  {isLoading ? (
+                    <div className="h-full rounded-lg bg-gray-50 animate-pulse" />
+                  ) : !hasAny ? (
+                    <div className="h-full flex items-center justify-center text-sm text-gray-500">
+                      {t("dashboards.noData")}
+                    </div>
+                  ) : (
+                    <ResponsiveContainer width="100%" height="100%">
+                      <BarChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+                        <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                        <XAxis
+                          dataKey="name"
+                          fontSize={10}
+                          tickLine={false}
+                          interval={0}
+                          angle={-25}
+                          textAnchor="end"
+                          height={54}
+                        />
+                        <YAxis
+                          allowDecimals={false}
+                          fontSize={11}
+                          width={46}
+                          tickLine={false}
+                          axisLine={false}
+                        />
+                        <Tooltip
+                          formatter={(v: number, key: string) => [v.toLocaleString(), segLabel(key)]}
+                          labelFormatter={(_l, payload) =>
+                            payload?.[0]?.payload?.fullName ?? String(_l)
+                          }
+                        />
+                        <Legend formatter={segLabel} wrapperStyle={{ fontSize: 12 }} />
+                        <Bar
+                          dataKey="fulfilled"
+                          stackId="qty"
+                          fill={FULFILLED}
+                          isAnimationActive={false}
+                        />
+                        <Bar
+                          dataKey="unfulfilled"
+                          stackId="qty"
+                          fill={UNFULFILLED}
+                          radius={[2, 2, 0, 0]}
+                          isAnimationActive={false}
+                        />
+                      </BarChart>
+                    </ResponsiveContainer>
+                  )}
+                </div>
+
+                <p className="text-xs text-gray-500 mt-4">{t("dashboards.materialUnitsNote")}</p>
+                {omitted > 0 && (
+                  <p className="text-xs text-amber-700 mt-1">
+                    {t("dashboards.materialsOmitted", { count: omitted })}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            {hasAny && (
+              <Card>
+                <CardContent className="pt-6 overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-xs uppercase tracking-wider text-gray-500">
+                        <th className="pb-2 pe-4" />
+                        <th className="pb-2 pe-4">{t("dashboards.unit")}</th>
+                        <th className="pb-2 pe-4 text-end">{t("dashboards.total")}</th>
+                        <th className="pb-2 pe-4 text-end">{t("dashboards.fulfilled")}</th>
+                        <th className="pb-2 text-end">{t("dashboards.unfulfilled")}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {(data?.materials ?? []).map((m) => (
+                        <tr key={`${m.material_uuid}-${m.unit}`} className="border-t border-gray-100">
+                          <td className="py-2 pe-4 font-semibold text-gray-900">{m.name}</td>
+                          <td className="py-2 pe-4 text-gray-500">{m.unit}</td>
+                          <td className="py-2 pe-4 text-end tabular-nums font-medium">
+                            {m.total.toLocaleString()}
+                          </td>
+                          <td className="py-2 pe-4 text-end tabular-nums text-green-700">
+                            {m.fulfilled.toLocaleString()}
+                          </td>
+                          <td
+                            className={`py-2 text-end tabular-nums ${
+                              m.unfulfilled > 0 ? "text-amber-700" : "text-gray-600"
+                            }`}
+                          >
+                            {m.unfulfilled.toLocaleString()}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </CardContent>
+              </Card>
+            )}
+          </>
+        )}
+      </div>
+    </AppLayout>
+  );
+}


### PR DESCRIPTION
> **Stacked on #115** (customer-orders → #114 → #113). Base is `dashboard-customer-orders` so this diff shows materials-sold only; GitHub auto-retargets as the chain merges. Merge order: **#113 → #114 → #115 → this**.

## What

The next pre-defined dashboard in both clients, off one shared endpoint: for **one period**, a **stacked bar per MATERIAL** showing the quantity sold via customer-order items, split into **fulfilled** (green) vs **unfulfilled** (amber).

- **Granularity picks a window** (day / week / month / quarter / year) and a **‹ › navigator** steps it back and forth — necessary, not decorative: the current period is often still empty.
- **Quantities are in each material's own unit** ("per unit of material"): the server groups by (material, item unit) and never sums across materials — a material ever sold in two units becomes two honest bars, and every bar carries its unit label.
- The chart carries the **top 12 by quantity** and discloses how many it left out.

## Semantics
- **Sold** = order items bucketed by their **order's** created_at (same convention as revenue), with both the order's and the item's soft-deletes respected.
- **Fulfilled** = `fulfilled_at` set (the model's own convention — verified **0 drift** against `is_fulfilled` across all rows), regardless of when — answering *"of what was ordered in this period, how much has been delivered by now"*.
- Retired materials keep their history (no `is_deleted` filter on Material).

## Surface area
- **Backend:** `GET /dashboard/materials-sold?granularity=&offset=` (admin / superuser / operation_manager / accountant). Catalog gains `materials-sold` (order 5); added to **operation_manager, accountant, sales_manager** defaults.
- **Web:** recharts stacked bar with angled truncated labels (full name in tooltip), ‹ › period pill, numbers table with units.
- **App:** reuses `StackedBarChart`; truncated bar labels with the full names + units in the table; RTL-aware ‹ › navigator.

## Verification (live, real data, both clients — ground truth computed independently from raw items first)
- All 12 July materials match exactly: cardboard box (pcs) 1486/1486/0, sugar (kg) 1439/1439/0, egyptial small raw peanuts 14 = **10 fulfilled + 4 unfulfilled**, large coated peanuts 10 **all unfulfilled**, etc.
- `fulfilled + unfulfilled = total` for every bar; August honestly empty; yearly view proves the top-N cap (12 shown, **3 omitted, disclosed**).
- Both clients rendered July via the navigator (screenshots in thread); sibling dashboards unaffected; both clients typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)