### PR TITLE
Retire a blacklist when a visit produces newer information

### DIFF
--- a/backend/app/domains/customer/auto_tags.py
+++ b/backend/app/domains/customer/auto_tags.py
@@ -11,9 +11,9 @@ Three triggers write through here (each cites this module):
   * customer order created     -> customer_sale:one_time_sale | :repeated_sale,
                                   and customer_interest:interested
   * trip stop completed        -> customer_interest from the outcome family,
-                                  plus the blacklist / prioritize_next_stop flags,
-                                  and it SPENDS prioritize_next_stop once the
-                                  visit it asked for has happened
+                                  plus the blacklist / prioritize_next_stop flags
+                                  — and it RETIRES those same two flags once a
+                                  visit has produced newer information
 
 Two rules hold everywhere:
 
@@ -172,6 +172,16 @@ _VERDICT_FAMILIES = ("sale", "interested", "not_interested", "blacklist")
 def tags_cleared_by_outcome(outcome) -> list[str]:
     """Which flags a completed stop SPENDS.
 
+    Both bare flags are answered by the next real visit, for different reasons.
+
+    blacklist is cleared by any verdict that is not itself a blacklist. The
+    rep standing in front of the customer has newer information than whoever
+    set the flag, so a visit that ends in anything else — a sale, interest, even
+    a plain refusal — retires it. Note what that means in practice: a single
+    not_interested:other un-blacklists someone. That is the accepted cost of
+    keeping the flag current rather than letting it harden into folklore; a
+    blacklist that nobody can dislodge by visiting is one nobody can trust.
+
     prioritize_next_stop means "see this customer sooner next round". The visit
     it was asking for is this one, so recording a verdict here uses it up. Left
     to accumulate it would end up on everyone who ever got that outcome, and a
@@ -186,15 +196,26 @@ def tags_cleared_by_outcome(outcome) -> list[str]:
         no time. Clearing here would quietly drop their priority without anyone
         having spoken to them, which is the very thing the flag exists to
         prevent, and it matches the rule that a skipped stop changes nothing.
+
+    skipped:* spends NEITHER flag, for the same reason in both cases: nobody
+    reached the customer, so there is no newer information to act on.
     """
     key = outcome_machine_key(outcome)
     if not key:
         return []
-    if key.split(":", 1)[0] not in _VERDICT_FAMILIES:
+    family = key.split(":", 1)[0]
+    if family not in _VERDICT_FAMILIES:
         return []
-    if key == "interested:prioritize_next_visit":
-        return []
-    return [PRIORITIZE_TAG]
+
+    cleared: list[str] = []
+    if key != "interested:prioritize_next_visit":
+        cleared.append(PRIORITIZE_TAG)
+    if family != "blacklist":
+        # a blacklist outcome re-states the flag rather than retiring it;
+        # tags_for_outcome adds it back, and apply_auto_tags lets a set beat a
+        # clear on the same key, so the two can never fight
+        cleared.append(BLACKLIST_TAG)
+    return cleared
 
 
 def with_default_sale_tag(tags) -> list[str]:

--- a/backend/tests/domains/test_customer_auto_tags.py
+++ b/backend/tests/domains/test_customer_auto_tags.py
@@ -138,38 +138,92 @@ def test_blacklist_outcome_both_marks_and_records_disinterest():
     assert BLACKLIST_TAG in tags and INTEREST_NO in tags
 
 
-# --- what a stop SPENDS -----------------------------------------------------
+# --- what a stop RETIRES ----------------------------------------------------
 #
-# prioritize_next_stop asks for the next visit to come sooner. That visit is the
-# next completed stop, so a verdict there uses the flag up — otherwise it sticks
-# to every customer who ever earned it and stops distinguishing anyone.
+# Both bare flags are answered by the next real visit. prioritize_next_stop asks
+# for that visit to come sooner, so a verdict there uses it up. blacklist is
+# retired by any verdict that is not itself a blacklist: the rep standing in
+# front of the customer has newer information than whoever set the flag.
 
 SPENT_BY_OUTCOME = {
-    TripStopOutcome.SALE: [PRIORITIZE_TAG],
-    TripStopOutcome.INTERESTED_HAVE_INVENTORY: [PRIORITIZE_TAG],
-    TripStopOutcome.INTERESTED_NEEDS_BETTER_PRICE: [PRIORITIZE_TAG],
-    TripStopOutcome.INTERESTED_INSUFFICIENT_FUNDS: [PRIORITIZE_TAG],
-    # asking for priority again must not spend the flag it is re-raising
-    TripStopOutcome.INTERESTED_PRIORITIZE_NEXT_VISIT: [],
-    TripStopOutcome.NOT_INTERESTED_COMPETITOR: [PRIORITIZE_TAG],
-    TripStopOutcome.NOT_INTERESTED_BAD_PRODUCT: [PRIORITIZE_TAG],
-    TripStopOutcome.NOT_INTERSTED_PRICE_TOO_HIGH: [PRIORITIZE_TAG],
-    TripStopOutcome.NOT_INTERESTED_OTHER: [PRIORITIZE_TAG],
-    # the visit never happened, so the priority it was owed is still owed
+    TripStopOutcome.SALE: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.INTERESTED_HAVE_INVENTORY: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.INTERESTED_NEEDS_BETTER_PRICE: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.INTERESTED_INSUFFICIENT_FUNDS: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    # asking for priority again must not spend the flag it is re-raising, but it
+    # is still a visit, so it still retires a blacklist
+    TripStopOutcome.INTERESTED_PRIORITIZE_NEXT_VISIT: [BLACKLIST_TAG],
+    # a refusal is newer information too — one of these un-blacklists someone,
+    # which is the accepted cost of keeping the flag current
+    TripStopOutcome.NOT_INTERESTED_COMPETITOR: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.NOT_INTERESTED_BAD_PRODUCT: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.NOT_INTERSTED_PRICE_TOO_HIGH: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.NOT_INTERESTED_OTHER: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    # nobody reached the customer, so neither flag has been answered
     TripStopOutcome.SKIPPED_CUSTOMER_NOT_AVAILABLE: [],
     TripStopOutcome.SKIPPED_VEHICLE_BREAKDOWN: [],
     TripStopOutcome.SKIPPED_NO_PARKING: [],
     TripStopOutcome.SKIPPED_NO_TIME: [],
     TripStopOutcome.SKIPPED_OTHER: [],
+    # re-stating the blacklist must not retire it
     TripStopOutcome.BLACKLIST: [PRIORITIZE_TAG],
 }
 
 
 def test_every_outcome_has_a_decided_spend():
     assert set(SPENT_BY_OUTCOME) == set(TripStopOutcome), (
-        "TripStopOutcome changed: decide whether the new option spends "
-        "prioritize_next_stop and add it to SPENT_BY_OUTCOME"
+        "TripStopOutcome changed: decide whether the new option retires "
+        "prioritize_next_stop and/or blacklist, and add it to SPENT_BY_OUTCOME"
     )
+
+
+def test_a_sale_retires_a_blacklist():
+    """Buying is the strongest counter-evidence there is."""
+    outcome = TripStopOutcome.SALE.value
+    customer = _Customer(BLACKLIST_TAG, INTEREST_NO)
+    uow, _ = _apply(customer, tags=tags_for_outcome(outcome),
+                    clear=tags_cleared_by_outcome(outcome))
+    assert BLACKLIST_TAG not in customer.tags
+    assert INTEREST_YES in customer.tags
+    assert ("blacklist", "", None) in {
+        (e.key, e.old_value, e.new_value) for e in uow.session.added
+    }
+
+
+def test_a_refusal_also_retires_a_blacklist():
+    """The accepted cost of keeping the flag current: one not_interested visit
+    un-blacklists someone. They stay not_interested — the two are separate
+    facts, and only the flag is retired."""
+    outcome = TripStopOutcome.NOT_INTERESTED_OTHER.value
+    customer = _Customer(BLACKLIST_TAG)
+    _apply(customer, tags=tags_for_outcome(outcome), clear=tags_cleared_by_outcome(outcome))
+    assert customer.tags == [INTEREST_NO]
+
+
+def test_restating_the_blacklist_does_not_retire_it():
+    """set beats clear on the same key, so the add and the retire cannot fight
+    even though a blacklist outcome is itself a verdict."""
+    outcome = TripStopOutcome.BLACKLIST.value
+    customer = _Customer(BLACKLIST_TAG)
+    _apply(customer, tags=tags_for_outcome(outcome), clear=tags_cleared_by_outcome(outcome))
+    assert BLACKLIST_TAG in customer.tags
+
+
+def test_a_skipped_stop_leaves_a_blacklist_alone():
+    """Nobody reached the customer, so there is no newer information."""
+    outcome = TripStopOutcome.SKIPPED_CUSTOMER_NOT_AVAILABLE.value
+    customer = _Customer(BLACKLIST_TAG)
+    uow, _ = _apply(customer, tags=tags_for_outcome(outcome),
+                    clear=tags_cleared_by_outcome(outcome))
+    assert customer.tags == [BLACKLIST_TAG]
+    assert uow.session.added == []
+
+
+def test_retiring_a_blacklist_leaves_manual_tags_alone():
+    customer = _Customer(BLACKLIST_TAG, "agent", "region:malki")
+    outcome = TripStopOutcome.SALE.value
+    _apply(customer, tags=tags_for_outcome(outcome), clear=tags_cleared_by_outcome(outcome))
+    assert set(customer.tags) == {"agent", "region:malki", INTEREST_YES}
 
 
 @pytest.mark.parametrize("outcome", list(TripStopOutcome), ids=lambda o: o.name)


### PR DESCRIPTION
Follow-up to #133. `blacklist` was **add-only** — once set, no outcome could dislodge it, so a customer who later bought from us carried the flag *and* `customer_interest:interested` at the same time. Harmless while nothing reads the tag; actively wrong the moment it starts excluding customers from trips.

## The rule

Any verdict that is **not itself a blacklist** now retires the flag — the rep standing in front of the customer has newer information than whoever set it.

| Outcome | `blacklist` |
|---|---|
| `sale` | **retired** |
| `interested:*` (incl. `prioritize_next_visit`) | **retired** |
| `not_interested:*` | **retired** |
| `blacklist` | kept — re-states the verdict |
| `skipped:*` | kept — nobody reached the customer |

**The accepted cost, chosen deliberately:** a single `not_interested:other` un-blacklists someone. A blacklist nobody can dislodge by visiting is one nobody can trust — and the narrower rule (only a sale clears it) leaves the flag stuck on every customer who is merely unenthusiastic.

Interest is unaffected by the retirement: a refused visit still leaves the customer `not_interested`, it just stops asserting the standing verdict too.

The `blacklist` outcome adding the flag and this rule retiring it can never fight: `apply_auto_tags` lets a *set* beat a *clear* on the same key, independent of argument order.

## Verified

94 module tests, with the per-outcome map now covering **both** bare flags so a new outcome can't ship without deciding what it retires. Full suite 484 pass / 227 pre-existing failures, unchanged.

Live, re-completing one stop with successive outcomes:

```
blacklist            -> ['blacklist', 'customer_interest:not_interested']
blacklist AGAIN      -> ['blacklist', 'customer_interest:not_interested']   # re-stated, kept
skipped:no_time      -> ['blacklist', 'customer_interest:not_interested']   # no info, kept
sale                 -> ['customer_interest:interested']                    # retired
not_interested:other -> ['customer_interest:not_interested']                # retired
```

with each raise and retire in the tag history (`blacklist: None -> ''` then `'' -> None`). Probe data removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)