### PR TITLE
web: clear the query cache when the signed-in account changes

### DIFF
--- a/frontend/client/src/contexts/AuthContext.tsx
+++ b/frontend/client/src/contexts/AuthContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { API_BASE_URL } from '../lib/config';
-import { notePermsVersion, resetPermsVersion, setOnPermsChanged } from '../lib/queryClient';
+import { notePermsVersion, resetPermsVersion, setOnPermsChanged, queryClient } from '../lib/queryClient';
 
 interface User {
   uuid: string;
@@ -167,7 +167,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         
         if (data.access_token) {
           localStorage.setItem('auth_token', data.access_token);
-          
+
+          // The query cache belongs to whoever was signed in before. A 401
+          // wipes it via full page reload, but login is an SPA transition —
+          // without this, dashboards render the previous tenant's cached
+          // numbers (staleTime keeps them for minutes) after switching
+          // accounts in the same browser session.
+          queryClient.clear();
+
           // Fetch user data after successful login
           const userResponse = await fetch(`${API_BASE_URL}/auth/me`, {
             headers: {
@@ -217,6 +224,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (result.access_token) {
           localStorage.setItem('auth_token', result.access_token);
 
+          // same reason as login: the cache still holds the previous
+          // account's data, and a brand-new tenant must start from nothing
+          queryClient.clear();
+
           // Fetch user data after successful signup (same flow as login)
           const userResponse = await fetch(`${API_BASE_URL}/auth/me`, {
             headers: {
@@ -264,6 +275,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // so the next user on this browser is not compared against this one's
     // fingerprint and refreshed for no reason
     resetPermsVersion();
+    // and is not served this one's cached data
+    queryClient.clear();
   };
 
   const scopes = (user?.permission_scope ?? '')


### PR DESCRIPTION
## The report

> when i create a new account on prod, it seems like the dashboards are not filtered per account

## What I found

**The server is not leaking.** All eight dashboard endpoints filter on the caller's `account_uuid` — probed each one with a freshly signed-up tenant's token against the same code prod runs: zeros across the board. What leaks is the **web client**: the React Query cache survives login, signup and logout (all SPA transitions — no reload), so after switching accounts in the same browser, Home renders the *previous* tenant's cached dashboards. `staleTime` keeps them looking fresh for 5 minutes. The 401 path was only safe by accident (full page reload).

## The fix

`queryClient.clear()` at every account boundary:
- **login** and **signup** — right after the new token is stored, *before* `/auth/me`, so nothing stale can ever be served to the new identity
- **logout** — alongside the existing perms-version reset

The Expo app has no equivalent hole (no react-query; screens refetch on mount; logout unmounts the authed navigator and wipes AsyncStorage).

## Verification

- Browser, local backend: karma admin's Home warm with real data (29,702 SYP / 17 orders / 2 trips) → sign out via the UI → switch to a fresh tenant → every dashboard renders zero / "No data for this range".
- `tsc --noEmit` error set byte-identical to main (all pre-existing).

## Related prod finding (config, not code — handled separately)

"No workflows for new accounts" turned out to be the **default account permissions cap** on prod: it predates newer features and is missing 11 of 37 resource blueprints (`workflow`, `task`, `employee`, `pricing`, `process`, …) and ~8 menu modules. Every new account snapshots that stale cap at signup. Being fixed as platform config via the super-admin API; no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)