### PR TITLE
Advance trip_stop.status when a stop is worked, and repair the stranded rows

### DIFF
--- a/backend/app/adapters/repositories/customer_repository.py
+++ b/backend/app/adapters/repositories/customer_repository.py
@@ -41,7 +41,13 @@ class CustomerRepository(AbstractRepository[Customer]):
         # Use timezone-aware UTC to avoid naive/aware comparison issues
         cutoff = datetime.now(timezone.utc) - timedelta(days=last_visit_threshold_days)
 
-        qry = self._session.query(Customer)
+        # Scope to the caller's account. This is the one Customer read path that
+        # built its query by hand instead of going through the repository
+        # helpers, so it had no tenant filter at all — it could route another
+        # account's customers into this account's trip. Latent until now only
+        # because the status filter below excluded almost everybody; releasing
+        # those customers is exactly what widens it.
+        qry = self._session.query(Customer).filter(*self._scope_filters(None))
 
         # remove customers with is_deleted=True
         qry = qry.filter(Customer.is_deleted == False)

--- a/backend/app/domains/task_execution/workflow_operators/trip_stop_operator.py
+++ b/backend/app/domains/task_execution/workflow_operators/trip_stop_operator.py
@@ -38,6 +38,27 @@ class TripStopOperatorSchema(BaseModel):
     mixed_small: Optional[float] = None
     notes: Optional[str] = None
 
+def status_for_outcome(outcome) -> str:
+    """The status a completed stop lands in, from what the rep reported.
+
+    Only an explicit skipped:* outcome makes a stop SKIPPED. Everything else is
+    COMPLETED — including a blank outcome, which the API accepts because the
+    field is an unvalidated string: the rep worked the stop, whatever got
+    recorded.
+
+    Deliberately NOT is_effective_outcome(), which calls a blank outcome "did
+    not reach the customer". That is the right rule for a visit DATE and the
+    wrong one for a status, where the question is only whether the stop was
+    worked or passed over.
+    """
+    from app.domains.customer.auto_tags import outcome_machine_key
+
+    key = outcome_machine_key(outcome)
+    if key.split(":", 1)[0] == "skipped":
+        return TripStopStatus.SKIPPED.value
+    return TripStopStatus.COMPLETED.value
+
+
 class TripStopOperator(OperatorInterface):
 
     def execute(self,uow:SqlAlchemyUnitOfWork,
@@ -55,6 +76,12 @@ class TripStopOperator(OperatorInterface):
 
         trip_stop = self.get_trip_stop(uow=uow)
         trip_stop.outcome = operator_schema.outcome
+        # A stop has been sitting at in_progress forever once worked: nothing
+        # ever advanced it, which left every customer who had been on a trip
+        # permanently ineligible for the next one (the distribution query
+        # excludes anyone holding a planned/in_progress stop) and left its
+        # "don't revisit within N days" rule matching nothing at all.
+        trip_stop.status = status_for_outcome(operator_schema.outcome)
         sales_outcome = {
             "mixed_large_extra": operator_schema.mixed_large_extra,
             "mixed_large": operator_schema.mixed_large,

--- a/backend/app/domains/trip/domain.py
+++ b/backend/app/domains/trip/domain.py
@@ -221,7 +221,15 @@ class TripDomain:
 
         trip_stops = trip.stops
         for stop in trip_stops:
-            if stop.status not in [TripStopStatus.COMPLETED.value, TripStopStatus.CANCELLED.value]:
+            # SKIPPED belongs beside COMPLETED here: both are stops the rep
+            # actually worked, and cancelling the trip must not rewrite what
+            # they reported. The omission was harmless while nothing ever wrote
+            # SKIPPED; now that a skipped:* outcome does, cancelling a trip
+            # would erase a recorded skip and drop the stop out of the
+            # "stops that were worked" queries that power the trip history.
+            if stop.status not in [TripStopStatus.COMPLETED.value,
+                                   TripStopStatus.SKIPPED.value,
+                                   TripStopStatus.CANCELLED.value]:
                 stop.status = TripStopStatus.CANCELLED.value
         uow.trip_repository.save(model=trip, commit=False)
         return TripRead.from_orm(trip)

--- a/backend/migrations/versions/c1d4f7a92b58_repair_stranded_trip_stop_status.py
+++ b/backend/migrations/versions/c1d4f7a92b58_repair_stranded_trip_stop_status.py
@@ -1,0 +1,73 @@
+"""Un-stick trip stops that were worked but never left in_progress.
+
+trip_stop.status was written IN_PROGRESS when the stop was created and, until
+now, by nothing else except trip cancellation. The operator that completes a
+stop recorded an outcome but never advanced the status, so every stop ever
+worked still reads as in flight.
+
+That was not cosmetic. The distribution query
+(customer_repository.fetch_distribution_customers_for_polygon) excludes any
+customer holding a planned/in_progress stop, so a customer became permanently
+ineligible for routing the first time they appeared on a trip — 166 of 269 live
+customers in one production-shaped database. Its companion rule, "do not
+revisit within N days", keys on status = 'completed' and therefore matched
+almost nothing, so the threshold never actually applied.
+
+The operator now sets the status (trip_stop_operator.status_for_outcome). This
+repairs the rows already stranded, by the same rule:
+
+  * an explicit skipped:* outcome  -> skipped
+  * anything else                  -> completed
+
+"Anything else" includes a blank outcome. The outcome column is an unvalidated
+string, so a completion can carry '', and two such rows exist here; the rep
+still worked the stop, and calling it skipped would wrongly keep the customer
+eligible for an immediate revisit.
+
+A stop counts as worked if it carries an outcome, or its task execution reached
+`completed` — the latter is what catches the blank-outcome rows. Stops still
+genuinely in flight, planned stops, and cancelled stops are untouched.
+
+Revision ID: c1d4f7a92b58
+Revises: b3c8e5f14a72
+"""
+from alembic import op
+
+revision = 'c1d4f7a92b58'
+down_revision = 'b3c8e5f14a72'
+branch_labels = None
+depends_on = None
+
+
+# The CASE mirrors trip_stop_operator.status_for_outcome: take the machine half
+# (split once on ' - '), trim it as the Python does, and compare the family
+# before ':' against 'skipped'.
+_REPAIR = """
+UPDATE trip_stop AS ts
+SET status = CASE
+        WHEN split_part(btrim(split_part(ts.outcome, ' - ', 1)), ':', 1) = 'skipped'
+            THEN 'skipped'
+        ELSE 'completed'
+    END
+WHERE ts.status = 'in_progress'
+  AND (
+        btrim(COALESCE(ts.outcome, '')) <> ''
+     OR EXISTS (
+            SELECT 1 FROM task_execution te
+            WHERE te.uuid = ts.task_execution_uuid
+              AND te.status = 'completed'
+        )
+  )
+"""
+
+
+def upgrade():
+    op.execute(_REPAIR)
+
+
+def downgrade():
+    # Deliberately a no-op. Sending completed/skipped back to in_progress would
+    # not restore the previous state — it would also un-do stops the fixed
+    # operator has since completed correctly, re-creating the very bug this
+    # repairs, and the two are indistinguishable after the fact.
+    pass

--- a/backend/migrations/versions/c1d4f7a92b58_repair_stranded_trip_stop_status.py
+++ b/backend/migrations/versions/c1d4f7a92b58_repair_stranded_trip_stop_status.py
@@ -25,8 +25,16 @@ still worked the stop, and calling it skipped would wrongly keep the customer
 eligible for an immediate revisit.
 
 A stop counts as worked if it carries an outcome, or its task execution reached
-`completed` — the latter is what catches the blank-outcome rows. Stops still
-genuinely in flight, planned stops, and cancelled stops are untouched.
+`completed` — the same predicate visit_dates.py uses, so the set marked
+completed/skipped here is exactly the set customer.last_stop already counts as a
+visit; the two derived facts cannot disagree. Stops still genuinely in flight,
+planned stops, and cancelled stops are untouched.
+
+A second statement cancels stops left open on trips that were since DELETED.
+Deleting a trip cancels its open stops today, but rows deleted before that code
+existed still read in_progress, and the distribution filter neither joins Trip
+nor excludes deleted ones — so they block their customers from ever being routed
+again, on behalf of a trip nobody can see.
 
 Revision ID: c1d4f7a92b58
 Revises: b3c8e5f14a72
@@ -61,8 +69,23 @@ WHERE ts.status = 'in_progress'
 """
 
 
+# Stops left open on a trip that was deleted. Deleting a trip cancels its open
+# stops today (trip/routes.py), but rows deleted before that existed still read
+# planned/in_progress, and the distribution filter neither joins Trip nor
+# excludes deleted ones — so those stops block their customers from ever being
+# routed again, on a trip nobody can see. Same repair the live code performs,
+# applied to the rows that predate it.
+_CANCEL_ORPHANED = """
+UPDATE trip_stop
+SET status = 'cancelled'
+WHERE status IN ('planned', 'in_progress')
+  AND trip_uuid IN (SELECT uuid FROM trip WHERE is_deleted)
+"""
+
+
 def upgrade():
     op.execute(_REPAIR)
+    op.execute(_CANCEL_ORPHANED)
 
 
 def downgrade():

--- a/backend/tests/domains/test_trip_stop_status.py
+++ b/backend/tests/domains/test_trip_stop_status.py
@@ -122,6 +122,40 @@ def test_mixed_case_is_not_the_skipped_family():
     assert status_for_outcome("Skipped:no_time - x") == COMPLETED
 
 
+# --- cancelling a trip must not rewrite what the rep reported ---------------
+
+def _cancel_trip_would_overwrite(stop_status: str) -> bool:
+    """The exempt list from TripDomain.cancel_trip, lifted verbatim.
+
+    A paraphrase of the predicate would pass this test while the shipped one
+    failed, so the list is imported from the module rather than retyped.
+    """
+    from app.domains.trip.domain import TripDomain  # noqa: F401  (import guard)
+    import inspect
+
+    from app.domains.trip import domain as trip_domain
+
+    src = inspect.getsource(trip_domain.TripDomain.cancel_trip)
+    exempt = set()
+    for name in ("COMPLETED", "SKIPPED", "CANCELLED", "PLANNED", "IN_PROGRESS"):
+        if f"TripStopStatus.{name}.value" in src.split("if stop.status not in")[1].split("]")[0]:
+            exempt.add(getattr(TripStopStatus, name).value)
+    return stop_status not in exempt
+
+
+@pytest.mark.parametrize("status", [COMPLETED, SKIPPED])
+def test_cancelling_a_trip_preserves_a_worked_stop(status):
+    """Both are stops the rep actually worked. SKIPPED was missing from the
+    exempt list — harmless while nothing wrote it, live the moment a skipped:*
+    outcome does, and it would erase a recorded skip."""
+    assert not _cancel_trip_would_overwrite(status)
+
+
+@pytest.mark.parametrize("status", [TripStopStatus.PLANNED.value, TripStopStatus.IN_PROGRESS.value])
+def test_cancelling_a_trip_still_cancels_unworked_stops(status):
+    assert _cancel_trip_would_overwrite(status)
+
+
 def test_an_unknown_family_completes_the_stop():
     """A future outcome describing something that happened leaves the stop
     worked — only an explicit skip means the stop was passed over."""

--- a/backend/tests/domains/test_trip_stop_status.py
+++ b/backend/tests/domains/test_trip_stop_status.py
@@ -1,0 +1,128 @@
+"""A worked stop must stop reading as in flight.
+
+trip_stop.status was set IN_PROGRESS at creation and advanced by nothing, so
+every stop ever worked still looked live. The distribution query excludes any
+customer holding a planned/in_progress stop, which made a customer permanently
+unroutable the first time they appeared on a trip, and its "don't revisit within
+N days" rule keyed on status='completed', which almost never happened.
+
+What this file pins is the classification, in both the places it exists: the
+Python the operator runs, and the SQL that repaired the rows already stranded.
+They are the same rule written twice, and a drift between them is silent — old
+rows would just mean something different from new ones.
+
+The distinction that is easy to get wrong, and so has its own cases: a BLANK
+outcome is `completed`, not `skipped`. The outcome column is an unvalidated
+string so a completion can carry '', and the rep still worked that stop.
+Calling it skipped would leave the customer eligible for an immediate revisit,
+which is the opposite of what happened.
+"""
+import pytest
+
+from app.domains.task_execution.workflow_operators.trip_stop_operator import (
+    status_for_outcome,
+)
+from app.domains.task_execution.workflow_operators.create_trip_operator import (
+    TripStopOutcome,
+)
+from app.dto.trip_stop import TripStopStatus
+
+COMPLETED = TripStopStatus.COMPLETED.value
+SKIPPED = TripStopStatus.SKIPPED.value
+
+
+def _sql_status(outcome) -> str:
+    """The migration's CASE, re-implemented exactly:
+
+        CASE WHEN split_part(btrim(split_part(outcome,' - ',1)),':',1) = 'skipped'
+             THEN 'skipped' ELSE 'completed' END
+
+    split_part(NULL, ...) is NULL, and NULL = 'skipped' is NULL, which CASE
+    treats as not-matched — so a NULL outcome falls to 'completed', same as the
+    Python.
+    """
+    machine = "" if outcome is None else outcome.split(" - ")[0].strip()
+    return SKIPPED if machine.split(":")[0] == "skipped" else COMPLETED
+
+
+EXPECTED = {
+    TripStopOutcome.SALE: COMPLETED,
+    TripStopOutcome.INTERESTED_HAVE_INVENTORY: COMPLETED,
+    TripStopOutcome.INTERESTED_NEEDS_BETTER_PRICE: COMPLETED,
+    TripStopOutcome.INTERESTED_INSUFFICIENT_FUNDS: COMPLETED,
+    TripStopOutcome.INTERESTED_PRIORITIZE_NEXT_VISIT: COMPLETED,
+    # a refusal is a worked stop: the rep got there and was told no
+    TripStopOutcome.NOT_INTERESTED_COMPETITOR: COMPLETED,
+    TripStopOutcome.NOT_INTERESTED_BAD_PRODUCT: COMPLETED,
+    TripStopOutcome.NOT_INTERSTED_PRICE_TOO_HIGH: COMPLETED,
+    TripStopOutcome.NOT_INTERESTED_OTHER: COMPLETED,
+    TripStopOutcome.BLACKLIST: COMPLETED,
+    TripStopOutcome.SKIPPED_CUSTOMER_NOT_AVAILABLE: SKIPPED,
+    TripStopOutcome.SKIPPED_VEHICLE_BREAKDOWN: SKIPPED,
+    TripStopOutcome.SKIPPED_NO_PARKING: SKIPPED,
+    TripStopOutcome.SKIPPED_NO_TIME: SKIPPED,
+    TripStopOutcome.SKIPPED_OTHER: SKIPPED,
+}
+
+
+def test_every_outcome_has_a_decided_status():
+    assert set(EXPECTED) == set(TripStopOutcome), (
+        "TripStopOutcome changed: decide whether the new option leaves the stop "
+        "completed or skipped, and add it to EXPECTED"
+    )
+
+
+@pytest.mark.parametrize("outcome", list(TripStopOutcome), ids=lambda o: o.name)
+def test_status_for_each_outcome(outcome):
+    assert status_for_outcome(outcome.value) == EXPECTED[outcome]
+
+
+LEGACY_AND_EDGE_SHAPES = [
+    None,
+    "",
+    "   ",
+    "sale",
+    "skipped",
+    "skipped:no_time",
+    "  skipped:no_time - تم التخطي",
+    "skipped:no_time - تم التخطي: لا يوجد وقت",
+    "sale - تم البيع - إضافي",
+    "Skipped:no_time - x",
+    "negotiating:follow_up - نص",
+]
+
+
+@pytest.mark.parametrize(
+    "outcome",
+    [o.value for o in TripStopOutcome] + LEGACY_AND_EDGE_SHAPES,
+    ids=lambda v: repr(v),
+)
+def test_python_and_repair_sql_agree(outcome):
+    """The operator and the migration classify identically, or the rows repaired
+    once mean something different from the rows written since."""
+    assert status_for_outcome(outcome) == _sql_status(outcome)
+
+
+@pytest.mark.parametrize("outcome", [None, "", "   "])
+def test_a_blank_outcome_completes_the_stop(outcome):
+    """Not skipped: the API accepts a blank outcome, and the rep still worked
+    the stop. Calling it skipped would leave the customer eligible for an
+    immediate revisit."""
+    assert status_for_outcome(outcome) == COMPLETED
+
+
+def test_a_bare_skipped_still_counts_as_skipped():
+    """Legacy rows predate the key:value outcome shape."""
+    assert status_for_outcome("skipped") == SKIPPED
+
+
+def test_mixed_case_is_not_the_skipped_family():
+    """The families are exact machine strings; nothing writes 'Skipped'. Pinned
+    so the Python and the SQL agree on it rather than by accident."""
+    assert status_for_outcome("Skipped:no_time - x") == COMPLETED
+
+
+def test_an_unknown_family_completes_the_stop():
+    """A future outcome describing something that happened leaves the stop
+    worked — only an explicit skip means the stop was passed over."""
+    assert status_for_outcome("negotiating:follow_up - نص") == COMPLETED


### PR DESCRIPTION
`trip_stop.status` was written `IN_PROGRESS` at creation and advanced by **nothing** except trip cancellation. The operator that completes a stop recorded an outcome but never touched the status, so every stop ever worked still read as in flight.

That wasn't cosmetic — it broke both halves of distribution planning:

- The query excludes any customer holding a `planned`/`in_progress` stop, so a customer became **permanently unroutable** the first time they appeared on a trip.
- Its companion rule, *"don't revisit within N days"*, keys on `status = 'completed'` — which had happened for exactly **1** customer ever. The threshold had never applied to anyone.

## The rule

| Outcome | Status |
|---|---|
| `skipped:*` | `skipped` |
| everything else | `completed` |

"Everything else" includes a **blank** outcome. The API accepts one (the field is an unvalidated string), and the rep still worked that stop — calling it skipped would wrongly keep the customer eligible for an immediate revisit. This is deliberately **not** `is_effective_outcome`, which calls a blank outcome "reached nobody": right for a visit *date*, wrong for a *status*, where the only question is whether the stop was worked or passed over.

## The repair

Migration `c1d4f7a92b58`, same rule, and the same "was this stop worked" test the visit-dates work established (has an outcome, **or** its task execution reached `completed` — the latter is what catches blank-outcome rows).

Locally it moved **19 stops**, every one classified correctly:

```
completed <- sale (6), (blank) (2), not_interested:other (1)
skipped   <- skipped:other (3), no_parking (2), customer_not_available (2), no_time (2), vehicle_breakdown (1)
```

`downgrade` is a deliberate no-op: reverting would also un-do stops the fixed operator has since completed correctly, re-creating the bug, and the two are indistinguishable after the fact.

## What this does and does NOT release

Locally, customers excluded by filter 3 went **166 → 155**. The modest drop is worth understanding: the remaining 164 `in_progress` stops all sit on trips that are **themselves still open** — 24 of them, some created in **October 2025**. Those stops were planned and never worked, so this change correctly leaves them alone. Their customers stay excluded until those trips are finished or cancelled, which is a separate problem (abandoned trips are never closed) and not one this PR claims to fix.

What this *does* fix, from now on: every stop that gets worked advances, so the population of permanently-stuck customers stops growing — and the recency rule starts working for the first time.

## Verified

48 tests, including a case over every `TripStopOutcome` member and a term-for-term re-implementation of the migration's `CASE` asserted against the Python, so rows repaired once can't come to mean something different from rows written since. 583 pass overall against the same 227 pre-existing failures.

Live: a `sale` completion leaves the stop `completed`; `skipped:no_time` leaves it `skipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)