### PR TITLE
Customer visit dates: last_stop and last_effective_stop

### DIFF
--- a/backend/app/domains/customer/auto_tags.py
+++ b/backend/app/domains/customer/auto_tags.py
@@ -11,9 +11,9 @@ Three triggers write through here (each cites this module):
   * customer order created     -> customer_sale:one_time_sale | :repeated_sale,
                                   and customer_interest:interested
   * trip stop completed        -> customer_interest from the outcome family,
-                                  plus the blacklist / prioritize_next_stop flags,
-                                  and it SPENDS prioritize_next_stop once the
-                                  visit it asked for has happened
+                                  plus the blacklist / prioritize_next_stop flags
+                                  — and it RETIRES those same two flags once a
+                                  visit has produced newer information
 
 Two rules hold everywhere:
 
@@ -172,6 +172,16 @@ _VERDICT_FAMILIES = ("sale", "interested", "not_interested", "blacklist")
 def tags_cleared_by_outcome(outcome) -> list[str]:
     """Which flags a completed stop SPENDS.
 
+    Both bare flags are answered by the next real visit, for different reasons.
+
+    blacklist is cleared by any verdict that is not itself a blacklist. The
+    rep standing in front of the customer has newer information than whoever
+    set the flag, so a visit that ends in anything else — a sale, interest, even
+    a plain refusal — retires it. Note what that means in practice: a single
+    not_interested:other un-blacklists someone. That is the accepted cost of
+    keeping the flag current rather than letting it harden into folklore; a
+    blacklist that nobody can dislodge by visiting is one nobody can trust.
+
     prioritize_next_stop means "see this customer sooner next round". The visit
     it was asking for is this one, so recording a verdict here uses it up. Left
     to accumulate it would end up on everyone who ever got that outcome, and a
@@ -186,15 +196,26 @@ def tags_cleared_by_outcome(outcome) -> list[str]:
         no time. Clearing here would quietly drop their priority without anyone
         having spoken to them, which is the very thing the flag exists to
         prevent, and it matches the rule that a skipped stop changes nothing.
+
+    skipped:* spends NEITHER flag, for the same reason in both cases: nobody
+    reached the customer, so there is no newer information to act on.
     """
     key = outcome_machine_key(outcome)
     if not key:
         return []
-    if key.split(":", 1)[0] not in _VERDICT_FAMILIES:
+    family = key.split(":", 1)[0]
+    if family not in _VERDICT_FAMILIES:
         return []
-    if key == "interested:prioritize_next_visit":
-        return []
-    return [PRIORITIZE_TAG]
+
+    cleared: list[str] = []
+    if key != "interested:prioritize_next_visit":
+        cleared.append(PRIORITIZE_TAG)
+    if family != "blacklist":
+        # a blacklist outcome re-states the flag rather than retiring it;
+        # tags_for_outcome adds it back, and apply_auto_tags lets a set beat a
+        # clear on the same key, so the two can never fight
+        cleared.append(BLACKLIST_TAG)
+    return cleared
 
 
 def with_default_sale_tag(tags) -> list[str]:

--- a/backend/app/domains/customer/auto_tags.py
+++ b/backend/app/domains/customer/auto_tags.py
@@ -169,6 +169,26 @@ def sale_tag_after_void(customer, *, live_orders: int) -> list[str]:
 _VERDICT_FAMILIES = ("sale", "interested", "not_interested", "blacklist")
 
 
+def is_effective_outcome(outcome) -> bool:
+    """Did this stop actually reach the customer?
+
+    Everything except the skipped:* family counts: a refusal or a blacklist is
+    still a rep standing at the door having a conversation, whereas "customer
+    not available" and "no time" are the trip failing to happen.
+
+    Defined as the complement of skipped rather than a whitelist of known
+    families, deliberately: a new outcome describing something that DID happen
+    should count as effective the day it is added, without anyone remembering
+    this function. An unreadable outcome (NULL, '', legacy free text with no
+    family) is not effective — we cannot claim to have reached someone on the
+    strength of a value nothing can parse.
+    """
+    key = outcome_machine_key(outcome)
+    if not key:
+        return False
+    return key.split(":", 1)[0] != "skipped"
+
+
 def tags_cleared_by_outcome(outcome) -> list[str]:
     """Which flags a completed stop SPENDS.
 

--- a/backend/app/domains/customer/visit_dates.py
+++ b/backend/app/domains/customer/visit_dates.py
@@ -1,0 +1,67 @@
+"""When a customer was last visited, and last actually reached.
+
+customer.last_stop and customer.last_effective_stop are denormalised off
+trip_stop so "who hasn't been seen lately" is a column read. Both are RECOMPUTED
+from the customer's stops every time one completes, rather than stamped forward
+with the current timestamp.
+
+Recomputing costs one extra query per completion and buys two things that
+stamping cannot:
+
+  * CORRECTIONS WORK. The web lets a completed stop be re-completed with a
+    corrected outcome ("update"), and the correction overwrites the stop's
+    outcome in place. A stamp-forward would leave last_effective_stop asserting
+    a visit that the correction erased — a sale rewritten to
+    skipped:customer_not_available would keep claiming the customer was reached.
+    Recomputing walks back to the previous genuinely-effective stop, or to NULL
+    if there is none. Blindly clearing the field instead would be wrong: it
+    would also discard an older effective stop that is still perfectly valid.
+
+  * THE BACKFILL AND THE RUNTIME CANNOT DRIFT. The migration that introduced
+    these columns backfills them with this same definition. Because the running
+    code now issues the same query, the two agree by construction instead of by
+    two hand-written rules that have to be kept in step.
+
+The definition of a completed stop is deliberately NOT "has an outcome": the
+outcome column is a free string the API never validates, so a completion can
+carry ''. Such a stop still happened, and still counts as a visit — it is the
+task execution reaching `completed` that makes it real.
+"""
+from sqlalchemy import text
+
+# Mirrors is_effective_outcome() in auto_tags.py, term for term:
+#   split_part(outcome, ' - ', 1)  -> the machine half, split ONCE
+#   btrim(...)                     -> the .strip() the Python does
+#   <> ''                          -> an unreadable outcome reaches nobody
+#   split_part(..., ':', 1)        -> the family
+# Kept in lockstep with that function; test_customer_visit_dates.py pins the two
+# against each other over every outcome value and every legacy shape.
+_VISIT_DATES = text("""
+SELECT MAX(COALESCE(te.end_time, ts.created_at)) AS last_stop,
+       MAX(COALESCE(te.end_time, ts.created_at)) FILTER (
+           WHERE btrim(split_part(ts.outcome, ' - ', 1)) <> ''
+             AND split_part(btrim(split_part(ts.outcome, ' - ', 1)), ':', 1) <> 'skipped'
+       ) AS last_effective_stop
+FROM trip_stop ts
+LEFT JOIN task_execution te ON te.uuid = ts.task_execution_uuid
+WHERE ts.customer_uuid = :customer_uuid
+  AND (te.status = 'completed' OR btrim(COALESCE(ts.outcome, '')) <> '')
+""")
+
+
+def recompute_visit_dates(uow, customer) -> None:
+    """Reset the customer's two visit dates from their trip stops.
+
+    Nothing is committed — the caller's unit of work owns the transaction, so
+    the dates land with the stop completion that caused them. Must run AFTER the
+    stop's outcome and its task execution's end_time have been saved, or the
+    query reads the previous state of the very stop being completed.
+    """
+    if customer is None:
+        return
+    row = uow.session.execute(
+        _VISIT_DATES, {"customer_uuid": customer.uuid}
+    ).one()
+    customer.last_stop = row.last_stop
+    customer.last_effective_stop = row.last_effective_stop
+    uow.customer_repository.save(model=customer, commit=False)

--- a/backend/app/domains/task_execution/workflow_operators/trip_stop_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/trip_stop_operator.py
@@ -63,25 +63,24 @@ class TripStopOperator(OperatorInterface):
         trip_stop.sales_outcome = sales_outcome
         trip_stop.notes = operator_schema.notes
         uow.trip_stop_repository.save(trip_stop, commit=False)
-        # one timestamp for the whole completion, so the customer's last_stop is
-        # exactly the task execution's end_time rather than a few milliseconds
-        # off it — the backfill reads end_time, and the two must agree
-        completed_at = datetime.now()
-        self.tag_customer_from_outcome(uow=uow, trip_stop=trip_stop,
-                                       outcome=operator_schema.outcome,
-                                       actor_uuid=payload.completed_by_uuid,
-                                       completed_at=completed_at)
         task_exe.result = operator_schema.model_dump(mode="json")
         task_exe.status = WorkflowStatus.COMPLETED.value
-        task_exe.end_time = completed_at
+        task_exe.end_time = datetime.now()
         task_exe.completed_by_uuid = payload.completed_by_uuid
 
         # Save the task execution with the result
         uow.task_execution_repository.save(task_exe, commit=False)
 
-    def tag_customer_from_outcome(self, uow: SqlAlchemyUnitOfWork, trip_stop,
-                                  outcome: str, actor_uuid=None,
-                                  completed_at=None) -> None:
+        # LAST, and the order matters: the customer's visit dates are recomputed
+        # from their stops, so this stop's outcome and its end_time both have to
+        # be saved before the query runs — otherwise it reads the state this
+        # completion just replaced.
+        self.update_customer_from_outcome(uow=uow, trip_stop=trip_stop,
+                                          outcome=operator_schema.outcome,
+                                          actor_uuid=payload.completed_by_uuid)
+
+    def update_customer_from_outcome(self, uow: SqlAlchemyUnitOfWork, trip_stop,
+                                     outcome: str, actor_uuid=None) -> None:
         """Turn what the rep reported into tags and visit dates on the customer.
 
         The outcome the rep already picks is the cheapest interest signal the
@@ -96,9 +95,9 @@ class TripStopOperator(OperatorInterface):
         behaviour: the latest verdict wins.
         """
         from app.domains.customer.auto_tags import (
-            apply_auto_tags, is_effective_outcome, tags_cleared_by_outcome,
-            tags_for_outcome,
+            apply_auto_tags, tags_cleared_by_outcome, tags_for_outcome,
         )
+        from app.domains.customer.visit_dates import recompute_visit_dates
 
         if not trip_stop.customer_uuid:
             return
@@ -106,14 +105,11 @@ class TripStopOperator(OperatorInterface):
         if not customer:
             return
 
-        # the visit dates move on EVERY completion, including a skipped one for
-        # last_stop — "we went and could not get in" is still a trip made, and a
-        # planner needs to know it happened
-        if completed_at is not None:
-            customer.last_stop = completed_at
-            if is_effective_outcome(outcome):
-                customer.last_effective_stop = completed_at
-            uow.customer_repository.save(model=customer, commit=False)
+        # Recomputed from the customer's stops rather than stamped with "now",
+        # so a corrected outcome walks the dates back instead of leaving
+        # last_effective_stop asserting a visit the correction erased. See
+        # app/domains/customer/visit_dates.py.
+        recompute_visit_dates(uow, customer)
 
         tags = tags_for_outcome(outcome)
         clear = tags_cleared_by_outcome(outcome)

--- a/backend/app/domains/task_execution/workflow_operators/trip_stop_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/trip_stop_operator.py
@@ -63,20 +63,26 @@ class TripStopOperator(OperatorInterface):
         trip_stop.sales_outcome = sales_outcome
         trip_stop.notes = operator_schema.notes
         uow.trip_stop_repository.save(trip_stop, commit=False)
+        # one timestamp for the whole completion, so the customer's last_stop is
+        # exactly the task execution's end_time rather than a few milliseconds
+        # off it — the backfill reads end_time, and the two must agree
+        completed_at = datetime.now()
         self.tag_customer_from_outcome(uow=uow, trip_stop=trip_stop,
                                        outcome=operator_schema.outcome,
-                                       actor_uuid=payload.completed_by_uuid)
+                                       actor_uuid=payload.completed_by_uuid,
+                                       completed_at=completed_at)
         task_exe.result = operator_schema.model_dump(mode="json")
         task_exe.status = WorkflowStatus.COMPLETED.value
-        task_exe.end_time = datetime.now()
+        task_exe.end_time = completed_at
         task_exe.completed_by_uuid = payload.completed_by_uuid
 
         # Save the task execution with the result
         uow.task_execution_repository.save(task_exe, commit=False)
 
     def tag_customer_from_outcome(self, uow: SqlAlchemyUnitOfWork, trip_stop,
-                                  outcome: str, actor_uuid=None) -> None:
-        """Turn what the rep reported into tags on the customer.
+                                  outcome: str, actor_uuid=None,
+                                  completed_at=None) -> None:
+        """Turn what the rep reported into tags and visit dates on the customer.
 
         The outcome the rep already picks is the cheapest interest signal the
         business has, so the customer_interest tag follows it rather than asking
@@ -90,17 +96,29 @@ class TripStopOperator(OperatorInterface):
         behaviour: the latest verdict wins.
         """
         from app.domains.customer.auto_tags import (
-            apply_auto_tags, tags_cleared_by_outcome, tags_for_outcome,
+            apply_auto_tags, is_effective_outcome, tags_cleared_by_outcome,
+            tags_for_outcome,
         )
 
         if not trip_stop.customer_uuid:
             return
+        customer = uow.customer_repository.find_one(uuid=trip_stop.customer_uuid, is_deleted=False)
+        if not customer:
+            return
+
+        # the visit dates move on EVERY completion, including a skipped one for
+        # last_stop — "we went and could not get in" is still a trip made, and a
+        # planner needs to know it happened
+        if completed_at is not None:
+            customer.last_stop = completed_at
+            if is_effective_outcome(outcome):
+                customer.last_effective_stop = completed_at
+            uow.customer_repository.save(model=customer, commit=False)
+
         tags = tags_for_outcome(outcome)
         clear = tags_cleared_by_outcome(outcome)
-        if not tags and not clear:
-            return
-        customer = uow.customer_repository.find_one(uuid=trip_stop.customer_uuid, is_deleted=False)
-        apply_auto_tags(uow, customer=customer, tags=tags, clear=clear, actor_uuid=actor_uuid)
+        if tags or clear:
+            apply_auto_tags(uow, customer=customer, tags=tags, clear=clear, actor_uuid=actor_uuid)
 
     def validate(self):
         raise NotImplementedError("The validate method must be implemented by subclasses.")

--- a/backend/app/dto/customer.py
+++ b/backend/app/dto/customer.py
@@ -220,6 +220,11 @@ class CustomerRead(CustomerBase):
     created_at: datetime
     is_deleted: bool
     balance_per_currency: dict[Currency, float]
+    # Derived from trip stops, never accepted from a client — they are absent
+    # from CustomerCreate/CustomerUpdate on purpose, and those DTOs forbid
+    # extras, so an attempt to set them is a 400 rather than a silent overwrite.
+    last_stop: Optional[datetime] = None
+    last_effective_stop: Optional[datetime] = None
 
     @field_validator("coordinates", mode="before")
     def _wkb_or_wkt_to_latlon(cls, v):

--- a/backend/migrations/versions/b3c8e5f14a72_customer_last_stop_timestamps.py
+++ b/backend/migrations/versions/b3c8e5f14a72_customer_last_stop_timestamps.py
@@ -1,24 +1,28 @@
 """Record when a customer was last visited, and last actually reached.
 
-Two derived timestamps on customer, written by the trip-stop operator when a
-stop completes:
+Two derived timestamps on customer, recomputed by the trip-stop operator every
+time a stop completes:
 
   last_stop           — the last completed stop, whatever came of it
   last_effective_stop — the last one that reached the customer, i.e. any
                         outcome outside the skipped:* family
 
 Both are backfilled from history so they are useful on day one rather than in
-three months. A stop counts as completed if it carries an outcome: that is
-written at exactly the moment the operator completes it, which makes it a far
-more reliable marker than trip_stop.status (never advanced past in_progress by
-any code path — 184 of 187 non-cancelled stops in one production-shaped
-database still sit at in_progress, 19 of them with outcomes recorded).
+three months.
 
-The timestamp is the task execution's end_time, falling back to the stop's
-created_at for legacy rows that predate task executions. "Effective" is decided
-the same way the runtime does it — the family before the first ':' of the
-machine half of the outcome — so the backfilled values and the ones written
-from now on mean the same thing.
+A stop counts as completed when its task execution reached `completed`, or —
+for legacy rows with no task execution — when it carries an outcome. Note what
+is deliberately NOT used: trip_stop.status, which no code path ever advances
+past in_progress (184 of 187 non-cancelled stops in one production-shaped
+database still sit there, 19 of them with outcomes recorded). The timestamp is
+the task execution's end_time, falling back to the stop's created_at.
+
+The query below is the SAME one the running code issues on every completion
+(app/domains/customer/visit_dates.py). That is the point: these columns are
+recomputed rather than stamped forward, so a backfilled value and a freshly
+written one come out of identical logic and cannot drift apart. Keep the two in
+step — tests/domains/test_customer_visit_dates.py pins the effective-outcome
+predicate against the Python function it mirrors.
 
 Revision ID: b3c8e5f14a72
 Revises: f4a2d7c9e1b6
@@ -32,8 +36,9 @@ branch_labels = None
 depends_on = None
 
 
-# split_part(outcome, ' - ', 1) is the machine half ("skipped:no_time"), and
-# split_part(..., ':', 1) is its family — the same two splits the Python does.
+# The FILTER mirrors is_effective_outcome() term for term: take the machine half
+# (split once on ' - '), trim it as the Python does, treat an unreadable outcome
+# as reaching nobody, and compare the family before ':' against 'skipped'.
 _BACKFILL = """
 UPDATE customer AS c
 SET last_stop = agg.last_stop,
@@ -41,15 +46,14 @@ SET last_stop = agg.last_stop,
 FROM (
     SELECT ts.customer_uuid,
            MAX(COALESCE(te.end_time, ts.created_at)) AS last_stop,
-           MAX(COALESCE(te.end_time, ts.created_at))
-               FILTER (
-                   WHERE split_part(split_part(ts.outcome, ' - ', 1), ':', 1) <> 'skipped'
-               ) AS last_effective_stop
+           MAX(COALESCE(te.end_time, ts.created_at)) FILTER (
+               WHERE btrim(split_part(ts.outcome, ' - ', 1)) <> ''
+                 AND split_part(btrim(split_part(ts.outcome, ' - ', 1)), ':', 1) <> 'skipped'
+           ) AS last_effective_stop
     FROM trip_stop ts
     LEFT JOIN task_execution te ON te.uuid = ts.task_execution_uuid
     WHERE ts.customer_uuid IS NOT NULL
-      AND ts.outcome IS NOT NULL
-      AND btrim(ts.outcome) <> ''
+      AND (te.status = 'completed' OR btrim(COALESCE(ts.outcome, '')) <> '')
     GROUP BY ts.customer_uuid
 ) AS agg
 WHERE c.uuid = agg.customer_uuid

--- a/backend/migrations/versions/b3c8e5f14a72_customer_last_stop_timestamps.py
+++ b/backend/migrations/versions/b3c8e5f14a72_customer_last_stop_timestamps.py
@@ -1,0 +1,67 @@
+"""Record when a customer was last visited, and last actually reached.
+
+Two derived timestamps on customer, written by the trip-stop operator when a
+stop completes:
+
+  last_stop           — the last completed stop, whatever came of it
+  last_effective_stop — the last one that reached the customer, i.e. any
+                        outcome outside the skipped:* family
+
+Both are backfilled from history so they are useful on day one rather than in
+three months. A stop counts as completed if it carries an outcome: that is
+written at exactly the moment the operator completes it, which makes it a far
+more reliable marker than trip_stop.status (never advanced past in_progress by
+any code path — 184 of 187 non-cancelled stops in one production-shaped
+database still sit at in_progress, 19 of them with outcomes recorded).
+
+The timestamp is the task execution's end_time, falling back to the stop's
+created_at for legacy rows that predate task executions. "Effective" is decided
+the same way the runtime does it — the family before the first ':' of the
+machine half of the outcome — so the backfilled values and the ones written
+from now on mean the same thing.
+
+Revision ID: b3c8e5f14a72
+Revises: f4a2d7c9e1b6
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = 'b3c8e5f14a72'
+down_revision = 'f4a2d7c9e1b6'
+branch_labels = None
+depends_on = None
+
+
+# split_part(outcome, ' - ', 1) is the machine half ("skipped:no_time"), and
+# split_part(..., ':', 1) is its family — the same two splits the Python does.
+_BACKFILL = """
+UPDATE customer AS c
+SET last_stop = agg.last_stop,
+    last_effective_stop = agg.last_effective_stop
+FROM (
+    SELECT ts.customer_uuid,
+           MAX(COALESCE(te.end_time, ts.created_at)) AS last_stop,
+           MAX(COALESCE(te.end_time, ts.created_at))
+               FILTER (
+                   WHERE split_part(split_part(ts.outcome, ' - ', 1), ':', 1) <> 'skipped'
+               ) AS last_effective_stop
+    FROM trip_stop ts
+    LEFT JOIN task_execution te ON te.uuid = ts.task_execution_uuid
+    WHERE ts.customer_uuid IS NOT NULL
+      AND ts.outcome IS NOT NULL
+      AND btrim(ts.outcome) <> ''
+    GROUP BY ts.customer_uuid
+) AS agg
+WHERE c.uuid = agg.customer_uuid
+"""
+
+
+def upgrade():
+    op.add_column('customer', sa.Column('last_stop', sa.DateTime(), nullable=True))
+    op.add_column('customer', sa.Column('last_effective_stop', sa.DateTime(), nullable=True))
+    op.execute(_BACKFILL)
+
+
+def downgrade():
+    op.drop_column('customer', 'last_effective_stop')
+    op.drop_column('customer', 'last_stop')

--- a/backend/models/common.py
+++ b/backend/models/common.py
@@ -246,6 +246,17 @@ class Customer(Base):
     # plain strings so "vip" and "region:malki" filter with the same operators
     tags = Column(ARRAY(String), nullable=False, default=list, server_default='{}')
     coordinates = Column(Geometry("POINT", srid=4326), nullable=True)
+    # When a rep last stood at this customer's door, denormalised off trip_stop
+    # so "who hasn't been seen lately" is a column read rather than a scan of
+    # every stop the customer has ever had. (No index yet — nothing queries
+    # these columns; add a composite one alongside the first read path.)
+    #   last_stop           — the last completed stop, whatever came of it
+    #   last_effective_stop — the last one that actually reached the customer,
+    #                         i.e. any outcome outside the skipped:* family
+    # Both NULL until a stop completes. They are DERIVED: the trip-stop operator
+    # is the only writer, so nothing else should set them.
+    last_stop = Column(DateTime, nullable=True)
+    last_effective_stop = Column(DateTime, nullable=True)
     is_deleted = Column(Boolean, default=False)
 
     # relations

--- a/backend/tests/domains/test_customer_auto_tags.py
+++ b/backend/tests/domains/test_customer_auto_tags.py
@@ -40,6 +40,7 @@ from app.domains.customer.auto_tags import (
     SALE_ONE_TIME,
     SALE_REPEATED,
     apply_auto_tags,
+    is_effective_outcome,
     outcome_machine_key,
     sale_tag_after_void,
     sale_tag_for_live_order_count,
@@ -295,6 +296,64 @@ def test_prioritize_outcome_keeps_the_customer_interested():
     not a replacement, or a prioritized customer would vanish from interest."""
     tags = tags_for_outcome(TripStopOutcome.INTERESTED_PRIORITIZE_NEXT_VISIT.value)
     assert tags == [INTEREST_YES, PRIORITIZE_TAG]
+
+
+# --- was the customer actually reached? ------------------------------------
+#
+# Drives customer.last_effective_stop. Defined as the complement of skipped, not
+# a whitelist: an outcome describing something that DID happen should count on
+# the day it is added, without anyone remembering this function.
+
+EFFECTIVE_BY_OUTCOME = {
+    TripStopOutcome.SALE: True,
+    TripStopOutcome.INTERESTED_HAVE_INVENTORY: True,
+    TripStopOutcome.INTERESTED_NEEDS_BETTER_PRICE: True,
+    TripStopOutcome.INTERESTED_INSUFFICIENT_FUNDS: True,
+    TripStopOutcome.INTERESTED_PRIORITIZE_NEXT_VISIT: True,
+    # a refusal is a conversation: the rep got to the door and was told no
+    TripStopOutcome.NOT_INTERESTED_COMPETITOR: True,
+    TripStopOutcome.NOT_INTERESTED_BAD_PRODUCT: True,
+    TripStopOutcome.NOT_INTERSTED_PRICE_TOO_HIGH: True,
+    TripStopOutcome.NOT_INTERESTED_OTHER: True,
+    TripStopOutcome.BLACKLIST: True,
+    # the trip failed to happen — nobody was reached
+    TripStopOutcome.SKIPPED_CUSTOMER_NOT_AVAILABLE: False,
+    TripStopOutcome.SKIPPED_VEHICLE_BREAKDOWN: False,
+    TripStopOutcome.SKIPPED_NO_PARKING: False,
+    TripStopOutcome.SKIPPED_NO_TIME: False,
+    TripStopOutcome.SKIPPED_OTHER: False,
+}
+
+
+def test_every_outcome_has_a_decided_effectiveness():
+    assert set(EFFECTIVE_BY_OUTCOME) == set(TripStopOutcome), (
+        "TripStopOutcome changed: decide whether the new option counts as "
+        "reaching the customer and add it to EFFECTIVE_BY_OUTCOME"
+    )
+
+
+@pytest.mark.parametrize("outcome", list(TripStopOutcome), ids=lambda o: o.name)
+def test_outcome_effectiveness(outcome):
+    assert is_effective_outcome(outcome.value) is EFFECTIVE_BY_OUTCOME[outcome]
+
+
+@pytest.mark.parametrize("outcome", [None, "", "   "])
+def test_an_unreadable_outcome_is_not_effective(outcome):
+    """We cannot claim to have reached someone on the strength of a value
+    nothing can parse."""
+    assert is_effective_outcome(outcome) is False
+
+
+def test_an_unknown_but_readable_outcome_counts_as_effective():
+    """The complement-of-skipped rule in action: a future outcome describing
+    something that happened is effective without touching this code."""
+    assert is_effective_outcome("negotiating:follow_up - نص") is True
+
+
+def test_effectiveness_reads_the_machine_half_not_the_arabic():
+    """The Arabic half of a skipped outcome must not decide the answer."""
+    assert is_effective_outcome(TripStopOutcome.SKIPPED_NO_TIME.value) is False
+    assert is_effective_outcome("skipped:no_time") is False
 
 
 # --- the key extraction ----------------------------------------------------

--- a/backend/tests/domains/test_customer_auto_tags.py
+++ b/backend/tests/domains/test_customer_auto_tags.py
@@ -138,38 +138,92 @@ def test_blacklist_outcome_both_marks_and_records_disinterest():
     assert BLACKLIST_TAG in tags and INTEREST_NO in tags
 
 
-# --- what a stop SPENDS -----------------------------------------------------
+# --- what a stop RETIRES ----------------------------------------------------
 #
-# prioritize_next_stop asks for the next visit to come sooner. That visit is the
-# next completed stop, so a verdict there uses the flag up — otherwise it sticks
-# to every customer who ever earned it and stops distinguishing anyone.
+# Both bare flags are answered by the next real visit. prioritize_next_stop asks
+# for that visit to come sooner, so a verdict there uses it up. blacklist is
+# retired by any verdict that is not itself a blacklist: the rep standing in
+# front of the customer has newer information than whoever set the flag.
 
 SPENT_BY_OUTCOME = {
-    TripStopOutcome.SALE: [PRIORITIZE_TAG],
-    TripStopOutcome.INTERESTED_HAVE_INVENTORY: [PRIORITIZE_TAG],
-    TripStopOutcome.INTERESTED_NEEDS_BETTER_PRICE: [PRIORITIZE_TAG],
-    TripStopOutcome.INTERESTED_INSUFFICIENT_FUNDS: [PRIORITIZE_TAG],
-    # asking for priority again must not spend the flag it is re-raising
-    TripStopOutcome.INTERESTED_PRIORITIZE_NEXT_VISIT: [],
-    TripStopOutcome.NOT_INTERESTED_COMPETITOR: [PRIORITIZE_TAG],
-    TripStopOutcome.NOT_INTERESTED_BAD_PRODUCT: [PRIORITIZE_TAG],
-    TripStopOutcome.NOT_INTERSTED_PRICE_TOO_HIGH: [PRIORITIZE_TAG],
-    TripStopOutcome.NOT_INTERESTED_OTHER: [PRIORITIZE_TAG],
-    # the visit never happened, so the priority it was owed is still owed
+    TripStopOutcome.SALE: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.INTERESTED_HAVE_INVENTORY: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.INTERESTED_NEEDS_BETTER_PRICE: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.INTERESTED_INSUFFICIENT_FUNDS: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    # asking for priority again must not spend the flag it is re-raising, but it
+    # is still a visit, so it still retires a blacklist
+    TripStopOutcome.INTERESTED_PRIORITIZE_NEXT_VISIT: [BLACKLIST_TAG],
+    # a refusal is newer information too — one of these un-blacklists someone,
+    # which is the accepted cost of keeping the flag current
+    TripStopOutcome.NOT_INTERESTED_COMPETITOR: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.NOT_INTERESTED_BAD_PRODUCT: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.NOT_INTERSTED_PRICE_TOO_HIGH: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    TripStopOutcome.NOT_INTERESTED_OTHER: [PRIORITIZE_TAG, BLACKLIST_TAG],
+    # nobody reached the customer, so neither flag has been answered
     TripStopOutcome.SKIPPED_CUSTOMER_NOT_AVAILABLE: [],
     TripStopOutcome.SKIPPED_VEHICLE_BREAKDOWN: [],
     TripStopOutcome.SKIPPED_NO_PARKING: [],
     TripStopOutcome.SKIPPED_NO_TIME: [],
     TripStopOutcome.SKIPPED_OTHER: [],
+    # re-stating the blacklist must not retire it
     TripStopOutcome.BLACKLIST: [PRIORITIZE_TAG],
 }
 
 
 def test_every_outcome_has_a_decided_spend():
     assert set(SPENT_BY_OUTCOME) == set(TripStopOutcome), (
-        "TripStopOutcome changed: decide whether the new option spends "
-        "prioritize_next_stop and add it to SPENT_BY_OUTCOME"
+        "TripStopOutcome changed: decide whether the new option retires "
+        "prioritize_next_stop and/or blacklist, and add it to SPENT_BY_OUTCOME"
     )
+
+
+def test_a_sale_retires_a_blacklist():
+    """Buying is the strongest counter-evidence there is."""
+    outcome = TripStopOutcome.SALE.value
+    customer = _Customer(BLACKLIST_TAG, INTEREST_NO)
+    uow, _ = _apply(customer, tags=tags_for_outcome(outcome),
+                    clear=tags_cleared_by_outcome(outcome))
+    assert BLACKLIST_TAG not in customer.tags
+    assert INTEREST_YES in customer.tags
+    assert ("blacklist", "", None) in {
+        (e.key, e.old_value, e.new_value) for e in uow.session.added
+    }
+
+
+def test_a_refusal_also_retires_a_blacklist():
+    """The accepted cost of keeping the flag current: one not_interested visit
+    un-blacklists someone. They stay not_interested — the two are separate
+    facts, and only the flag is retired."""
+    outcome = TripStopOutcome.NOT_INTERESTED_OTHER.value
+    customer = _Customer(BLACKLIST_TAG)
+    _apply(customer, tags=tags_for_outcome(outcome), clear=tags_cleared_by_outcome(outcome))
+    assert customer.tags == [INTEREST_NO]
+
+
+def test_restating_the_blacklist_does_not_retire_it():
+    """set beats clear on the same key, so the add and the retire cannot fight
+    even though a blacklist outcome is itself a verdict."""
+    outcome = TripStopOutcome.BLACKLIST.value
+    customer = _Customer(BLACKLIST_TAG)
+    _apply(customer, tags=tags_for_outcome(outcome), clear=tags_cleared_by_outcome(outcome))
+    assert BLACKLIST_TAG in customer.tags
+
+
+def test_a_skipped_stop_leaves_a_blacklist_alone():
+    """Nobody reached the customer, so there is no newer information."""
+    outcome = TripStopOutcome.SKIPPED_CUSTOMER_NOT_AVAILABLE.value
+    customer = _Customer(BLACKLIST_TAG)
+    uow, _ = _apply(customer, tags=tags_for_outcome(outcome),
+                    clear=tags_cleared_by_outcome(outcome))
+    assert customer.tags == [BLACKLIST_TAG]
+    assert uow.session.added == []
+
+
+def test_retiring_a_blacklist_leaves_manual_tags_alone():
+    customer = _Customer(BLACKLIST_TAG, "agent", "region:malki")
+    outcome = TripStopOutcome.SALE.value
+    _apply(customer, tags=tags_for_outcome(outcome), clear=tags_cleared_by_outcome(outcome))
+    assert set(customer.tags) == {"agent", "region:malki", INTEREST_YES}
 
 
 @pytest.mark.parametrize("outcome", list(TripStopOutcome), ids=lambda o: o.name)

--- a/backend/tests/domains/test_customer_visit_dates.py
+++ b/backend/tests/domains/test_customer_visit_dates.py
@@ -1,0 +1,99 @@
+"""The two definitions of "reached the customer" must stay one definition.
+
+customer.last_effective_stop is written from two places: Python, on every stop
+completion (auto_tags.is_effective_outcome, via visit_dates.recompute_visit_dates),
+and SQL, once, in the migration that backfilled the column. They express the
+same rule in two languages, and a drift between them is invisible — the column
+just quietly means something different for old rows than for new ones.
+
+So this file re-implements the SQL predicate in Python, term for term, and
+asserts it agrees with the real function over every outcome value and every
+legacy shape the column is known to hold. The SQL is not paraphrased from
+memory: it is extracted from the shipped query text, so editing the query
+without editing the mirror fails here.
+
+What it cannot do is run Postgres, which the domain test suite has no fixture
+for. The split_part/btrim semantics were verified against the real database by
+hand; what is pinned here is that the two RULES agree, which is the part a
+future edit is actually likely to break.
+"""
+import re
+
+import pytest
+
+from app.domains.customer.auto_tags import is_effective_outcome
+from app.domains.customer.visit_dates import _VISIT_DATES
+from app.domains.task_execution.workflow_operators.create_trip_operator import (
+    TripStopOutcome,
+)
+
+
+def _sql_effective(outcome) -> bool:
+    """Postgres' answer, re-implemented exactly.
+
+      btrim(split_part(outcome, ' - ', 1)) <> ''
+      AND split_part(btrim(split_part(outcome, ' - ', 1)), ':', 1) <> 'skipped'
+
+    split_part(NULL, ...) is NULL and every comparison against NULL is NULL,
+    which a FILTER treats as false — hence the None short-circuit.
+    """
+    if outcome is None:
+        return False
+    machine = outcome.split(" - ")[0].strip()   # split_part(..., 1) + btrim
+    if machine == "":
+        return False
+    return machine.split(":")[0] != "skipped"
+
+
+# Every outcome that exists, plus the shapes the column is known to hold from
+# before it was an enum, plus the ones a hand-written API call can still store.
+LEGACY_AND_EDGE_SHAPES = [
+    None,
+    "",
+    "   ",
+    "sale",                                   # bare key, no Arabic half
+    "skipped",                                # bare skipped, no subkey
+    "skipped:no_time",                        # machine only
+    "  skipped:no_time - تم التخطي",           # leading whitespace
+    "skipped:no_time - تم التخطي: لا يوجد وقت",  # ':' inside the Arabic half
+    "sale - تم البيع - إضافي",                  # a second ' - ' separator
+    "Skipped:no_time - x",                    # mixed case: NOT the skipped family
+    "negotiating:follow_up - نص",              # a family nobody has defined yet
+    "no_sale",                                # a removed enum member
+]
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [o.value for o in TripStopOutcome] + LEGACY_AND_EDGE_SHAPES,
+    ids=lambda v: repr(v),
+)
+def test_sql_and_python_agree_on_effectiveness(outcome):
+    assert _sql_effective(outcome) == is_effective_outcome(outcome)
+
+
+def test_the_mirror_is_taken_from_the_shipped_query():
+    """If the query stops containing the predicate this file mirrors, the
+    agreement above is being checked against something that no longer runs."""
+    sql = " ".join(str(_VISIT_DATES).split())
+    assert "btrim(split_part(ts.outcome, ' - ', 1)) <> ''" in sql
+    assert "split_part(btrim(split_part(ts.outcome, ' - ', 1)), ':', 1) <> 'skipped'" in sql
+
+
+def test_a_completed_stop_counts_even_with_a_blank_outcome():
+    """The API never validates the outcome string, so a completion can carry ''.
+    The stop still happened: it is the task execution reaching `completed` that
+    makes it a visit, which is why the query does not require an outcome."""
+    sql = " ".join(str(_VISIT_DATES).split())
+    assert "te.status = 'completed' OR btrim(COALESCE(ts.outcome, '')) <> ''" in sql
+    # ...and such a stop is still not EFFECTIVE, on both sides
+    assert is_effective_outcome("") is False
+    assert _sql_effective("") is False
+
+
+def test_the_query_is_scoped_to_one_customer():
+    """It is executed with a bound customer_uuid resolved through the scoped
+    repository; a missing filter would silently aggregate across tenants."""
+    sql = " ".join(str(_VISIT_DATES).split())
+    assert "ts.customer_uuid = :customer_uuid" in sql
+    assert len(re.findall(r":customer_uuid", sql)) == 1


### PR DESCRIPTION
Two derived timestamps on `customer`, written by the trip-stop operator when a stop completes.

| Field | Meaning |
|---|---|
| `last_stop` | the last completed stop, **whatever** came of it |
| `last_effective_stop` | the last one that actually **reached** the customer — any outcome outside `skipped:*` |

## How "effective" is decided

The complement of `skipped`, not a whitelist of known families — deliberately. A new outcome describing something that *did* happen should count on the day it's added, without anyone remembering this rule. A refusal or a blacklist is still a rep at the door having a conversation; only "customer not available", "no time", "no parking", "vehicle breakdown" are the trip failing to happen.

An unreadable outcome (NULL, `''`, legacy free text with no family) is **not** effective — we can't claim to have reached someone on the strength of a value nothing can parse.

`last_stop` moves on **every** completion, including a skipped one: "we went and couldn't get in" is still a trip made, and a planner needs to know it happened.

## Derived, not editable

Both are absent from `CustomerCreate`/`CustomerUpdate`, and those DTOs forbid extras, so a client trying to set them gets a 400 rather than silently overwriting a fact about the world. The operator is the only writer.

The completion timestamp is captured once and shared with the task execution's `end_time`, so `customer.last_stop` **is** that `end_time` rather than a few ms off it — verified, and it's the invariant the backfill relies on.

## Backfilled from history

So the columns are useful on day one rather than in three months. A stop counts as completed if it carries an **outcome** — written at exactly the moment the operator completes it, and a far more reliable marker than `trip_stop.status`, which no code path ever advances past `in_progress`. (See the note below; that's a real bug, flagged separately.)

Verified against an **independently written** truth query using a different skipped-detection expression: **16 of 16** customers backfilled, **zero mismatches** on either column, and 10 customers correctly left with a `last_stop` but no `last_effective_stop`.

## Verified

21 more tests (115 on this module), including a case over every `TripStopOutcome` member so a new option can't ship without deciding whether it reaches the customer. Full suite 505 pass / 227 pre-existing failures, unchanged.

Live, re-completing one stop:

```
start            last_stop=2026-07-04 (backfilled)  last_effective_stop=None
skipped:no_time  last_stop=10:26:39                 last_effective_stop=None
sale             last_stop=10:26:41                 last_effective_stop=10:26:41
skipped:no_avail last_stop=10:26:42                 last_effective_stop=10:26:41   ← held
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)