### PR TITLE
Web: replace the Workflow module with Distribution, opening the trips list

### DIFF
--- a/frontend/client/src/App.tsx
+++ b/frontend/client/src/App.tsx
@@ -88,6 +88,7 @@ import ProcessDetail from "@/pages/ProcessDetail";
 import WorkflowDetail from "@/pages/WorkflowDetail";
 import WorkflowCreate from "@/pages/WorkflowCreate";
 import WorkflowExecution from "@/pages/WorkflowExecution";
+import Distribution from "@/pages/Distribution";
 import WorkflowExecutionDetail from "@/pages/WorkflowExecutionDetail";
 import WorkflowExecutionTaskDetail from "@/pages/WorkflowExecutionTaskDetail";
 import AccountSettings from "@/pages/AccountSettings";
@@ -184,6 +185,10 @@ function Router() {
       <Route path="/workflows" component={() => <ProtectedRoute><SuperAdmin /></ProtectedRoute>} />
       <Route path="/workflows/new" component={() => <ProtectedRoute><WorkflowCreate /></ProtectedRoute>} />
       <Route path="/workflows/:uuid" component={() => <ProtectedRoute><WorkflowDetail /></ProtectedRoute>} />
+      {/* The menu entry points here. The /workflow-execution routes below stay
+          reachable for deep links and for the task detail the stop-completion
+          flow navigates to. */}
+      <Route path="/distribution" component={() => <ProtectedRoute><Distribution /></ProtectedRoute>} />
       <Route path="/workflow-execution" component={() => <ProtectedRoute><WorkflowExecution /></ProtectedRoute>} />
       <Route path="/workflow-execution/:workflow_uuid/:execution_uuid" component={() => <ProtectedRoute><WorkflowExecutionTaskDetail /></ProtectedRoute>} />
       <Route path="/workflow-execution/:uuid" component={() => <ProtectedRoute><WorkflowExecutionDetail /></ProtectedRoute>} />

--- a/frontend/client/src/components/layout/Sidebar.tsx
+++ b/frontend/client/src/components/layout/Sidebar.tsx
@@ -76,7 +76,13 @@ const navigation = [
   { key: "nav.creditNoteItems", href: "/credit-note-items", icon: FileText },
   { key: "nav.debitNoteItems", href: "/debit-note-items", icon: FileText },
   { key: "nav.processes", href: "/processes", icon: Factory },
-  { key: "nav.workflowExecution", href: "/workflow-execution", icon: Play },
+  // Distribution IS the workflow module, renamed for what people actually use
+  // it for and pointed straight at the trips list instead of a workflow picker
+  // with one option. `module` is pinned because the ACL id is otherwise derived
+  // from the href, and the backend's permission list knows "workflow-execution"
+  // — deriving "distribution" from the new href would hide the entry from every
+  // non-admin and from every account whose feature cap lists the old id.
+  { key: "nav.distribution", href: "/distribution", module: "workflow-execution", icon: Truck },
   // adminOnly entries are filtered out for non-admin users below
   { key: "nav.liveMap", href: "/live-map", icon: MapPin, adminOnly: true },
   // alwaysVisible: NOT subject to the tenant feature cap. A company must always be

--- a/frontend/client/src/i18n/translations/nav.ts
+++ b/frontend/client/src/i18n/translations/nav.ts
@@ -30,6 +30,10 @@ export const en: Record<string, string> = {
   'nav.debitNoteItems': 'Debit Note Items',
   'nav.processes': 'Processes',
   'nav.workflows': 'Workflows',
+  // the menu entry; matches the Expo app's distribution tile so the two
+  // clients call the same thing by the same name
+  'nav.distribution': 'Distribution',
+  // still used by the /workflow-execution picker page, reachable by deep link
   'nav.workflowExecution': 'Workflow Execution',
   'nav.accountSettings': 'Account settings',
   'nav.liveMap': 'Live Map',
@@ -68,6 +72,7 @@ export const ar: Record<string, string> = {
   'nav.debitNoteItems': 'إشعارات مدينة',
   'nav.processes': 'عمليات الإنتاج',
   'nav.workflows': 'سير العمل',
+  'nav.distribution': 'التوزيع',
   'nav.workflowExecution': 'تنفيذ سير العمل',
   'nav.accountSettings': 'إعدادات الحساب',
   'nav.liveMap': 'الخريطة المباشرة',

--- a/frontend/client/src/i18n/translations/workflows.ts
+++ b/frontend/client/src/i18n/translations/workflows.ts
@@ -94,6 +94,8 @@ export const en: Record<string, string> = {
 
   // Workflow executions table
   'workflows.workflowExecutions': 'Workflow Executions',
+  // shown by the Distribution page when the tenant has no trip workflow seeded
+  'distribution.workflowMissing': 'No distribution workflow is set up for this account yet. Ask an administrator to provision it.',
   'workflows.executeWorkflow': 'Execute Workflow',
   'workflows.noExecutionsFound': 'No workflow executions found',
   'workflows.started': 'Started',
@@ -304,6 +306,7 @@ export const ar: Record<string, string> = {
 
   // Workflow executions table
   'workflows.workflowExecutions': 'عمليات تنفيذ سير العمل',
+  'distribution.workflowMissing': 'لم يتم إعداد سير عمل التوزيع لهذا الحساب بعد. يرجى الطلب من المسؤول تفعيله.',
   'workflows.executeWorkflow': 'تنفيذ سير العمل',
   'workflows.noExecutionsFound': 'لم يتم العثور على عمليات تنفيذ لسير العمل',
   'workflows.started': 'البدء',

--- a/frontend/client/src/pages/Distribution.tsx
+++ b/frontend/client/src/pages/Distribution.tsx
@@ -1,0 +1,72 @@
+import { useQuery } from "@tanstack/react-query";
+import { Loader2 } from "lucide-react";
+import { AppLayout } from "@/components/layout/AppLayout";
+import { apiRequest } from "@/lib/queryClient";
+import { useLanguage } from "@/contexts/LanguageContext";
+import WorkflowExecutionDetail from "@/pages/WorkflowExecutionDetail";
+
+/**
+ * The Distribution module: the trips list, one click from the menu.
+ *
+ * Distribution is the only workflow anyone runs from the web, so making people
+ * pick it out of a list of workflows first was a step that never had a second
+ * option. This resolves the trip workflow BY NAME and renders its executions
+ * directly — the same thing the Expo app's distribution tile does
+ * (expo_app/app/distribution.tsx), so the two clients agree on what
+ * "distribution" opens.
+ *
+ * Resolved by name rather than a hardcoded uuid because the workflow is seeded
+ * per tenant: every account has its own row with its own uuid, and only the
+ * name is stable across them.
+ */
+const TRIP_WORKFLOW_NAME = "simple_trip_workflow";
+
+interface WorkflowsResponse {
+  workflows: { uuid: string; name: string }[];
+}
+
+export default function Distribution() {
+  const { t } = useLanguage();
+
+  const { data, isLoading } = useQuery<WorkflowsResponse>({
+    queryKey: ["/workflow/", TRIP_WORKFLOW_NAME],
+    queryFn: () => apiRequest(`/workflow/?name=${TRIP_WORKFLOW_NAME}&per_page=1`),
+    // the tenant's trip workflow is seeded once and never renamed
+    staleTime: Infinity,
+  });
+
+  if (isLoading) {
+    return (
+      <AppLayout>
+        <div className="flex-1 flex items-center justify-center p-8">
+          <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        </div>
+      </AppLayout>
+    );
+  }
+
+  const workflowUuid = data?.workflows?.[0]?.uuid;
+
+  if (!workflowUuid) {
+    // An account whose workflows were never provisioned. Say which workflow is
+    // missing rather than showing an empty trip list, which would read as
+    // "no trips yet" and send someone hunting in the wrong place.
+    return (
+      <AppLayout>
+        <div className="flex-1 flex items-center justify-center p-8">
+          <p className="text-sm text-gray-500 dark:text-gray-400 text-center">
+            {t("distribution.workflowMissing")}
+          </p>
+        </div>
+      </AppLayout>
+    );
+  }
+
+  return (
+    <WorkflowExecutionDetail
+      workflowUuid={workflowUuid}
+      showBack={false}
+      title={t("nav.distribution")}
+    />
+  );
+}

--- a/frontend/client/src/pages/WorkflowExecutionDetail.tsx
+++ b/frontend/client/src/pages/WorkflowExecutionDetail.tsx
@@ -69,9 +69,29 @@ const parseNaiveUtc = (ts: string): Date =>
   new Date(ts.includes("T") && !/(?:Z|[+-]\d{2}:?\d{2})$/.test(ts) ? `${ts}Z` : ts);
 
 
-export default function WorkflowExecutionDetail() {
+/**
+ * The executions of one workflow.
+ *
+ * Reached two ways. From /workflow-execution/:uuid the workflow comes off the
+ * route, and the Back button returns to the picker. From /distribution the
+ * Distribution page has already resolved the trip workflow by name and passes
+ * it in — there is no picker to go back to, so the button is suppressed.
+ */
+export default function WorkflowExecutionDetail({
+  workflowUuid: workflowUuidProp,
+  showBack = true,
+  title,
+}: {
+  workflowUuid?: string;
+  showBack?: boolean;
+  /** Overrides the heading. Given a title, the page is a named module rather
+   *  than "the executions of some workflow", so the internal workflow name is
+   *  dropped from the subtitle too — "simple_trip_workflow" is an identifier,
+   *  not something to show under a heading that reads Distribution. */
+  title?: string;
+} = {}) {
   const [, params] = useRoute("/workflow-execution/:uuid");
-  const workflowUuid = params?.uuid || "";
+  const workflowUuid = workflowUuidProp || params?.uuid || "";
   const [, setLocation] = useLocation();
   const { toast } = useToast();
   const { t, te } = useLanguage();
@@ -301,17 +321,19 @@ export default function WorkflowExecutionDetail() {
           {/* Header */}
           <div className="flex justify-between items-center">
             <div className="flex items-center gap-4">
-              <Link href="/workflow-execution">
-                <Button variant="ghost" size="sm" data-testid="button-back">
-                  <ArrowLeft className="h-4 w-4 me-2" />
-                  {t('common.back')}
-                </Button>
-              </Link>
+              {showBack && (
+                <Link href="/workflow-execution">
+                  <Button variant="ghost" size="sm" data-testid="button-back">
+                    <ArrowLeft className="h-4 w-4 me-2" />
+                    {t('common.back')}
+                  </Button>
+                </Link>
+              )}
               <div>
                 <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-                  {t('workflows.workflowExecutions')}
+                  {title ?? t('workflows.workflowExecutions')}
                 </h1>
-                {workflow && (
+                {!title && workflow && (
                   <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
                     {workflow.name}
                   </p>


### PR DESCRIPTION
Distribution is the only workflow anyone runs from the web, so the menu sent people to a picker with **one option** before they could see their trips. The entry is now **Distribution** and opens the trip list directly — matching the Expo app's distribution tile, down to the heading, so the two clients call the same thing by the same name.

| | Before | After |
|---|---|---|
| Menu entry | Workflow Execution | **Distribution** / التوزيع (truck icon) |
| Click goes to | `/workflow-execution` — a list of workflows | `/distribution` — the trips, directly |
| Heading | Workflow Executions + `simple_trip_workflow` | **Distribution** |

## The trap this had to avoid

The sidebar derives each entry's **ACL module id from its href** (`href.slice(1)`). Renaming the href to `/distribution` would have derived the module id `distribution` — which **is not in the backend's permission list**. The entry would have silently vanished for every non-admin, and for every account whose feature cap lists the old id.

So `module` is pinned to `"workflow-execution"`. Verified against a real driver account whose grants contain `workflow-execution` and **not** `distribution`: the entry still shows, and both of the page's API calls return 200 for them.

## Resolved by name, not uuid

`simple_trip_workflow` is seeded **per tenant** — every account has its own row with its own uuid, and only the name is stable. The page resolves it the same way the app does, and says so explicitly when an account has no workflow provisioned rather than showing an empty trip list that reads as "no trips yet".

## Nothing removed

`WorkflowExecutionDetail` grew three optional props (`workflowUuid`, `showBack`, `title`) so one page serves both routes without a fork. The `/workflow-execution` routes stay: deep links keep working, and the task detail under them is where the stop-completion flow navigates.

## Verified in the browser, both languages

- `/distribution` resolves by name, lists trips, no Back button, no internal workflow name in the heading
- Menu shows Distribution / التوزيع, highlights as active; Workflow Execution is gone
- Driver account sees the entry (the ACL case above)
- `/workflow-execution/<uuid>` unchanged — Back, "Workflow Executions", and the `simple_trip_workflow` subtitle all intact
- `tsc` clean vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)