### PR TITLE
Web: "/" becomes Home — the role's dashboards stacked in one feed

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -77,6 +77,7 @@ def _load_request_identity():
     from flask_jwt_extended import verify_jwt_in_request, get_jwt
     from app.entrypoint.routes.common.permissions import (
         RESOURCE_SET,
+        SELF_SCOPED_DASHBOARD_ENDPOINTS,
         endpoint_allowed,
         effective_permissions,
         dashboards_for_scope,
@@ -213,10 +214,13 @@ def _load_request_identity():
             return jsonify(
                 {"msg": "Forbidden — feature not enabled for this account"}
             ), 403
-        # per-user fine-grained grant (admins bypass)
+        # per-user fine-grained grant (admins bypass; self-scoped dashboard
+        # endpoints too — they only ever return the caller's own records, so
+        # the per-user resource ACL is not the right gate for them)
         if (
             not g.is_admin
             and g.user_acl is not None
+            and request.endpoint not in SELF_SCOPED_DASHBOARD_ENDPOINTS
             and not endpoint_allowed(g.user_acl, request.blueprint, request.method)
         ):
             return jsonify({"msg": "Forbidden — missing endpoint permission"}), 403

--- a/backend/app/entrypoint/routes/common/permissions.py
+++ b/backend/app/entrypoint/routes/common/permissions.py
@@ -139,6 +139,19 @@ MODULES = [
 ]
 
 RESOURCE_SET = set(RESOURCES)
+
+# Dashboard endpoints that return only the CALLER's own records (their orders,
+# their customers, their assigned stops). Self-scoped by construction, so the
+# per-user resource ACL does not apply to them — a sales rep or driver without
+# the `dashboard` resource grant may still read their own numbers. The account
+# gates (verification, tenant feature cap) still bind; this only skips the
+# per-user check. Flask endpoint names: blueprint.function.
+SELF_SCOPED_DASHBOARD_ENDPOINTS = {
+    "dashboard.my_revenue_over_time",
+    "dashboard.my_materials_sold",
+    "dashboard.my_new_customers",
+    "dashboard.my_trip_stops",
+}
 MODULE_SET = set(MODULES)
 ACTION_SET = set(ACTIONS)
 

--- a/expo_app/app/(tabs)/index.tsx
+++ b/expo_app/app/(tabs)/index.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, ScrollView, TouchableOpacity, View, Alert } from 'react-nat
 import { useAuth } from '@/contexts/AuthContext';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
-import { WelcomeContent } from '@/components/WelcomeContent';
+import { HomeDashboards } from '@/components/HomeDashboards';
 import { BottomNavigation } from '@/components/layout/BottomNavigation';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter, useLocalSearchParams } from 'expo-router';
@@ -178,7 +178,9 @@ export default function HomeScreen() {
         showsVerticalScrollIndicator={false}
       >
         {activeTab === 'home' ? (
-          <WelcomeContent />
+          // Home: the role's dashboards stacked (falls back to the old welcome
+          // screen when the role has none) — the app twin of the web "/" feed
+          <HomeDashboards />
         ) : (
           <View style={styles.menuContainer}>
             <View style={styles.menuSection}>

--- a/expo_app/app/dashboard.tsx
+++ b/expo_app/app/dashboard.tsx
@@ -106,7 +106,7 @@ function bucketize(points: Point[], maxMarks = MAX_MARKS): Point[] {
  * presets are generated from these same decorators, which is what keeps the two
  * gates in step.
  */
-export default function DashboardScreen() {
+export function DashboardScreenImpl({ embedded = false }: { embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -147,33 +147,8 @@ export default function DashboardScreen() {
   const collected = cur ? (data?.series?.collected?.[cur] ?? []) : [];
   const chartW = width - 72;
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="dashboard-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle} numberOfLines={1}>
-            {t('menu.dashboard')}
-          </ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.chips}>
             {RANGES.map((r) => (
               <TouchableOpacity
@@ -311,6 +286,48 @@ export default function DashboardScreen() {
               )}
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t('dashboards.businessOverview')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="dashboard-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle} numberOfLines={1}>
+            {t('menu.dashboard')}
+          </ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
         <BottomNavigation activeTab="menu" onTabPress={() => router.replace('/(tabs)?tab=menu')} />
       </ThemedView>
@@ -327,7 +344,13 @@ function LegendItem({ colour, label }: { colour: string; label: string }) {
   );
 }
 
+export default function DashboardScreen() {
+  return <DashboardScreenImpl />;
+}
+
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/app/dashboards/customer-orders.tsx
+++ b/expo_app/app/dashboards/customer-orders.tsx
@@ -47,7 +47,7 @@ const REPEAT = '#5469D4';
  * chart — while a yearly chart counts their whole first year as new. Counts, not
  * money, so this is the one dashboard without a currency toggle.
  */
-export default function CustomerOrdersScreen() {
+export function CustomerOrdersScreenImpl({ embedded = false }: { embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -89,30 +89,8 @@ export default function CustomerOrdersScreen() {
     ['year', t('dashboards.gYear')],
   ];
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="co-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle}>{t('dashboards.customerOrders')}</ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.controls}>
             <ScrollingChipRow>
               {GRANS.map(([g, label]) => (
@@ -181,13 +159,58 @@ export default function CustomerOrdersScreen() {
               </View>
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t('dashboards.customerOrders')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="co-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>{t('dashboards.customerOrders')}</ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
       </ThemedView>
     </ModuleGuard>
   );
 }
 
+export default function CustomerOrdersScreen() {
+  return <CustomerOrdersScreenImpl />;
+}
+
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/app/dashboards/materials-sold.tsx
+++ b/expo_app/app/dashboards/materials-sold.tsx
@@ -53,7 +53,7 @@ const short = (s: string, n = 7) => (s.length > n ? `${s.slice(0, n - 1)}…` : 
  * the server groups by (material, unit) and never sums across materials. Bar labels
  * are truncated for phone width — the table below carries the full names.
  */
-export function MaterialsSoldScreenImpl({ mine = false }: { mine?: boolean }) {
+export function MaterialsSoldScreenImpl({ mine = false, embedded = false }: { mine?: boolean; embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -109,32 +109,8 @@ export function MaterialsSoldScreenImpl({ mine = false }: { mine?: boolean }) {
     ['year', t('dashboards.gYear')],
   ];
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="ms-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle}>
-            {t(mine ? 'dashboards.myMaterialsSold' : 'dashboards.materialsSold')}
-          </ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.controls}>
             <ScrollingChipRow>
               {GRANS.map(([g, label]) => (
@@ -232,6 +208,47 @@ export function MaterialsSoldScreenImpl({ mine = false }: { mine?: boolean }) {
               </View>
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t(mine ? 'dashboards.myMaterialsSold' : 'dashboards.materialsSold')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="ms-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>
+            {t(mine ? 'dashboards.myMaterialsSold' : 'dashboards.materialsSold')}
+          </ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
       </ThemedView>
     </ModuleGuard>
@@ -243,6 +260,8 @@ export default function MaterialsSoldScreen() {
 }
 
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/app/dashboards/my-trip-stops.tsx
+++ b/expo_app/app/dashboards/my-trip-stops.tsx
@@ -45,7 +45,7 @@ const NOT_COMPLETED = '#d97706';
  * global dashboard's per-user split is meaningless, so status is the honest
  * breakdown. Self-scoped endpoint: a driver may see their own numbers.
  */
-export default function MyTripStopsScreen() {
+export function MyTripStopsScreenImpl({ embedded = false }: { embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -87,30 +87,8 @@ export default function MyTripStopsScreen() {
     ['year', t('dashboards.gYear')],
   ];
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="mts-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle}>{t('dashboards.myTripStops')}</ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.controls}>
             <ScrollingChipRow>
               {GRANS.map(([g, label]) => (
@@ -174,13 +152,58 @@ export default function MyTripStopsScreen() {
               </View>
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t('dashboards.myTripStops')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="mts-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>{t('dashboards.myTripStops')}</ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
       </ThemedView>
     </ModuleGuard>
   );
 }
 
+export default function MyTripStopsScreen() {
+  return <MyTripStopsScreenImpl />;
+}
+
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/app/dashboards/new-customers.tsx
+++ b/expo_app/app/dashboards/new-customers.tsx
@@ -42,7 +42,7 @@ const NEW = '#16a34a';
  * purchasing side. One series, so this uses the plain BarChart rather than a
  * stack, and there is no currency involved.
  */
-export function NewCustomersScreenImpl({ mine = false }: { mine?: boolean }) {
+export function NewCustomersScreenImpl({ mine = false, embedded = false }: { mine?: boolean; embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -86,32 +86,8 @@ export function NewCustomersScreenImpl({ mine = false }: { mine?: boolean }) {
     ['year', t('dashboards.gYear')],
   ];
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="nc-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle}>
-            {t(mine ? 'dashboards.myNewCustomers' : 'dashboards.newCustomers')}
-          </ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.controls}>
             <ScrollingChipRow>
               {GRANS.map(([g, label]) => (
@@ -158,6 +134,47 @@ export function NewCustomersScreenImpl({ mine = false }: { mine?: boolean }) {
               </View>
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t(mine ? 'dashboards.myNewCustomers' : 'dashboards.newCustomers')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="nc-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>
+            {t(mine ? 'dashboards.myNewCustomers' : 'dashboards.newCustomers')}
+          </ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
       </ThemedView>
     </ModuleGuard>
@@ -169,6 +186,8 @@ export default function NewCustomersScreen() {
 }
 
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/app/dashboards/profitability.tsx
+++ b/expo_app/app/dashboards/profitability.tsx
@@ -56,7 +56,7 @@ type Gran = 'year' | 'quarter' | 'month';
  * quietly overstating gross. And until employee payouts exist, net is "before
  * salaries" rather than a real subtraction.
  */
-export default function ProfitabilityScreen() {
+export function ProfitabilityScreenImpl({ embedded = false }: { embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -102,30 +102,8 @@ export default function ProfitabilityScreen() {
     ['month', t('dashboards.gMonth')],
   ];
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="prof-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle}>{t('dashboards.profitability')}</ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.controls}>
             <ScrollingChipRow>
               {GRANS.map(([g, label]) => (
@@ -195,13 +173,58 @@ export default function ProfitabilityScreen() {
               </View>
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t('dashboards.profitability')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="prof-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>{t('dashboards.profitability')}</ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
       </ThemedView>
     </ModuleGuard>
   );
 }
 
+export default function ProfitabilityScreen() {
+  return <ProfitabilityScreenImpl />;
+}
+
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/app/dashboards/revenue-over-time.tsx
+++ b/expo_app/app/dashboards/revenue-over-time.tsx
@@ -58,7 +58,7 @@ const REVENUE = '#5469D4';
  * equals that period's revenue, so the stacked bar's two segments always add up to
  * the bar — the client only draws what it is given and never does money maths.
  */
-export function RevenueOverTimeScreenImpl({ mine = false }: { mine?: boolean }) {
+export function RevenueOverTimeScreenImpl({ mine = false, embedded = false }: { mine?: boolean; embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -112,32 +112,8 @@ export function RevenueOverTimeScreenImpl({ mine = false }: { mine?: boolean }) 
   const cumNames = [t('dashboards.cumulativeRevenue'), t('dashboards.cumulativeDebt')];
   const barNames = [t('dashboards.received'), t('dashboards.debt')];
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="rot-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle}>
-            {t(mine ? 'dashboards.myRevenue' : 'dashboards.revenueOverTime')}
-          </ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.controls}>
             <ScrollingChipRow>
               {MODES.map(([m, label]) => (
@@ -246,6 +222,47 @@ export function RevenueOverTimeScreenImpl({ mine = false }: { mine?: boolean }) 
               </View>
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t(mine ? 'dashboards.myRevenue' : 'dashboards.revenueOverTime')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="rot-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>
+            {t(mine ? 'dashboards.myRevenue' : 'dashboards.revenueOverTime')}
+          </ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
       </ThemedView>
     </ModuleGuard>
@@ -257,6 +274,8 @@ export default function RevenueOverTimeScreen() {
 }
 
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/app/dashboards/spend.tsx
+++ b/expo_app/app/dashboards/spend.tsx
@@ -50,7 +50,7 @@ type Gran = 'year' | 'quarter' | 'month' | 'week';
  * breakdown, so the client only stacks what it is given. Segment colours are the
  * shared SERIES_COLOURS by position, matching the web and the legend.
  */
-export default function SpendScreen() {
+export function SpendScreenImpl({ embedded = false }: { embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -97,30 +97,8 @@ export default function SpendScreen() {
     ['year', t('dashboards.gYear')],
   ];
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="spend-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle}>{t('dashboards.spend')}</ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.controls}>
             <ScrollingChipRow>
               {GRANS.map(([g, l]) => (
@@ -199,13 +177,58 @@ export default function SpendScreen() {
               </View>
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t('dashboards.spend')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="spend-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>{t('dashboards.spend')}</ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
       </ThemedView>
     </ModuleGuard>
   );
 }
 
+export default function SpendScreen() {
+  return <SpendScreenImpl />;
+}
+
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/app/dashboards/trip-stops.tsx
+++ b/expo_app/app/dashboards/trip-stops.tsx
@@ -46,7 +46,7 @@ const UNASSIGNED_COLOUR = '#9ca3af';
  * keep their true height, and puts stops of unassigned trips into "__unassigned__"
  * (gray). Counts, not money — the one control here is granularity.
  */
-export default function TripStopsScreen() {
+export function TripStopsScreenImpl({ embedded = false }: { embedded?: boolean }) {
   const router = useRouter();
   const insets = useSafeAreaInsets();
   const { width } = useWindowDimensions();
@@ -98,30 +98,8 @@ export default function TripStopsScreen() {
     ['year', t('dashboards.gYear')],
   ];
 
-  return (
-    <ModuleGuard module="dashboard">
-      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-        <Stack.Screen options={{ headerShown: false }} />
-        <View style={styles.topBar}>
-          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="ts-back">
-            <ThemedText style={styles.back}>‹</ThemedText>
-          </TouchableOpacity>
-          <ThemedText style={styles.topTitle}>{t('dashboards.tripStops')}</ThemedText>
-          <View style={styles.backSpacer} />
-        </View>
-
-        <ScrollView
-          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
-          refreshControl={
-            <RefreshControl
-              refreshing={refreshing}
-              onRefresh={() => {
-                setRefreshing(true);
-                load(true);
-              }}
-            />
-          }
-        >
+  const inner = (
+    <>
           <View style={styles.controls}>
             <ScrollingChipRow>
               {GRANS.map(([g, l]) => (
@@ -189,13 +167,58 @@ export default function TripStopsScreen() {
               </View>
             </>
           )}
+    </>
+  );
+
+  // Home stacks this panel inside its own scroller: section title in place
+  // of the top bar, and no ScrollView / guard of its own
+  if (embedded) {
+    return (
+      <View style={styles.embeddedSection}>
+        <ThemedText style={styles.embeddedTitle}>{t('dashboards.tripStops')}</ThemedText>
+        {inner}
+      </View>
+    );
+  }
+
+  return (
+    <ModuleGuard module="dashboard">
+      <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View style={styles.topBar}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={12} testID="ts-back">
+            <ThemedText style={styles.back}>‹</ThemedText>
+          </TouchableOpacity>
+          <ThemedText style={styles.topTitle}>{t('dashboards.tripStops')}</ThemedText>
+          <View style={styles.backSpacer} />
+        </View>
+
+        <ScrollView
+          contentContainerStyle={[styles.body, { paddingBottom: 40 + insets.bottom }]}
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => {
+                setRefreshing(true);
+                load(true);
+              }}
+            />
+          }
+        >
+          {inner}
         </ScrollView>
       </ThemedView>
     </ModuleGuard>
   );
 }
 
+export default function TripStopsScreen() {
+  return <TripStopsScreenImpl />;
+}
+
 const styles = StyleSheet.create({
+  embeddedSection: { paddingHorizontal: 20 },
+  embeddedTitle: { fontSize: 20, fontWeight: '700', color: '#111827', marginBottom: 12, textAlign: 'left' },
   container: { flex: 1, backgroundColor: '#f1f5f9' },
   topBar: { flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16, paddingVertical: 10 },
   back: { fontSize: 30, lineHeight: 34, color: '#5469D4', fontWeight: '700' },

--- a/expo_app/components/HomeDashboards.tsx
+++ b/expo_app/components/HomeDashboards.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useAuth } from '@/contexts/AuthContext';
+import { WelcomeContent } from '@/components/WelcomeContent';
+import { DashboardScreenImpl } from '@/app/dashboard';
+import { ProfitabilityScreenImpl } from '@/app/dashboards/profitability';
+import { RevenueOverTimeScreenImpl } from '@/app/dashboards/revenue-over-time';
+import { CustomerOrdersScreenImpl } from '@/app/dashboards/customer-orders';
+import { NewCustomersScreenImpl } from '@/app/dashboards/new-customers';
+import { MaterialsSoldScreenImpl } from '@/app/dashboards/materials-sold';
+import { TripStopsScreenImpl } from '@/app/dashboards/trip-stops';
+import { MyTripStopsScreenImpl } from '@/app/dashboards/my-trip-stops';
+import { SpendScreenImpl } from '@/app/dashboards/spend';
+
+// dashboard id -> its embedded panel. The personal trio reuses the global
+// screens with `mine`; every panel brings its own section title (the
+// dashboard's name) and controls, mirroring the web Home feed exactly.
+const PANELS: Record<string, () => React.ReactElement> = {
+  'business-overview': () => <DashboardScreenImpl embedded />,
+  profitability: () => <ProfitabilityScreenImpl embedded />,
+  'revenue-over-time': () => <RevenueOverTimeScreenImpl embedded />,
+  'customer-orders': () => <CustomerOrdersScreenImpl embedded />,
+  'new-customers': () => <NewCustomersScreenImpl embedded />,
+  'materials-sold': () => <MaterialsSoldScreenImpl embedded />,
+  'trip-stops': () => <TripStopsScreenImpl embedded />,
+  spend: () => <SpendScreenImpl embedded />,
+  'my-revenue': () => <RevenueOverTimeScreenImpl mine embedded />,
+  'my-materials-sold': () => <MaterialsSoldScreenImpl mine embedded />,
+  'my-new-customers': () => <NewCustomersScreenImpl mine embedded />,
+  'my-trip-stops': () => <MyTripStopsScreenImpl embedded />,
+};
+
+// implemented dashboards in catalog order — an assigned id without a screen
+// simply doesn't appear, same rule as the hub
+const ORDER = [
+  'business-overview',
+  'profitability',
+  'revenue-over-time',
+  'customer-orders',
+  'new-customers',
+  'materials-sold',
+  'trip-stops',
+  'my-revenue',
+  'my-materials-sold',
+  'my-new-customers',
+  'my-trip-stops',
+  'spend',
+];
+
+/**
+ * The Home tab's content: every dashboard the signed-in user's role allows,
+ * stacked in catalog order — the app twin of the web Home feed.
+ *
+ * The list is /auth/me `dashboards` (null = all, for admins) intersected with
+ * the dashboards this client implements. A user with nothing assigned keeps
+ * the old welcome screen rather than an empty feed.
+ */
+export function HomeDashboards() {
+  const { user } = useAuth();
+  const assigned: string[] | null | undefined = (user as any)?.dashboards;
+  const ids = assigned ? ORDER.filter((id) => assigned.includes(id)) : ORDER;
+
+  if (ids.length === 0) return <WelcomeContent />;
+
+  return (
+    <View style={styles.feed}>
+      {ids.map((id) => (
+        <View key={id} style={styles.section}>
+          {PANELS[id]?.() ?? null}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  feed: { paddingTop: 14 },
+  section: {
+    marginBottom: 22,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#d1d5db',
+    paddingBottom: 22,
+  },
+});

--- a/frontend/client/src/App.tsx
+++ b/frontend/client/src/App.tsx
@@ -10,6 +10,7 @@ import Landing from "@/pages/Landing";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import NotFound from "@/pages/not-found";
 import Dashboard from "@/pages/Dashboard";
+import Home from "@/pages/Home";
 import Dashboards from "@/pages/Dashboards";
 import ProfitabilityDashboard from "@/pages/ProfitabilityDashboard";
 import RevenueOverTimeDashboard from "@/pages/RevenueOverTimeDashboard";
@@ -95,13 +96,13 @@ import Signup from "@/pages/Signup";
 import SuperAdmin from "@/pages/SuperAdmin";
 
 function HomeRoute() {
-  // "/" is the public landing page for visitors and the dashboard for
-  // signed-in users
+  // "/" is the public landing page for visitors and, for signed-in users,
+  // Home: their role's dashboards stacked in one feed
   const { isAuthenticated, isLoading } = useAuth();
   if (isLoading) return <div className="min-h-screen brand-gradient" />;
   return isAuthenticated ? (
     <ProtectedRoute>
-      <Dashboard />
+      <Home />
     </ProtectedRoute>
   ) : (
     <Landing />
@@ -116,6 +117,7 @@ function Router() {
       <Route path="/signup" component={Signup} />
       <Route path="/" component={HomeRoute} />
       <Route path="/dashboards" component={() => <ProtectedRoute><Dashboards /></ProtectedRoute>} />
+      <Route path="/dashboards/business-overview" component={() => <ProtectedRoute><Dashboard /></ProtectedRoute>} />
       <Route path="/dashboards/profitability" component={() => <ProtectedRoute><ProfitabilityDashboard /></ProtectedRoute>} />
       <Route path="/dashboards/revenue-over-time" component={() => <ProtectedRoute><RevenueOverTimeDashboard /></ProtectedRoute>} />
       <Route path="/dashboards/spend" component={() => <ProtectedRoute><SpendDashboard /></ProtectedRoute>} />

--- a/frontend/client/src/components/DashboardShell.tsx
+++ b/frontend/client/src/components/DashboardShell.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from "react";
+import { AppLayout } from "@/components/layout/AppLayout";
+
+/**
+ * The wrapper every dashboard page renders inside.
+ *
+ * Standalone (the default) it is the usual full page: AppLayout plus the
+ * scrolling padded container. Embedded, it is just a section — the Home feed
+ * stacks many dashboards inside ONE scrolling page, so each panel must bring
+ * its content (title, controls, cards) but not its own chrome.
+ */
+export function DashboardShell({
+  embedded,
+  children,
+}: {
+  embedded?: boolean;
+  children: ReactNode;
+}) {
+  if (embedded) {
+    return <section className="space-y-6">{children}</section>;
+  }
+  return (
+    <AppLayout>
+      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">{children}</div>
+    </AppLayout>
+  );
+}

--- a/frontend/client/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/client/src/components/layout/MobileBottomNav.tsx
@@ -20,7 +20,7 @@ import {
 } from "lucide-react";
 
 const navigation = [
-  { key: "nav.dashboard", href: "/", icon: LayoutDashboard },
+  { key: "nav.home", href: "/", icon: LayoutDashboard },
   { key: "nav.customers", href: "/customers", icon: Users },
   { key: "nav.materials", href: "/materials", icon: Package },
   { key: "nav.purchase", href: "/purchase-orders", icon: ShoppingCart },

--- a/frontend/client/src/components/layout/Sidebar.tsx
+++ b/frontend/client/src/components/layout/Sidebar.tsx
@@ -41,7 +41,9 @@ interface SidebarProps {
 }
 
 const navigation = [
-  { key: "nav.dashboard", href: "/", icon: LayoutDashboard },
+  // "/" is Home: the signed-in user's role dashboards, stacked. Still gated on
+  // the backend's `dashboard` module (derived from the href below).
+  { key: "nav.home", href: "/", icon: LayoutDashboard },
   // The dashboards hub. `module` is set explicitly because the id checked against the
   // ACL is derived from href.slice(1) below, which would be "dashboards" (plural, not
   // a backend module) — so without this the entry would gate on a module nobody holds.

--- a/frontend/client/src/i18n/translations/nav.ts
+++ b/frontend/client/src/i18n/translations/nav.ts
@@ -2,6 +2,7 @@
 
 export const en: Record<string, string> = {
   'nav.dashboard': 'Dashboard',
+  'nav.home': 'Home',
   'nav.dashboards': 'Dashboards',
   'nav.accounts': 'Accounts',
   'nav.customers': 'Customers',
@@ -39,6 +40,7 @@ export const en: Record<string, string> = {
 
 export const ar: Record<string, string> = {
   'nav.dashboard': 'لوحة التحكم',
+  'nav.home': 'الرئيسية',
   'nav.dashboards': 'لوحات المعلومات',
   'nav.accounts': 'حسابات الشركات',
   'nav.customers': 'العملاء',

--- a/frontend/client/src/lib/dashboards.ts
+++ b/frontend/client/src/lib/dashboards.ts
@@ -30,8 +30,9 @@ export interface DashboardEntry {
  */
 export const IMPLEMENTED_DASHBOARDS: DashboardEntry[] = [
   {
+    // "/" is now Home (the stacked feed); the overview keeps its own page here
     id: "business-overview",
-    href: "/",
+    href: "/dashboards/business-overview",
     icon: LayoutDashboard,
     titleKey: "dashboards.businessOverview",
     descKey: "dashboards.businessOverviewDesc",

--- a/frontend/client/src/pages/CustomerOrdersDashboard.tsx
+++ b/frontend/client/src/pages/CustomerOrdersDashboard.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from "recharts";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -44,7 +44,7 @@ const REPEAT = "#5469D4";
  * while a yearly chart counts their whole first year as new. Counts, not money, so
  * there is no currency here.
  */
-export default function CustomerOrdersDashboard() {
+export default function CustomerOrdersDashboard({ embedded = false }: { embedded?: boolean }) {
   const { t } = useLanguage();
   const [gran, setGran] = useState<Gran>("month");
 
@@ -74,8 +74,7 @@ export default function CustomerOrdersDashboard() {
     key === "newOrders" ? t("dashboards.newCustomers") : t("dashboards.repeatCustomers");
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">{t("dashboards.customerOrders")}</h2>
@@ -189,7 +188,6 @@ export default function CustomerOrdersDashboard() {
             )}
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }

--- a/frontend/client/src/pages/Dashboard.tsx
+++ b/frontend/client/src/pages/Dashboard.tsx
@@ -9,7 +9,7 @@ import {
   CartesianGrid,
   Tooltip,
 } from "recharts";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useAuth } from "@/contexts/AuthContext";
@@ -154,7 +154,7 @@ function StatCard({
   );
 }
 
-export default function Dashboard() {
+export default function Dashboard({ embedded = false }: { embedded?: boolean }) {
   const { user } = useAuth();
   const { t, te } = useLanguage();
   const [days, setDays] = useState(30);
@@ -188,15 +188,19 @@ export default function Dashboard() {
   const forbidden = error && /^403/.test((error as Error).message || "");
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         {/* header */}
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
-            <h2 className="text-2xl font-bold text-gray-900">{t("dashboard.title")}</h2>
-            <p className="text-sm text-gray-600">
-              {t("dashboard.welcome", { name: firstName ? `, ${firstName}` : "" })}
-            </p>
+            {/* titled by its dashboard name, so the Home stack reads uniformly */}
+            <h2 className="text-2xl font-bold text-gray-900">
+              {t("dashboards.businessOverview")}
+            </h2>
+            {!embedded && (
+              <p className="text-sm text-gray-600">
+                {t("dashboard.welcome", { name: firstName ? `, ${firstName}` : "" })}
+              </p>
+            )}
           </div>
           {!forbidden && (
             <div className="flex items-center gap-2 flex-wrap">
@@ -400,7 +404,6 @@ export default function Dashboard() {
             </div>
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }

--- a/frontend/client/src/pages/Home.tsx
+++ b/frontend/client/src/pages/Home.tsx
@@ -1,0 +1,70 @@
+import { AppLayout } from "@/components/layout/AppLayout";
+import { Card, CardContent } from "@/components/ui/card";
+import { useAuth } from "@/contexts/AuthContext";
+import { useLanguage } from "@/contexts/LanguageContext";
+import { visibleDashboards } from "@/lib/dashboards";
+import Dashboard from "@/pages/Dashboard";
+import ProfitabilityDashboard from "@/pages/ProfitabilityDashboard";
+import RevenueOverTimeDashboard from "@/pages/RevenueOverTimeDashboard";
+import CustomerOrdersDashboard from "@/pages/CustomerOrdersDashboard";
+import NewCustomersDashboard from "@/pages/NewCustomersDashboard";
+import MaterialsSoldDashboard from "@/pages/MaterialsSoldDashboard";
+import TripStopsDashboard from "@/pages/TripStopsDashboard";
+import MyTripStopsDashboard from "@/pages/MyTripStopsDashboard";
+import SpendDashboard from "@/pages/SpendDashboard";
+
+// dashboard id -> its embedded panel. The personal trio reuses the global
+// screens with `mine`; every panel brings its own title (the dashboard's name)
+// and controls, so the feed needs no extra headers.
+const PANELS: Record<string, () => JSX.Element> = {
+  "business-overview": () => <Dashboard embedded />,
+  profitability: () => <ProfitabilityDashboard embedded />,
+  "revenue-over-time": () => <RevenueOverTimeDashboard embedded />,
+  "customer-orders": () => <CustomerOrdersDashboard embedded />,
+  "new-customers": () => <NewCustomersDashboard embedded />,
+  "materials-sold": () => <MaterialsSoldDashboard embedded />,
+  "trip-stops": () => <TripStopsDashboard embedded />,
+  spend: () => <SpendDashboard embedded />,
+  "my-revenue": () => <RevenueOverTimeDashboard mine embedded />,
+  "my-materials-sold": () => <MaterialsSoldDashboard mine embedded />,
+  "my-new-customers": () => <NewCustomersDashboard mine embedded />,
+  "my-trip-stops": () => <MyTripStopsDashboard embedded />,
+};
+
+/**
+ * Home: every dashboard the signed-in user's role allows, stacked in catalog
+ * order, each titled by its dashboard name.
+ *
+ * The list comes from /auth/me `dashboards` (null = all, for admins) — the same
+ * role assignment the hub and the app read — intersected with the dashboards
+ * this client implements, so a role sees the same set everywhere and an id
+ * without a screen never renders a hole. A role with nothing assigned gets an
+ * honest empty card rather than a blank page.
+ */
+export default function Home() {
+  const { user } = useAuth();
+  const { t } = useLanguage();
+  const entries = visibleDashboards(user?.dashboards);
+
+  return (
+    <AppLayout>
+      <div className="flex-1 overflow-auto p-4 lg:p-6">
+        {entries.length === 0 ? (
+          <Card>
+            <CardContent className="pt-6 text-sm text-gray-500">
+              {t("dashboards.none")}
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="divide-y divide-gray-200">
+            {entries.map((d) => (
+              <div key={d.id} className="py-8 first:pt-0">
+                {PANELS[d.id]?.() ?? null}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </AppLayout>
+  );
+}

--- a/frontend/client/src/pages/MaterialsSoldDashboard.tsx
+++ b/frontend/client/src/pages/MaterialsSoldDashboard.tsx
@@ -11,7 +11,7 @@ import {
   Legend,
 } from "recharts";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -52,7 +52,7 @@ const short = (s: string, n = 12) => (s.length > n ? `${s.slice(0, n - 1)}…` :
  * by (material, unit) and never sums across materials, so the bars are honest even
  * though the y-axis mixes units.
  */
-export default function MaterialsSoldDashboard({ mine = false }: { mine?: boolean }) {
+export default function MaterialsSoldDashboard({ mine = false, embedded = false }: { mine?: boolean; embedded?: boolean }) {
   const { t } = useLanguage();
   const [gran, setGranRaw] = useState<Gran>("month");
   const [offset, setOffset] = useState(0);
@@ -95,8 +95,7 @@ export default function MaterialsSoldDashboard({ mine = false }: { mine?: boolea
     key === "fulfilled" ? t("dashboards.fulfilled") : t("dashboards.unfulfilled");
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">
@@ -265,7 +264,6 @@ export default function MaterialsSoldDashboard({ mine = false }: { mine?: boolea
             )}
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }

--- a/frontend/client/src/pages/MyTripStopsDashboard.tsx
+++ b/frontend/client/src/pages/MyTripStopsDashboard.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from "recharts";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -43,7 +43,7 @@ const NOT_COMPLETED = "#d97706";
  * so status is the honest breakdown. Self-scoped endpoint, so any authenticated
  * user (a driver, a rep) may see their own numbers.
  */
-export default function MyTripStopsDashboard() {
+export default function MyTripStopsDashboard({ embedded = false }: { embedded?: boolean }) {
   const { t } = useLanguage();
   const [gran, setGran] = useState<Gran>("month");
 
@@ -73,8 +73,7 @@ export default function MyTripStopsDashboard() {
     key === "completed" ? t("dashboards.completed") : t("dashboards.notCompleted");
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">{t("dashboards.myTripStops")}</h2>
@@ -189,7 +188,6 @@ export default function MyTripStopsDashboard() {
             )}
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }

--- a/frontend/client/src/pages/NewCustomersDashboard.tsx
+++ b/frontend/client/src/pages/NewCustomersDashboard.tsx
@@ -9,7 +9,7 @@ import {
   CartesianGrid,
   Tooltip,
 } from "recharts";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -38,7 +38,7 @@ const NEW = "#16a34a";
  * purchasing side. One series, so the bars are unstacked and there is no
  * currency involved.
  */
-export default function NewCustomersDashboard({ mine = false }: { mine?: boolean }) {
+export default function NewCustomersDashboard({ mine = false, embedded = false }: { mine?: boolean; embedded?: boolean }) {
   const { t } = useLanguage();
   const [gran, setGran] = useState<Gran>("month");
 
@@ -64,8 +64,7 @@ export default function NewCustomersDashboard({ mine = false }: { mine?: boolean
   ];
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">
@@ -170,7 +169,6 @@ export default function NewCustomersDashboard({ mine = false }: { mine?: boolean
             )}
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }

--- a/frontend/client/src/pages/ProfitabilityDashboard.tsx
+++ b/frontend/client/src/pages/ProfitabilityDashboard.tsx
@@ -11,7 +11,7 @@ import {
   Legend,
   ReferenceLine,
 } from "recharts";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -93,7 +93,7 @@ function PillGroup({
  * unknown cost are left out of cost of goods rather than counted as free, and until
  * employee payouts exist net is "before salaries".
  */
-export default function ProfitabilityDashboard() {
+export default function ProfitabilityDashboard({ embedded = false }: { embedded?: boolean }) {
   const { t, te } = useLanguage();
   const [gran, setGran] = useState<Gran>("month");
   const [ccy, setCcy] = useState<Ccy>("USD");
@@ -122,8 +122,7 @@ export default function ProfitabilityDashboard() {
   ];
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">{t("dashboards.profitability")}</h2>
@@ -268,7 +267,6 @@ export default function ProfitabilityDashboard() {
             )}
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }

--- a/frontend/client/src/pages/RevenueOverTimeDashboard.tsx
+++ b/frontend/client/src/pages/RevenueOverTimeDashboard.tsx
@@ -12,7 +12,7 @@ import {
   Tooltip,
   Legend,
 } from "recharts";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -97,7 +97,7 @@ function PillGroup({
  * stacked bar's two segments always add up to the bar. A currency switch converts
  * each order at its own date rather than dropping the other currency.
  */
-export default function RevenueOverTimeDashboard({ mine = false }: { mine?: boolean }) {
+export default function RevenueOverTimeDashboard({ mine = false, embedded = false }: { mine?: boolean; embedded?: boolean }) {
   const { t, te } = useLanguage();
   const [mode, setMode] = useState<Mode>("cumulative");
   const [gran, setGran] = useState<Gran>("month");
@@ -146,8 +146,7 @@ export default function RevenueOverTimeDashboard({ mine = false }: { mine?: bool
   };
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">
@@ -321,7 +320,6 @@ export default function RevenueOverTimeDashboard({ mine = false }: { mine?: bool
             )}
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }

--- a/frontend/client/src/pages/SpendDashboard.tsx
+++ b/frontend/client/src/pages/SpendDashboard.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from "recharts";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -93,7 +93,7 @@ function PillGroup({
  * breakdown converted to the chosen currency, so the client just stacks what it is
  * given and a currency switch converts rather than drops the other currency.
  */
-export default function SpendDashboard() {
+export default function SpendDashboard({ embedded = false }: { embedded?: boolean }) {
   const { t, te } = useLanguage();
   const [gran, setGran] = useState<Gran>("month");
   const [ccy, setCcy] = useState<Ccy>("USD");
@@ -125,8 +125,7 @@ export default function SpendDashboard() {
   ];
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">{t("dashboards.spend")}</h2>
@@ -248,7 +247,6 @@ export default function SpendDashboard() {
             )}
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }

--- a/frontend/client/src/pages/TripStopsDashboard.tsx
+++ b/frontend/client/src/pages/TripStopsDashboard.tsx
@@ -10,7 +10,7 @@ import {
   Tooltip,
   Legend,
 } from "recharts";
-import { AppLayout } from "@/components/layout/AppLayout";
+import { DashboardShell } from "@/components/DashboardShell";
 import { Card, CardContent } from "@/components/ui/card";
 import { apiRequest } from "@/lib/queryClient";
 import { useLanguage } from "@/contexts/LanguageContext";
@@ -49,7 +49,7 @@ const OTHERS = "__others__";
  * unassigned trips into "__unassigned__" (drawn gray). Counts, not money — no
  * currency toggle.
  */
-export default function TripStopsDashboard() {
+export default function TripStopsDashboard({ embedded = false }: { embedded?: boolean }) {
   const { t } = useLanguage();
   const [gran, setGran] = useState<Gran>("month");
 
@@ -85,8 +85,7 @@ export default function TripStopsDashboard() {
   ];
 
   return (
-    <AppLayout>
-      <div className="flex-1 overflow-auto p-4 lg:p-6 space-y-6">
+    <DashboardShell embedded={embedded}>
         <div className="flex items-end justify-between flex-wrap gap-3">
           <div>
             <h2 className="text-2xl font-bold text-gray-900">{t("dashboards.tripStops")}</h2>
@@ -197,7 +196,6 @@ export default function TripStopsDashboard() {
             )}
           </>
         )}
-      </div>
-    </AppLayout>
+    </DashboardShell>
   );
 }


### PR DESCRIPTION
## What

Two changes to the web app, plus a permission bug fix the verification surfaced:

1. **Rename:** the sidebar / mobile-nav first entry is now **Home** ("Home" / "الرئيسية") instead of "Dashboard". Same route, same `dashboard` module gating.

2. **Home = the role's dashboards, stacked.** For the signed-in user, `/` now renders **every dashboard their role allows**, in catalog order, **each titled by its dashboard name**. The list is `/auth/me` `dashboards` (null = all, for admins) intersected with what the client implements — the same resolution the hub and the app use. A role with nothing assigned gets an honest empty card.

   Mechanically, each dashboard page now renders inside a shared `DashboardShell` (full page standalone, bare section when `embedded`) — so Home composes the **real pages**, controls and all, not copies. The business overview keeps a standalone route at `/dashboards/business-overview` (the hub card points there now that `/` is the feed) and is retitled to its dashboard name.

## 🐛 Bug fix: self-scoped dashboards were 403 for the roles they were built for

Verifying Home as a real **sales** user exposed a bug #120 shipped with: the app-wide fine-grained ACL checks every `/dashboard/*` request against the caller's per-resource grants, so the self-scoped `my-*` endpoints returned **403** for sales/driver users (earlier verification missed it — both test users hit the is-admin bypass). Fixed by exempting the four `SELF_SCOPED_DASHBOARD_ENDPOINTS` from the **per-user** check only: they return nothing but the caller's own records, and the account gates (verification, tenant feature cap) still bind.

## Verification (live, three users)
- **Superuser Home:** all 12 implemented dashboards stacked, each titled (Business Overview → … → Expenses & Salaries).
- **Sales (wael) Home:** exactly their 4 personal panels — and after the ACL fix, with data (My New Customers shows the **88 customers wael created**; the rest honestly empty).
- **Access matrix:** wael's `my-*` → 200, wael's business-wide endpoints → still 403, admin unchanged.
- Sidebar + mobile nav read "Home"; web typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)