### PR TITLE
Orders: payment-aware price-per-unit editing (both clients)

### DIFF
--- a/backend/app/dto/customer_order.py
+++ b/backend/app/dto/customer_order.py
@@ -138,6 +138,11 @@ class CustomerOrderWithItemsAndInvoiceRead(BaseModel):
     model_config = ConfigDict(extra="forbid")
     customer_order: CustomerOrderRead
     invoices: list[InvoiceRead]
+    # whether line prices may be edited, decided by the ORDER's payment state:
+    # "unpaid" (free), "single_payment" (allowed; the one payment absorbs the
+    # delta) or "locked". Set by the detail route — both clients read it here
+    # so the rule lives server-side only.
+    price_edit_state: Optional[str] = None
 
     @classmethod
     def from_customer_order_model(cls, customer_order:CustomerOrder):

--- a/backend/app/dto/invoice_item.py
+++ b/backend/app/dto/invoice_item.py
@@ -65,3 +65,11 @@ class InvoiceItemPage(BaseModel):
     page: int
     per_page: int
     pages: int
+class InvoiceItemPriceUpdate(BaseModel):
+    """Change one line's price per unit — the payment-aware edit.
+
+    Deliberately the ONLY editable field: quantity changes stock and
+    fulfilment, price is the thing that gets corrected after the fact.
+    """
+    model_config = ConfigDict(extra="forbid")
+    price_per_unit: float = Field(ge=0)

--- a/backend/app/entrypoint/routes/customer_order/routes.py
+++ b/backend/app/entrypoint/routes/customer_order/routes.py
@@ -66,12 +66,17 @@ def create_customer_order_checkout():
                     PermissionScope.ACCOUNTANT.value
                  )
 def get_customer_order_with_items_and_invoice(uuid: str):
+    from app.entrypoint.routes.invoice_item.routes import order_price_edit_state
+
     with SqlAlchemyUnitOfWork() as uow:
         cus_order = uow.customer_order_repository.find_one(uuid=uuid, is_deleted=False)
         if not cus_order:
             raise NotFoundError("CustomerOrder not found")
 
         dto=CustomerOrderWithItemsAndInvoiceRead.from_customer_order_model(cus_order)
+        # both clients decide whether to offer the price editor from this one
+        # server-computed flag, so the payment-state rule cannot drift
+        dto.price_edit_state, _ = order_price_edit_state(cus_order)
         result = dto.model_dump(mode="json")
     return jsonify(result), 201
 

--- a/backend/app/entrypoint/routes/invoice_item/routes.py
+++ b/backend/app/entrypoint/routes/invoice_item/routes.py
@@ -99,3 +99,136 @@ def bulk_delete_invoice_items():
         )
         uow.commit()
     return jsonify(bulk_read.model_dump(mode='json')), 200
+
+
+# ---------------------------------------------------------------------------
+# Payment-aware price editing
+# ---------------------------------------------------------------------------
+
+def order_price_edit_state(order):
+    """Whether line prices on this ORDER may be edited, and how.
+
+    Returns (state, payment):
+      * "unpaid"         — nothing has settled any of the order's invoices:
+                           prices may change freely, nothing else moves.
+      * "single_payment" — the order is fully paid by exactly ONE payment:
+                           a price change is allowed and that payment moves by
+                           the same delta, so the order stays exactly paid.
+                           `payment` is that payment.
+      * "locked"         — every other case (partially paid, several payments,
+                           credit/debit notes in play): the money trail is not
+                           a single reversible step, so prices are read-only.
+
+    Credit/debit notes lock even the unpaid case on purpose: they adjust the
+    very total a price edit would change, and untangling which of the two
+    "corrections" wins is a judgement call, not arithmetic.
+    """
+    from models.common import MONEY_TOLERANCE
+
+    invoices = [inv for inv in order.invoices if not inv.is_deleted]
+    payments = [
+        p for inv in invoices for p in inv.payments if not p.is_deleted
+    ]
+    has_notes = any(
+        not note.is_deleted
+        for inv in invoices
+        for item in inv.invoice_items
+        if not item.is_deleted
+        for note in (list(item.credit_note_items) + list(item.debit_note_items))
+    )
+    if has_notes:
+        return "locked", None
+    if not payments and abs(order.net_amount_paid) <= MONEY_TOLERANCE:
+        return "unpaid", None
+    if len(payments) == 1 and order.is_paid:
+        return "single_payment", payments[0]
+    return "locked", None
+
+
+@invoice_item_blueprint.route('/<string:uuid>/price', methods=['PUT'])
+@jwt_required()
+@scopes_required(PermissionScope.ADMIN.value,
+                 PermissionScope.SUPER_ADMIN.value,
+                 PermissionScope.ACCOUNTANT.value,
+                 PermissionScope.SALES.value,
+                 PermissionScope.DRIVER.value)
+def update_invoice_item_price(uuid: str):
+    """Change one line's price per unit, if the order's payment state allows.
+
+    unpaid          -> the price changes, nothing else moves.
+    single_payment  -> the price changes AND the one payment that settled the
+                       order moves by the same delta, so the order stays
+                       exactly paid — a correction, not a new money event.
+    locked          -> 409 with code "price_locked"; nothing changes.
+    """
+    from flask import g
+    from models.common import MONEY_TOLERANCE
+    from app.dto.invoice_item import InvoiceItemPriceUpdate
+    from app.dto.payment import PaymentRead
+    from app.entrypoint.routes.common.errors import BadRequestError
+
+    payload = InvoiceItemPriceUpdate(**request.json)
+    with SqlAlchemyUnitOfWork() as uow:
+        item = uow.invoice_item_repository.find_one(uuid=uuid, is_deleted=False)
+        if not item:
+            raise NotFoundError('Invoice item not found')
+        invoice = item.invoice
+        if not invoice or invoice.is_deleted:
+            raise NotFoundError('Invoice not found')
+        order = invoice.customer_order
+
+        state, payment = order_price_edit_state(order)
+        if state == "locked":
+            return jsonify({
+                "code": "price_locked",
+                "msg": "Price editing is locked: the order is partially paid, "
+                       "settled by several payments, or carries credit/debit "
+                       "notes.",
+            }), 409
+
+        old_price = item.price_per_unit or 0.0
+        delta = (payload.price_per_unit - old_price) * (item.quantity or 0)
+
+        adjusted_payment = None
+        if state == "single_payment":
+            # the payment must sit on the same invoice as the line it is asked
+            # to absorb — with several invoices on the order, moving invoice
+            # B's total against invoice A's payment would unbalance both
+            if payment.invoice_uuid != invoice.uuid:
+                return jsonify({
+                    "code": "price_locked",
+                    "msg": "The order's payment settles a different invoice "
+                           "than this line's.",
+                }), 409
+            new_amount = (payment.amount or 0.0) + delta
+            if new_amount < -MONEY_TOLERANCE:
+                raise BadRequestError(
+                    f"price change would drive the payment negative "
+                    f"({round(new_amount, 2)})"
+                )
+            payment.amount = max(0.0, new_amount)
+            adjusted_payment = payment
+
+        item.price_per_unit = payload.price_per_unit
+        uow.session.flush()
+
+        # the whole point of the single-payment branch is that the order stays
+        # exactly paid; if float dust or a missed relationship broke that,
+        # refuse to commit rather than ship a half-applied correction
+        if state == "single_payment" and abs(order.net_amount_due) > MONEY_TOLERANCE:
+            uow.session.rollback()
+            raise BadRequestError(
+                "price change failed to keep the order fully paid; nothing "
+                "was changed"
+            )
+
+        result = {
+            "invoice_item": InvoiceItemRead.from_orm(item).model_dump(mode='json'),
+            "payment": (
+                PaymentRead.from_orm(adjusted_payment).model_dump(mode='json')
+                if adjusted_payment else None
+            ),
+            "price_edit_state": state,
+        }
+        uow.commit()
+    return jsonify(result), 200

--- a/expo_app/app/customer-orders/[uuid].tsx
+++ b/expo_app/app/customer-orders/[uuid].tsx
@@ -69,6 +69,8 @@ interface Order {
 interface OrderPayload {
   customer_order: Order;
   invoices?: Invoice[] | null;
+  /** server-decided price editability: "unpaid" | "single_payment" | "locked" */
+  price_edit_state?: string | null;
 }
 
 /**
@@ -89,10 +91,12 @@ interface OrderPayload {
  * recorded payments, stock movements — even on settled orders. Its confirm spells
  * that out, because the web version hides the same power behind a bare confirm().
  *
- * Items are IMMUTABLE after creation, and that is the billing contract, not a gap:
- * the bulk item endpoint rejects prices and creates no invoice line, so an item added
- * later would be unpriced and invisible to the invoice totals. Fixing a wrong order
- * is void-and-recreate, never editing lines in place.
+ * Items are mostly immutable after creation — quantities and materials stay the
+ * billing contract, fixed by void-and-recreate. The ONE in-place edit is price per
+ * unit, and only when the server says the order's payment state allows it
+ * (price_edit_state): freely while nothing is paid, or on a fully-paid order
+ * settled by a single payment — in which case that payment absorbs the delta so
+ * the order stays exactly paid. Everything else is locked server-side.
  */
 export default function CustomerOrderDetailScreen() {
   const { uuid } = useLocalSearchParams<{ uuid: string }>();
@@ -105,6 +109,32 @@ export default function CustomerOrderDetailScreen() {
   const [notesOpen, setNotesOpen] = useState(false);
   const [notesDraft, setNotesDraft] = useState('');
   const [notesSaving, setNotesSaving] = useState(false);
+
+  // price editor state — one invoice line at a time, seeded with its current price
+  const [priceItem, setPriceItem] = useState<InvoiceItem | null>(null);
+  const [priceDraft, setPriceDraft] = useState('');
+  const [priceSaving, setPriceSaving] = useState(false);
+
+  const savePrice = async () => {
+    if (!priceItem) return;
+    const price = parseFloat(priceDraft);
+    if (isNaN(price) || price < 0) return;
+    setPriceSaving(true);
+    const res = await apiCall(`/invoice-item/${priceItem.uuid}/price`, {
+      method: 'PUT',
+      body: JSON.stringify({ price_per_unit: price }),
+    });
+    setPriceSaving(false);
+    if (isOk(res.status)) {
+      setPriceItem(null);
+      setReloadKey((k) => k + 1);
+    } else {
+      Alert.alert(
+        t('customerOrders.editPrice'),
+        String(res.error ?? '').slice(0, 300) || t('form.tryAgain'),
+      );
+    }
+  };
 
   const liveItems = (o: Order) =>
     (o.customer_order_items ?? []).filter((i) => !i.is_deleted);
@@ -284,6 +314,11 @@ export default function CustomerOrderDetailScreen() {
                         {t('customerOrders.paidAmount')} {money(inv.net_amount_paid, inv.currency)}
                         {inv.due_date ? ` · ${formatNumericDate(new Date(inv.due_date))}` : ''}
                       </ThemedText>
+                      {d.price_edit_state === 'single_payment' && (
+                        <ThemedText style={styles.priceNote}>
+                          {t('customerOrders.priceEditPaymentNote')}
+                        </ThemedText>
+                      )}
                       {(inv.invoice_items ?? [])
                         .filter((li) => !li.is_deleted)
                         .map((li) => (
@@ -295,6 +330,23 @@ export default function CustomerOrderDetailScreen() {
                               {li.quantity ?? '—'} × {money(li.price_per_unit, null)} ={' '}
                               {money(li.total_price, inv.currency)}
                             </ThemedText>
+                            {/* price is the one editable line field, and only when
+                                the ORDER's payment state allows (server-decided) */}
+                            {(d.price_edit_state === 'unpaid' ||
+                              d.price_edit_state === 'single_payment') && (
+                              <TouchableOpacity
+                                onPress={() => {
+                                  setPriceDraft(String(li.price_per_unit ?? ''));
+                                  setPriceItem(li);
+                                }}
+                                hitSlop={8}
+                                testID={`edit-price-${li.uuid}`}
+                              >
+                                <ThemedText style={styles.editPrice}>
+                                  {t('customerOrders.editPrice')}
+                                </ThemedText>
+                              </TouchableOpacity>
+                            )}
                           </View>
                         ))}
                       {/* per-invoice, so a second invoice on the order is payable
@@ -406,6 +458,51 @@ export default function CustomerOrderDetailScreen() {
           </View>
         </View>
       </Modal>
+
+      <Modal
+        visible={!!priceItem}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setPriceItem(null)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalSheet}>
+            <ThemedText style={styles.modalTitle}>
+              {t('customerOrders.editPrice')}
+              {priceItem?.material_name ? ` — ${priceItem.material_name}` : ''}
+            </ThemedText>
+            <TextInput
+              style={styles.priceInput}
+              value={priceDraft}
+              onChangeText={setPriceDraft}
+              keyboardType="decimal-pad"
+              placeholder={t('customerOrders.newPricePerUnit')}
+              placeholderTextColor="#9ca3af"
+              autoFocus
+              testID="order-price-input"
+            />
+            <View style={styles.modalRow}>
+              <TouchableOpacity
+                style={styles.modalCancel}
+                onPress={() => setPriceItem(null)}
+                disabled={priceSaving}
+              >
+                <ThemedText style={styles.modalCancelText}>{t('common.cancel')}</ThemedText>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalSave, priceSaving && styles.modalSaveOff]}
+                onPress={savePrice}
+                disabled={priceSaving}
+                testID="order-price-save"
+              >
+                <ThemedText style={styles.modalSaveText}>
+                  {priceSaving ? t('custdetail.saving') : t('form.save')}
+                </ThemedText>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </>
   );
 }
@@ -445,6 +542,18 @@ const styles = StyleSheet.create({
   },
   invoiceLineName: { flex: 1, fontSize: 12, opacity: 0.75 },
   invoiceLineFigures: { fontSize: 12, opacity: 0.6 },
+  editPrice: { fontSize: 12, fontWeight: '700', color: '#5469D4' },
+  priceNote: { fontSize: 11, color: '#B45309', lineHeight: 15, marginTop: 6 },
+  priceInput: {
+    borderWidth: 1,
+    borderColor: 'rgba(0,0,0,0.15)',
+    borderRadius: 8,
+    backgroundColor: '#fff',
+    paddingHorizontal: 10,
+    paddingVertical: 10,
+    fontSize: 16,
+    color: '#111827',
+  },
   payBtn: {
     alignSelf: 'flex-start',
     marginTop: 8,

--- a/expo_app/app/distribution/order.tsx
+++ b/expo_app/app/distribution/order.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Modal,
   ScrollView,
   StyleSheet,
   Switch,
@@ -68,6 +69,46 @@ export default function OrderActionsScreen() {
     ? (data?.invoices || []).find((i: any) => i.uuid === invoiceUuid) ?? data?.invoices?.[0]
     : data?.invoices?.[0];
   const items = (order?.customer_order_items || []).filter((i: any) => !i.is_deleted);
+
+  // payment-aware price editing, same rule the order detail screen follows:
+  // the server decides ("unpaid" | "single_payment" | "locked"). Prices live
+  // on the INVOICE lines, so map each order item to its invoice line here.
+  const priceEditState: string | undefined = data?.price_edit_state;
+  const canEditPrice = priceEditState === 'unpaid' || priceEditState === 'single_payment';
+  const invoiceItemFor = (orderItemUuid: string) => {
+    for (const inv of data?.invoices || []) {
+      if (inv.is_deleted) continue;
+      const hit = (inv.invoice_items || []).find(
+        (li: any) => !li.is_deleted && li.customer_order_item_uuid === orderItemUuid,
+      );
+      if (hit) return hit;
+    }
+    return null;
+  };
+  const [priceItem, setPriceItem] = useState<any>(null);
+  const [priceDraft, setPriceDraft] = useState('');
+  const [priceSaving, setPriceSaving] = useState(false);
+
+  const savePrice = async () => {
+    if (!priceItem) return;
+    const price = parseFloat(priceDraft);
+    if (isNaN(price) || price < 0) return;
+    setPriceSaving(true);
+    const res = await apiCall(`/invoice-item/${priceItem.uuid}/price`, {
+      method: 'PUT',
+      body: JSON.stringify({ price_per_unit: price }),
+    });
+    setPriceSaving(false);
+    if (res.status === 200) {
+      setPriceItem(null);
+      load();
+    } else {
+      Alert.alert(
+        t('customerOrders.editPrice'),
+        String(res.error ?? '').slice(0, 300) || t('form.tryAgain'),
+      );
+    }
+  };
   const unfulfilled = items.filter((i: any) => !i.is_fulfilled);
   const amountDue = invoice?.net_amount_due ?? order?.net_amount_due ?? 0;
   const currency = order?.currency || '';
@@ -201,38 +242,66 @@ export default function OrderActionsScreen() {
 
           {/* items */}
           <View style={styles.itemsBox}>
-            {items.map((i: any) =>
-              i.is_fulfilled ? (
-                <View key={i.uuid} style={styles.itemRow}>
-                  <ThemedText style={styles.itemName}>{i.material_name} × {i.quantity} {i.unit || ''}</ThemedText>
-                  <ThemedText style={[styles.itemTag, styles.tagGreen]}>
-                    {t('order.itemFulfilled')}
+            {priceEditState === 'single_payment' && (
+              <ThemedText style={styles.priceNote}>
+                {t('customerOrders.priceEditPaymentNote')}
+              </ThemedText>
+            )}
+            {items.map((i: any) => {
+              // the price lives on the matching INVOICE line; editable only
+              // when the order's payment state allows (server-decided)
+              const li = invoiceItemFor(i.uuid);
+              const priceRow = canEditPrice && li && (
+                <TouchableOpacity
+                  style={styles.editPriceRow}
+                  onPress={() => {
+                    setPriceDraft(String(li.price_per_unit ?? ''));
+                    setPriceItem(li);
+                  }}
+                  hitSlop={8}
+                  testID={`edit-price-${li.uuid}`}
+                >
+                  <ThemedText style={styles.editPriceText}>
+                    {round2(li.price_per_unit ?? 0)} {te(currency)} · {t('customerOrders.editPrice')}
                   </ThemedText>
+                </TouchableOpacity>
+              );
+              return i.is_fulfilled ? (
+                <View key={i.uuid}>
+                  <View style={styles.itemRow}>
+                    <ThemedText style={styles.itemName}>{i.material_name} × {i.quantity} {i.unit || ''}</ThemedText>
+                    <ThemedText style={[styles.itemTag, styles.tagGreen]}>
+                      {t('order.itemFulfilled')}
+                    </ThemedText>
+                  </View>
+                  {priceRow}
                 </View>
               ) : (
                 // tappable: untick a line to leave it undelivered this time. All
                 // lines start ticked, so tapping nothing keeps the old behaviour.
-                <TouchableOpacity
-                  key={i.uuid}
-                  style={styles.itemRow}
-                  onPress={() =>
-                    setPicked((prev) => {
-                      const next = new Set(prev);
-                      if (next.has(i.uuid)) next.delete(i.uuid);
-                      else next.add(i.uuid);
-                      return next;
-                    })
-                  }
-                  testID={`pick-item-${i.uuid}`}
-                >
-                  <ThemedText style={styles.check}>{picked.has(i.uuid) ? '☑' : '☐'}</ThemedText>
-                  <ThemedText style={styles.itemName}>{i.material_name} × {i.quantity} {i.unit || ''}</ThemedText>
-                  <ThemedText style={[styles.itemTag, styles.tagGray]}>
-                    {t('order.itemPending')}
-                  </ThemedText>
-                </TouchableOpacity>
-              )
-            )}
+                <View key={i.uuid}>
+                  <TouchableOpacity
+                    style={styles.itemRow}
+                    onPress={() =>
+                      setPicked((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(i.uuid)) next.delete(i.uuid);
+                        else next.add(i.uuid);
+                        return next;
+                      })
+                    }
+                    testID={`pick-item-${i.uuid}`}
+                  >
+                    <ThemedText style={styles.check}>{picked.has(i.uuid) ? '☑' : '☐'}</ThemedText>
+                    <ThemedText style={styles.itemName}>{i.material_name} × {i.quantity} {i.unit || ''}</ThemedText>
+                    <ThemedText style={[styles.itemTag, styles.tagGray]}>
+                      {t('order.itemPending')}
+                    </ThemedText>
+                  </TouchableOpacity>
+                  {priceRow}
+                </View>
+              );
+            })}
           </View>
 
           {savedBanner && (
@@ -314,6 +383,51 @@ export default function OrderActionsScreen() {
           )}
         </ScrollView>
       )}
+
+      <Modal
+        visible={!!priceItem}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setPriceItem(null)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalSheet}>
+            <ThemedText style={styles.modalTitle}>
+              {t('customerOrders.editPrice')}
+              {priceItem?.material_name ? ` — ${priceItem.material_name}` : ''}
+            </ThemedText>
+            <TextInput
+              style={styles.priceInput}
+              value={priceDraft}
+              onChangeText={setPriceDraft}
+              keyboardType="decimal-pad"
+              placeholder={t('customerOrders.newPricePerUnit')}
+              placeholderTextColor="#9ca3af"
+              autoFocus
+              testID="order-price-input"
+            />
+            <View style={styles.modalRow}>
+              <TouchableOpacity
+                style={styles.modalCancel}
+                onPress={() => setPriceItem(null)}
+                disabled={priceSaving}
+              >
+                <ThemedText style={styles.modalCancelText}>{t('common.cancel')}</ThemedText>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={[styles.modalSave, priceSaving && styles.modalSaveOff]}
+                onPress={savePrice}
+                disabled={priceSaving}
+                testID="order-price-save"
+              >
+                <ThemedText style={styles.modalSaveText}>
+                  {priceSaving ? t('custdetail.saving') : t('form.save')}
+                </ThemedText>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </ThemedView>
   );
 }
@@ -342,6 +456,33 @@ const styles = StyleSheet.create({
   itemTag: { fontSize: 11, fontWeight: '600', paddingHorizontal: 8, paddingVertical: 2, borderRadius: 8, overflow: 'hidden' },
   tagGreen: { backgroundColor: '#D1FAE5', color: '#047857' },
   tagGray: { backgroundColor: '#E5E7EB', color: '#4B5563' },
+  priceNote: {
+    fontSize: 11, color: '#B45309', lineHeight: 15,
+    paddingHorizontal: 12, paddingTop: 8,
+  },
+  editPriceRow: {
+    paddingHorizontal: 12, paddingBottom: 8, marginTop: -4,
+    alignSelf: 'flex-start',
+  },
+  editPriceText: { fontSize: 12, fontWeight: '700', color: '#5469D4' },
+  modalOverlay: { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.35)' },
+  modalSheet: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 16, borderTopRightRadius: 16,
+    padding: 16, paddingBottom: 32,
+  },
+  modalTitle: { fontSize: 16, fontWeight: '700', marginBottom: 10 },
+  priceInput: {
+    borderWidth: 1, borderColor: 'rgba(0,0,0,0.15)', borderRadius: 8,
+    backgroundColor: '#fff', paddingHorizontal: 10, paddingVertical: 10,
+    fontSize: 16, color: '#111827',
+  },
+  modalRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 10, marginTop: 12 },
+  modalCancel: { paddingHorizontal: 14, paddingVertical: 10 },
+  modalCancelText: { color: '#6b7280', fontWeight: '600' },
+  modalSave: { backgroundColor: '#5469D4', borderRadius: 10, paddingHorizontal: 18, paddingVertical: 10 },
+  modalSaveOff: { opacity: 0.6 },
+  modalSaveText: { color: '#fff', fontWeight: '700' },
   // same green as the stop screen's completed banner, so success reads the same
   // way everywhere in the app
   savedBanner: { backgroundColor: '#D1FAE5', borderRadius: 12, paddingVertical: 14, alignItems: 'center', marginBottom: 14 },

--- a/expo_app/i18n/translations.ts
+++ b/expo_app/i18n/translations.ts
@@ -1174,6 +1174,10 @@ export const translations: Record<Lang, Record<string, string>> = {
   'customerOrders.notes': 'Notes',
   'customerOrders.notesPlaceholder': 'Order notes…',
   'customerOrders.editNotes': 'Edit notes',
+  'customerOrders.editPrice': 'Edit price',
+  'customerOrders.newPricePerUnit': 'New price per unit',
+  'customerOrders.priceEditPaymentNote':
+    'This order is settled by a single payment — changing a price also adjusts that payment by the same amount.',
   'customerOrders.void': 'Void order (admin)',
   'customerOrders.voidConfirm': 'Voids this order and reverses everything it did: line items, the invoice, ALL RECORDED PAYMENTS, and stock movements. This works even on paid and fulfilled orders. This cannot be undone from the app.',
   'customerOrders.unfulfil': 'Unfulfil',
@@ -2399,6 +2403,10 @@ export const translations: Record<Lang, Record<string, string>> = {
   'customerOrders.notes': 'ملاحظات',
   'customerOrders.notesPlaceholder': 'ملاحظات الطلب…',
   'customerOrders.editNotes': 'تعديل الملاحظات',
+  'customerOrders.editPrice': 'تعديل السعر',
+  'customerOrders.newPricePerUnit': 'السعر الجديد للوحدة',
+  'customerOrders.priceEditPaymentNote':
+    'هذا الطلب مسدَّد بدفعة واحدة — تغيير السعر سيعدِّل تلك الدفعة بالمقدار نفسه.',
   'customerOrders.void': 'إلغاء الطلب (مسؤول)',
   'customerOrders.voidConfirm': 'سيؤدي إلغاء هذا الطلب إلى عكس كل ما نتج عنه: البنود والفاتورة وجميع الدفعات المسجلة وحركات المخزون، حتى لو كان الطلب مدفوعاً ومنفذاً. لا يمكن التراجع عن هذا من التطبيق.',
   'customerOrders.unfulfil': 'إلغاء التنفيذ',

--- a/frontend/client/src/i18n/translations/customerOrders.ts
+++ b/frontend/client/src/i18n/translations/customerOrders.ts
@@ -168,6 +168,10 @@ export const en: Record<string, string> = {
   'customerOrders.createdOn': 'Created {date}',
   'customerOrders.dueDatePrefix': 'Due {date}',
   'customerOrders.invoiceItems': 'Invoice Items',
+  'customerOrders.editPrice': 'Edit price',
+  'customerOrders.priceUpdated': 'Price updated',
+  'customerOrders.priceEditPaymentNote':
+    'This order is settled by a single payment — changing a price also adjusts that payment by the same amount.',
   'customerOrders.orderItemDetails': 'Order Item Details',
   'customerOrders.fulfilledOn': 'Fulfilled {date}',
   'customerOrders.itemUuid': 'Item UUID',
@@ -356,6 +360,10 @@ export const ar: Record<string, string> = {
   'customerOrders.createdOn': 'أُنشئ في {date}',
   'customerOrders.dueDatePrefix': 'الاستحقاق {date}',
   'customerOrders.invoiceItems': 'أصناف الفاتورة',
+  'customerOrders.editPrice': 'تعديل السعر',
+  'customerOrders.priceUpdated': 'تم تحديث السعر',
+  'customerOrders.priceEditPaymentNote':
+    'هذا الطلب مسدَّد بدفعة واحدة — تغيير السعر سيعدِّل تلك الدفعة بالمقدار نفسه.',
   'customerOrders.orderItemDetails': 'تفاصيل صنف الطلب',
   'customerOrders.fulfilledOn': 'سُلّم في {date}',
   'customerOrders.itemUuid': 'معرّف الصنف',

--- a/frontend/client/src/pages/CustomerOrderDetail.tsx
+++ b/frontend/client/src/pages/CustomerOrderDetail.tsx
@@ -133,6 +133,42 @@ export default function CustomerOrderDetail() {
   const customerOrder = orderData?.customer_order;
   const customerOrderItems = customerOrder?.customer_order_items || [];
   const invoices = orderData?.invoices || [];
+  // payment-aware price editing, decided SERVER-side from the order's payment
+  // state: "unpaid" (free), "single_payment" (allowed; the one payment absorbs
+  // the delta) or "locked" (partial / several payments / notes)
+  const priceEditState: string | undefined = orderData?.price_edit_state;
+  const canEditPrice = priceEditState === "unpaid" || priceEditState === "single_payment";
+  const [priceEditUuid, setPriceEditUuid] = useState<string | null>(null);
+  const [priceDraft, setPriceDraft] = useState("");
+
+  const priceMutation = useMutation({
+    mutationFn: ({ uuid, price }: { uuid: string; price: number }) =>
+      apiRequest(`/invoice-item/${uuid}/price`, {
+        method: "PUT",
+        body: { price_per_unit: price },
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/customer-order/with-items-and-invoice", params?.id] });
+      setPriceEditUuid(null);
+      toast({
+        title: t('common.success'),
+        description: t('customerOrders.priceUpdated'),
+      });
+    },
+    onError: (error: any) => {
+      toast({
+        title: t('common.error'),
+        description: error.message || t('customerOrders.updateFailed'),
+        variant: "destructive",
+      });
+    },
+  });
+
+  const savePrice = (uuid: string) => {
+    const price = parseFloat(priceDraft);
+    if (isNaN(price) || price < 0) return;
+    priceMutation.mutate({ uuid, price });
+  };
 
   const updateMutation = useMutation({
     mutationFn: (data: { notes?: string }) =>
@@ -764,19 +800,73 @@ export default function CustomerOrderDetail() {
                       </div>
                     </div>
 
-                    {/* Invoice Items */}
+                    {/* Invoice Items — price per unit editable when the order's
+                        payment state allows (server-decided) */}
                     {invoice.invoice_items && invoice.invoice_items.length > 0 && (
                       <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
                         <h5 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">{t('customerOrders.invoiceItems')}</h5>
+                        {priceEditState === "single_payment" && (
+                          <p className="text-xs text-amber-700 mb-2" data-testid="price-edit-payment-note">
+                            {t('customerOrders.priceEditPaymentNote')}
+                          </p>
+                        )}
                         <div className="space-y-2">
                           {invoice.invoice_items.map((item: InvoiceItem) => (
-                            <div key={item.uuid} className="flex items-center justify-between text-sm">
+                            <div key={item.uuid} className="flex items-center justify-between gap-3 text-sm">
                               <span className="text-gray-600 dark:text-gray-400">
-                                {item.material_name} ({item.quantity} {item.unit})
+                                {item.material_name} ({item.quantity} {item.unit} × {formatCurrency(item.price_per_unit, item.currency)})
                               </span>
-                              <span className="font-medium text-gray-900 dark:text-gray-100">
-                                {formatCurrency(item.total_price, item.currency)}
-                              </span>
+                              {priceEditUuid === item.uuid ? (
+                                <span className="flex items-center gap-1">
+                                  <Input
+                                    type="number"
+                                    min="0"
+                                    step="any"
+                                    value={priceDraft}
+                                    onChange={(e) => setPriceDraft(e.target.value)}
+                                    className="h-7 w-28 text-sm"
+                                    data-testid={`price-input-${item.uuid}`}
+                                    autoFocus
+                                  />
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    className="h-7 w-7 p-0"
+                                    onClick={() => savePrice(item.uuid)}
+                                    disabled={priceMutation.isPending}
+                                    data-testid={`price-save-${item.uuid}`}
+                                  >
+                                    <Save className="h-4 w-4 text-green-700" />
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    className="h-7 w-7 p-0"
+                                    onClick={() => setPriceEditUuid(null)}
+                                  >
+                                    <X className="h-4 w-4" />
+                                  </Button>
+                                </span>
+                              ) : (
+                                <span className="flex items-center gap-1 font-medium text-gray-900 dark:text-gray-100">
+                                  {formatCurrency(item.total_price, item.currency)}
+                                  {canEditPrice && (
+                                    <Button
+                                      size="sm"
+                                      variant="ghost"
+                                      className="h-7 w-7 p-0"
+                                      title={t('customerOrders.editPrice')}
+                                      onClick={() => {
+                                        setPriceEditUuid(item.uuid);
+                                        setPriceDraft(String(item.price_per_unit));
+                                      }}
+                                      data-testid={`price-edit-${item.uuid}`}
+                                    >
+                                      <Edit3 className="h-3.5 w-3.5 text-gray-400" />
+                                    </Button>
+                                  )}
+                                </span>
+                              )}
                             </div>
                           ))}
                         </div>


### PR DESCRIPTION
## What

A line's **price per unit** becomes editable on the customer-order detail — gated by the order's payment state, exactly as specified:

| Order state | Behaviour |
|---|---|
| **Not paid at all** | Price edits freely; nothing else moves. |
| **Fully paid by exactly one payment** | Price edits, and **that payment moves by the same delta** — the order stays exactly paid (a correction, not a new money event). |
| **Everything else** (partial, several payments, credit/debit notes) | **Locked** — `409 price_locked`, no editor shown. |

## Design
- **One server-side rule.** `PUT /invoice-item/<uuid>/price` enforces it; the with-items-and-invoice read advertises it as `price_edit_state` (`unpaid` / `single_payment` / `locked`), so both clients offer or hide the editor from the same server-computed flag — the rule cannot drift.
- **Safety rails on the single-payment branch:** the payment must sit on the same invoice as the edited line (multi-invoice orders can't cross-balance); a cut that would drive the payment negative is rejected; and after the flush the endpoint asserts the order is still *exactly* paid, refusing to commit otherwise.
- **Credit/debit notes lock even the unpaid case**, deliberately: notes adjust the very total a price edit changes — 409 rather than guess which correction wins.
- **No ledger bookkeeping needed:** verified before writing this — payments create no transaction rows and financial-account balances are derived, so adjusting `payment.amount` is a clean single-row update.
- **Web:** inline pencil → input → save on each invoice line, with a note in the single-payment case. **App:** an "Edit price" link per line opening the same bottom-sheet pattern as the notes editor. The app's stale "items are immutable" comment now describes the real contract.

## Verification (live, four seeded orders + a credit-note case, API **and both UIs**)
- Unpaid: edits change price + totals only (web $9→$6; app 6→68 via the modal).
- **Single payment: the payment tracked the price 50 → 75 → 20 → 40 in lockstep, both directions, order exactly paid throughout** (`net_amount_due` 0, `is_paid` true after every edit).
- Two payments / partial / credit-note: `409 price_locked` via API; **no editor rendered** in either client.
- Probe data fully removed afterwards; both clients typecheck clean (3 pre-existing `CustomerOrderDetail` errors unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)