### PR TITLE
android: build the installable APK against prod, not dev

### DIFF
--- a/.github/workflows/build-apps.yml
+++ b/.github/workflows/build-apps.yml
@@ -146,7 +146,7 @@ jobs:
         run: rm -f asc-api-key.p8
 
   build-android-preview:
-    name: Android APK (internal install)
+    name: Android APK (internal install, prod API)
     needs: check-trigger
     if: needs.check-trigger.outputs.build_preview == 'true' && needs.check-trigger.outputs.android == 'true'
     runs-on: ubuntu-latest
@@ -179,7 +179,10 @@ jobs:
         run: |
           # pipefail so tee cannot mask a failed build
           set -o pipefail
-          eas build --platform android --profile preview --non-interactive 2>&1 | tee build.log
+          # production-apk = the production profile (prod API) as an installable
+          # internal APK. The iOS ad-hoc job still uses `preview` (dev); only the
+          # Android sideload build is moved to prod, which is what gets installed.
+          eas build --platform android --profile production-apk --non-interactive 2>&1 | tee build.log
 
       - name: Publish install link
         if: always()

--- a/expo_app/eas.json
+++ b/expo_app/eas.json
@@ -22,6 +22,11 @@
       "distribution": "store",
       "autoIncrement": true,
       "env": { "API_BASE_URL": "https://api-prod.karma-grp.com" }
+    },
+    "production-apk": {
+      "extends": "production",
+      "distribution": "internal",
+      "android": { "buildType": "apk" }
     }
   },
   "submit": {


### PR DESCRIPTION
## Problem

The Android **internal-install APK** (the sideload build) used the `preview` profile, whose `env.API_BASE_URL` is **`api-dev`** — so the installed app talked to dev, while iOS TestFlight (the `production` profile) talked to prod. The only Android build that used prod was the store AAB, which isn't installable.

## Fix (Android-only)

EAS `env` is per-profile, not per-platform, and `preview` is shared with the iOS ad-hoc build. So I added a **`production-apk`** profile that extends `production` (prod API + autoIncrement) but overrides to `distribution: internal` + `buildType: apk`. The Android internal-install job now builds it; the iOS ad-hoc job still builds `preview` (dev), and the store paths are unchanged.

## Verified

Green build from this branch — log confirms env loaded from the `production-apk` profile; installable APK on EAS pointed at `api-prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)