### PR TITLE
Web: static sidebar — page and sidebar scroll independently

### DIFF
--- a/frontend/client/src/components/layout/AppLayout.tsx
+++ b/frontend/client/src/components/layout/AppLayout.tsx
@@ -29,7 +29,10 @@ export function AppLayout({ children }: AppLayoutProps) {
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
+    // h-screen + overflow-hidden pin the shell to the viewport: the DOCUMENT
+    // never scrolls, so the sidebar stays put while <main> below scrolls its
+    // own content (and the sidebar's nav keeps its own independent scroll)
+    <div className="h-screen overflow-hidden flex flex-col">
       {impersonatingCompany && (
         <div
           data-testid="impersonation-banner"
@@ -45,12 +48,18 @@ export function AppLayout({ children }: AppLayoutProps) {
           </button>
         </div>
       )}
-      <div className="flex-1 flex flex-col lg:flex-row">
+      {/* min-h-0 lets this row shrink to the leftover viewport height instead
+          of growing with its content — without it flexbox sizes the row to the
+          tallest child and the document scrolls again */}
+      <div className="flex-1 min-h-0 flex flex-col lg:flex-row overflow-hidden">
         <Sidebar isOpen={isMobileMenuOpen} onClose={() => setIsMobileMenuOpen(false)} />
 
         <MobileHeader onMenuToggle={() => setIsMobileMenuOpen(!isMobileMenuOpen)} />
 
-        <main className="flex-1 flex flex-col overflow-hidden pb-16 lg:pb-0">
+        {/* overflow-y-auto (not hidden): pages that bring their own scroll
+            container keep it; pages that don't now scroll here instead of
+            scrolling the document out from under the sidebar */}
+        <main className="flex-1 min-h-0 flex flex-col overflow-y-auto pb-16 lg:pb-0">
           {children}
         </main>
 

--- a/frontend/client/src/components/layout/Sidebar.tsx
+++ b/frontend/client/src/components/layout/Sidebar.tsx
@@ -179,7 +179,10 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
       <aside className={cn(
         "fixed inset-y-0 start-0 z-50 w-64 bg-white border-e border-gray-200 shadow-sm transform transition-transform duration-200 ease-in-out lg:translate-x-0 lg:static lg:inset-0",
         isOpen ? "translate-x-0" : "max-lg:-translate-x-full max-lg:rtl:translate-x-full",
-        "flex flex-col h-screen touch-none"
+        // h-screen only for the mobile fixed overlay; on desktop the aside sits
+        // inside the viewport-pinned row, so it fills THAT (h-full) — h-screen
+        // there would overflow by the impersonation banner's height
+        "flex flex-col h-screen lg:h-full touch-none"
       )}
         onTouchMove={(e) => {
           // Prevent touch events from bubbling to the main page when sidebar is open on mobile


### PR DESCRIPTION
## What

The sidebar now stays put while the page scrolls, and keeps its own independent scroll — most visible on the new Home feed, where scrolling 12 stacked dashboards used to carry the sidebar off-screen.

## How

The layout root was `min-h-screen`, so any page taller than the viewport scrolled the **document**, taking the `lg:static` sidebar with it. Now:

- root: `h-screen overflow-hidden` — the document never scrolls;
- the flex row gets `min-h-0` so it shrinks to the leftover viewport instead of growing with its tallest child;
- `<main>`: `overflow-y-auto` (was `hidden`) — pages with their own scroll container keep it, pages without one still scroll;
- the aside keeps `h-screen` only for the mobile fixed overlay and fills the row (`lg:h-full`) on desktop, so it sizes correctly under the impersonation banner;
- the sidebar's nav keeps its existing independent `overflow-y-auto` scroll — which now actually shows.

## Verified live
- Home (longest page): document reports unscrollable; the content scroller moves 2000px while the aside stays at (0,0); the sidebar nav scrolls independently.
- A regular list page (customers) scrolls internally as before.
- Mobile viewport: internal content scroll + fixed bottom nav intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)